### PR TITLE
fix: preserve grep_search line whitespace

### DIFF
--- a/src/sztu_code/core/tools/builtin/grep_search.py
+++ b/src/sztu_code/core/tools/builtin/grep_search.py
@@ -111,7 +111,7 @@ class GrepSearchTool(BaseTool):
             for lineno, line in enumerate(text.splitlines(), start=1):
                 if matcher.search(line):
                     rel = file.relative_to(root)
-                    matches.append(f"{rel.as_posix()}:{lineno}: {line.strip()}")
+                    matches.append(f"{rel.as_posix()}:{lineno}: {line}")
                     if len(matches) >= _MAX_MATCHES:
                         matches.append("[truncated]")
                         return ToolResult(content="\n".join(matches))

--- a/tests/unit/test_grep_search.py
+++ b/tests/unit/test_grep_search.py
@@ -29,6 +29,34 @@ async def test_match_returns_file_line_text(tmp_path: Path) -> None:
     assert "src/main.py:3: class Greeter:" in result.content
 
 
+# 功能：命中结果保留行首空格和行尾空白
+# 设计：精确比较包含四格缩进与两个尾随空格的整行，防止 strip 再次破坏源文本
+async def test_match_preserves_space_indentation_and_trailing_whitespace(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "example.py"
+    source.write_text('def greet():\n    return "hello"  \n', encoding="utf-8")
+    tool = GrepSearchTool(tmp_path)
+
+    result = await tool.invoke({"pattern": "return"})
+
+    assert not result.is_error
+    assert result.content == 'example.py:2:     return "hello"  '
+
+
+# 功能：命中结果保留 Tab 缩进且不携带 CRLF 换行符
+# 设计：用字节写入固定 CRLF 与 Tab，精确断言单行输出以覆盖跨平台换行处理
+async def test_match_preserves_tab_indentation_without_source_newline(tmp_path: Path) -> None:
+    source = tmp_path / "example.py"
+    source.write_bytes(b'def greet():\r\n\treturn "hello"\r\n')
+    tool = GrepSearchTool(tmp_path)
+
+    result = await tool.invoke({"pattern": "return"})
+
+    assert not result.is_error
+    assert result.content == 'example.py:2: \treturn "hello"'
+
+
 # 功能：默认忽略大小写，case_sensitive=True 时区分大小写
 # 设计：同一 pattern 分别搜大小写两种写法，验证开关行为
 async def test_case_sensitivity_flag(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- 保留 `grep_search` 命中行的原始行首与行尾空白。
- 继续依赖 `splitlines()` 去除源文件换行符，保持现有 `path:line: text` 输出契约。
- 新增空格缩进、Tab 缩进、尾随空格和 CRLF 的回归测试。

Closes #23

## Behavior

搜索 Python、YAML 等缩进敏感文件时，结果不再丢失命中行缩进；源文件的 `LF` 或 `CRLF` 不会重复进入结果。

## Validation

通过：

```text
python -m uv run --no-sync pytest tests/unit/test_grep_search.py -v -p no:cacheprovider
# 10 passed (Python 3.12.13)

python -m uv run --no-sync ruff check src/sztu_code/core/tools/builtin/grep_search.py tests/unit/test_grep_search.py --no-cache
# All checks passed

git diff --check
```

补充运行完整单元测试：609 passed, 20 failed。失败均位于未修改的测试/模块，主要是 Windows 绝对路径工作区边界、近期终止状态断言与 session 时间戳断言；`test_grep_search.py` 无失败。

协议文档检查显示上游当前 `docs/reference/wire-protocol.md` 已与代码不同步；本 PR 未修改协议模型或生成文档。

## Risk

风险低：修改仅影响命中行的展示文本，不改变正则匹配、路径过滤、二进制检测、排序或截断逻辑。回滚本提交即可恢复原行为。

## UI evidence

N/A

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加与风险匹配的回归测试。
- [x] 协议未变化，无需重新生成 `docs/reference/wire-protocol.md`。
- [x] 用户文档、配置示例和迁移说明不受影响。
- [x] 提交包含 `Signed-off-by`（DCO）。

