### PR TITLE
fix: restore cross-platform unit test baseline

### DIFF
--- a/src/sztu_code/core/tools/workspace.py
+++ b/src/sztu_code/core/tools/workspace.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 
 # 将工具相对路径解析到指定工作区并拒绝越界访问
 def resolve_workspace_path(workspace_root: Path | None, relative_path: str) -> Path:
     root = (workspace_root or Path.cwd()).resolve()
+    if Path(relative_path).is_absolute() or PureWindowsPath(relative_path).anchor:
+        raise PermissionError(f"path escapes workspace: {relative_path}")
     candidate = (root / relative_path).resolve()
     try:
         candidate.relative_to(root)

--- a/tests/unit/test_builtin_tools.py
+++ b/tests/unit/test_builtin_tools.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -29,12 +31,21 @@ async def test_bash_nonzero_exit_is_error() -> None:
 
 
 # 功能：验证命令超时后 is_error=True，error_type 为 "timeout"
-# 设计：timeout=1s 搭配 sleep 2 必然超时；验证 error_type 而非 content，避免超时消息格式耦合
+# 设计：用受控假进程模拟 communicate 超时，避免依赖平台特定的 sleep 命令
 @pytest.mark.asyncio
-async def test_bash_timeout() -> None:
-    result = await BashTool().invoke({"command": "sleep 5", "timeout": 1})
+async def test_bash_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = Mock(returncode=None)
+    process.communicate = AsyncMock(side_effect=[TimeoutError, (b"", None)])
+    process.kill = Mock()
+    create_process = AsyncMock(return_value=process)
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", create_process)
+
+    result = await BashTool().invoke({"command": "long-running", "timeout": 1})
+
     assert result.is_error
     assert result.error_type == "timeout"
+    process.kill.assert_called_once_with()
+    assert process.communicate.await_count == 2
 
 
 # 功能：验证 stderr 被合并到 stdout 输出中
@@ -53,8 +64,8 @@ async def test_bash_stderr_merged() -> None:
 @pytest.mark.asyncio
 async def test_write_file_creates_and_returns_size(tmp_path: Path) -> None:
     target = tmp_path / "out.txt"
-    result = await WriteFileTool().invoke(
-        {"path": str(target), "content": "hello world"}
+    result = await WriteFileTool(tmp_path).invoke(
+        {"path": "out.txt", "content": "hello world"}
     )
     assert not result.is_error
     assert "11" in result.content  # "hello world" = 11 bytes
@@ -66,7 +77,9 @@ async def test_write_file_creates_and_returns_size(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_write_file_creates_parent_dirs(tmp_path: Path) -> None:
     target = tmp_path / "a" / "b" / "file.txt"
-    result = await WriteFileTool().invoke({"path": str(target), "content": "x"})
+    result = await WriteFileTool(tmp_path).invoke(
+        {"path": "a/b/file.txt", "content": "x"}
+    )
     assert not result.is_error
     assert target.exists()
 
@@ -74,9 +87,11 @@ async def test_write_file_creates_parent_dirs(tmp_path: Path) -> None:
 # 功能：验证 write_file 拒绝包含 .. 的路径并抛出 PermissionError
 # 设计：.. 路径遍历与 read_file 遵循相同规则，用相同的断言模式保持一致性
 @pytest.mark.asyncio
-async def test_write_file_rejects_traversal() -> None:
+async def test_write_file_rejects_traversal(tmp_path: Path) -> None:
     with pytest.raises(PermissionError):
-        await WriteFileTool().invoke({"path": "../secret.txt", "content": "x"})
+        await WriteFileTool(tmp_path).invoke(
+            {"path": "../secret.txt", "content": "x"}
+        )
 
 
 # ── list_dir ──────────────────────────────────────────────────────────────────
@@ -87,7 +102,7 @@ async def test_write_file_rejects_traversal() -> None:
 async def test_list_dir_shows_files(tmp_path: Path) -> None:
     (tmp_path / "foo.py").write_text("x")
     (tmp_path / "bar.md").write_text("y")
-    result = await ListDirTool().invoke({"path": str(tmp_path)})
+    result = await ListDirTool(tmp_path).invoke({"path": "."})
     assert not result.is_error
     assert "foo.py" in result.content
     assert "bar.md" in result.content
@@ -103,7 +118,7 @@ async def test_list_dir_respects_max_depth(tmp_path: Path) -> None:
     grandchild.mkdir()
     (grandchild / "deep.txt").write_text("x")
 
-    result = await ListDirTool().invoke({"path": str(tmp_path), "max_depth": 1})
+    result = await ListDirTool(tmp_path).invoke({"path": ".", "max_depth": 1})
     assert not result.is_error
     assert "child" in result.content
     assert "deep.txt" not in result.content
@@ -112,14 +127,14 @@ async def test_list_dir_respects_max_depth(tmp_path: Path) -> None:
 # 功能：验证对不存在的路径 list_dir 抛出 FileNotFoundError
 # 设计：直接传入不存在的路径字符串，预期抛出标准异常（invocation.py 捕获后返回 error ToolResult）
 @pytest.mark.asyncio
-async def test_list_dir_missing_path_raises() -> None:
+async def test_list_dir_missing_path_raises(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
-        await ListDirTool().invoke({"path": "/this/does/not/exist"})
+        await ListDirTool(tmp_path).invoke({"path": "missing"})
 
 
 # 功能：验证 list_dir 拒绝包含 .. 的路径
 # 设计：与 read_file 和 write_file 保持一致的安全规则
 @pytest.mark.asyncio
-async def test_list_dir_rejects_traversal() -> None:
+async def test_list_dir_rejects_traversal(tmp_path: Path) -> None:
     with pytest.raises(PermissionError):
-        await ListDirTool().invoke({"path": "../"})
+        await ListDirTool(tmp_path).invoke({"path": "../"})

--- a/tests/unit/test_deep_integration.py
+++ b/tests/unit/test_deep_integration.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel
 
-from sztu_code.core.context import ExecutionContext
+from sztu_code.core.context import ExecutionContext, TerminationReason
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import LlmResponse, ToolCallBlock
 from sztu_code.core.loop import AgentLoop
@@ -172,7 +172,7 @@ class TestStepLimit:
         await loop.run(ctx)
         assert ctx.step == 2
         assert ctx.status == "success"
-        assert ctx.reason is None
+        assert ctx.reason == TerminationReason.SUCCESS
         assert ctx.result == "all done"
 
     # 功能：验证每步都发布 step.started 和 step.finished 事件，顺序正确
@@ -232,11 +232,19 @@ class TestStepLimit:
     # 功能：验证 max_steps 耗尽后循环不再调用 LLM
     # 设计：provider 包含 10 个响应但 max_steps=3，断言 call_count == 3
     async def test_max_steps_stops_calling_llm(self) -> None:
-        tc = _tc("unknown", {}, uid="t0")
+        tc = _tc("echo", uid="t0")
         provider = _MockProvider(
             [LlmResponse(stop_reason="tool_use", tool_calls=[tc])] * 10
         )
-        loop = AgentLoop(provider, ToolRegistry(), EventBus(), wrap_up_on_max_steps=False)
+        registry = ToolRegistry()
+        registry.register(_EchoTool())
+        loop = AgentLoop(
+            provider,
+            registry,
+            EventBus(),
+            wrap_up_on_max_steps=False,
+            grace_step_on_max_steps=False,
+        )
         ctx = _ctx(max_steps=3)
         await loop.run(ctx)
         assert ctx.status == "interrupted"

--- a/tests/unit/test_edit_file.py
+++ b/tests/unit/test_edit_file.py
@@ -15,9 +15,9 @@ async def test_edit_file_single_replace(tmp_path: Path) -> None:
     path = tmp_path / "test.py"
     path.write_text("hello world\nhi again\n")
 
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     result = await tool.invoke({
-        "path": str(path),
+        "path": "test.py",
         "old_string": "hello world",
         "new_string": "hi world",
     })
@@ -33,9 +33,9 @@ async def test_edit_file_replace_all(tmp_path: Path) -> None:
     path = tmp_path / "test.py"
     path.write_text("TODO: fix\n# TODO: improve\nTODO: remove\n")
 
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     result = await tool.invoke({
-        "path": str(path),
+        "path": "test.py",
         "old_string": "TODO:",
         "new_string": "DONE:",
         "replace_all": True,
@@ -53,9 +53,9 @@ async def test_edit_file_old_string_not_found(tmp_path: Path) -> None:
     path = tmp_path / "test.py"
     path.write_text("hello world\n")
 
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     result = await tool.invoke({
-        "path": str(path),
+        "path": "test.py",
         "old_string": "nonexistent",
         "new_string": "replacement",
     })
@@ -70,9 +70,9 @@ async def test_edit_file_ambiguous_without_replace_all(tmp_path: Path) -> None:
     path = tmp_path / "test.py"
     path.write_text("x = 1\ny = x\nz = x\n")
 
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     result = await tool.invoke({
-        "path": str(path),
+        "path": "test.py",
         "old_string": "x",
         "new_string": "n",
     })
@@ -87,9 +87,9 @@ async def test_edit_file_identical_strings(tmp_path: Path) -> None:
     path = tmp_path / "test.py"
     path.write_text("hello\n")
 
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     result = await tool.invoke({
-        "path": str(path),
+        "path": "test.py",
         "old_string": "hello",
         "new_string": "hello",
     })
@@ -101,9 +101,9 @@ async def test_edit_file_identical_strings(tmp_path: Path) -> None:
 # 功能：验证文件不存在时返回错误
 # 设计：指定不存在的文件路径，断言返回错误
 async def test_edit_file_missing_file(tmp_path: Path) -> None:
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     result = await tool.invoke({
-        "path": str(tmp_path / "nonexistent.py"),
+        "path": "nonexistent.py",
         "old_string": "a",
         "new_string": "b",
     })
@@ -115,10 +115,10 @@ async def test_edit_file_missing_file(tmp_path: Path) -> None:
 # 功能：验证 .. 路径遍历被拒绝
 # 设计：路径中包含 .. 组件，断言抛出 PermissionError
 async def test_edit_file_rejects_traversal(tmp_path: Path) -> None:
-    tool = EditFileTool()
+    tool = EditFileTool(tmp_path)
     with pytest.raises(PermissionError):
         await tool.invoke({
-            "path": str(tmp_path / ".." / "outside.py"),
+            "path": "../outside.py",
             "old_string": "a",
             "new_string": "b",
         })

--- a/tests/unit/test_read_file.py
+++ b/tests/unit/test_read_file.py
@@ -12,7 +12,7 @@ from sztu_code.core.tools.builtin.read_file import ReadFileTool
 async def test_read_existing_file(tmp_path: Path) -> None:
     f = tmp_path / "hello.txt"
     f.write_text("hello world", encoding="utf-8")
-    result = await ReadFileTool().invoke({"path": str(f)})
+    result = await ReadFileTool(tmp_path).invoke({"path": "hello.txt"})
     assert not result.is_error
     assert result.content == "hello world"
 
@@ -21,21 +21,21 @@ async def test_read_existing_file(tmp_path: Path) -> None:
 # 设计：传入不存在的路径，确认 ReadFileTool 不吞掉异常，让调用方（invoke_tool）负责错误分类和事件发布
 async def test_file_not_found_raises(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError):
-        await ReadFileTool().invoke({"path": str(tmp_path / "missing.txt")})
+        await ReadFileTool(tmp_path).invoke({"path": "missing.txt"})
 
 
 # 功能：验证包含 `..` 的路径被拒绝并抛出 PermissionError
 # 设计：传入 `"../secret.txt"` 这种最典型的目录遍历形式，确认安全边界第一道防线有效
-async def test_path_traversal_dotdot_raises() -> None:
+async def test_path_traversal_dotdot_raises(tmp_path: Path) -> None:
     with pytest.raises(PermissionError):
-        await ReadFileTool().invoke({"path": "../secret.txt"})
+        await ReadFileTool(tmp_path).invoke({"path": "../secret.txt"})
 
 
 # 功能：验证多级路径中嵌入的 `..` 经过路径规范化后也被正确检测
 # 设计：使用 `"subdir/../../etc/passwd"` 测试路径 resolve 后的深度遍历，确认单层 `..` 过滤不足以覆盖此情况
-async def test_path_traversal_nested_raises() -> None:
+async def test_path_traversal_nested_raises(tmp_path: Path) -> None:
     with pytest.raises(PermissionError):
-        await ReadFileTool().invoke({"path": "subdir/../../etc/passwd"})
+        await ReadFileTool(tmp_path).invoke({"path": "subdir/../../etc/passwd"})
 
 
 # 功能：验证超过 512KB 的文件被截断并在末尾追加 [truncated] 标记
@@ -43,7 +43,7 @@ async def test_path_traversal_nested_raises() -> None:
 async def test_truncation_over_512kb(tmp_path: Path) -> None:
     f = tmp_path / "big.txt"
     f.write_bytes(b"x" * (600 * 1024))
-    result = await ReadFileTool().invoke({"path": str(f)})
+    result = await ReadFileTool(tmp_path).invoke({"path": "big.txt"})
     assert not result.is_error
     assert result.content.endswith("[truncated]")
     # Actual text content is exactly 512KB worth of 'x' chars
@@ -55,7 +55,7 @@ async def test_truncation_over_512kb(tmp_path: Path) -> None:
 async def test_exact_512kb_is_not_truncated(tmp_path: Path) -> None:
     f = tmp_path / "exact.txt"
     f.write_bytes(b"y" * (512 * 1024))
-    result = await ReadFileTool().invoke({"path": str(f)})
+    result = await ReadFileTool(tmp_path).invoke({"path": "exact.txt"})
     assert not result.is_error
     assert not result.content.endswith("[truncated]")
     assert len(result.content) == 512 * 1024
@@ -66,6 +66,6 @@ async def test_exact_512kb_is_not_truncated(tmp_path: Path) -> None:
 async def test_empty_file_returns_empty_content(tmp_path: Path) -> None:
     f = tmp_path / "empty.txt"
     f.write_text("", encoding="utf-8")
-    result = await ReadFileTool().invoke({"path": str(f)})
+    result = await ReadFileTool(tmp_path).invoke({"path": "empty.txt"})
     assert not result.is_error
     assert result.content == ""

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -186,8 +186,8 @@ async def test_run_finished_event_published_on_success(tmp_path: Path) -> None:
     assert finished.status == "success"  # type: ignore[attr-defined]
 
 
-# 功能：验证步数耗尽时 run.finished 携带 failed 状态和正确的失败原因
-# 设计：LoopingProvider + max_steps=2 触发失败路径，确认 runner 在失败终止路径同样发布 finished 事件
+# 功能：验证步数耗尽时 run.finished 携带 interrupted 状态和正确的中断原因
+# 设计：LoopingProvider + max_steps=2 触发可续跑的中断路径，确认 runner 发布 finished 事件
 async def test_run_finished_event_published_on_max_steps(tmp_path: Path) -> None:
     events = await _run(
         provider=_LoopingProvider(),
@@ -195,7 +195,7 @@ async def test_run_finished_event_published_on_max_steps(tmp_path: Path) -> None
         tmp_path=tmp_path,
     )
     finished = next(e for e in events if e.type == "run.finished")  # type: ignore[attr-defined]
-    assert finished.status == "failed"  # type: ignore[attr-defined]
+    assert finished.status == "interrupted"  # type: ignore[attr-defined]
     assert finished.reason == "exceeded_max_steps"  # type: ignore[attr-defined]
 
 
@@ -284,8 +284,8 @@ async def test_injected_bus_receives_events(tmp_path: Path) -> None:
     assert "run.finished" in types
 
 
-# 功能：验证 session run 会从 thread.jsonl 预填 messages，并把 notes 注入 system prompt
-# 设计：用 CapturingProvider 截获 LLM 入参，不触发真实 API；同时断言 run 目录写到 session/runs 下
+# 功能：验证 session run 会从 thread.jsonl 预填带时间戳的 messages，并把 notes 注入 system prompt
+# 设计：截获 LLM 入参并逐字段断言历史消息，同时确认 run 目录写到 session/runs 下
 async def test_session_history_and_notes_injected(tmp_path: Path) -> None:
     from sztu_code.core.session.model import Session
     from sztu_code.core.session.store import SessionStore
@@ -308,7 +308,10 @@ async def test_session_history_and_notes_injected(tmp_path: Path) -> None:
 
     await runner.run_and_capture("remember python", run_id="run-new", session=session, store=store)
 
-    assert provider.messages == [{"role": "user", "content": "remember python"}]
+    assert len(provider.messages) == 1
+    assert provider.messages[0]["role"] == "user"
+    assert provider.messages[0]["content"] == "remember python"
+    assert provider.messages[0]["ts"]
     assert provider.system is not None
     assert "Python 3.12" in provider.system
     assert (store.runs_dir("sess-1") / "run-new" / "events.jsonl").exists()

--- a/tests/unit/test_workspace_bound_tools.py
+++ b/tests/unit/test_workspace_bound_tools.py
@@ -23,9 +23,12 @@ async def test_workspace_bound_read_and_write_use_project_root(tmp_path: Path) -
     assert read.content == "workspace scoped"
 
 
-# 功能：验证绑定工作区后的文件工具拒绝绝对路径和父目录穿越。
-# 设计：对同一根目录分别提供 ../ 与临时目录绝对路径，直接断言 PermissionError，覆盖 resolve 后的真实边界检查。
-@pytest.mark.parametrize("path", ["../outside.txt", "C:/outside.txt"])
+# 功能：验证绑定工作区后的文件工具跨平台拒绝绝对路径和父目录穿越。
+# 设计：覆盖父目录、Windows 盘符、盘根和 UNC 写法，防止 POSIX 将 Windows 绝对路径误判为普通文件名。
+@pytest.mark.parametrize(
+    "path",
+    ["../outside.txt", "C:/outside.txt", r"\outside.txt", r"\\server\share\outside.txt"],
+)
 async def test_workspace_bound_tools_reject_paths_outside_project(tmp_path: Path, path: str) -> None:
     project = tmp_path / "project"
     project.mkdir()


### PR DESCRIPTION
## Summary

Closes #42.

- 将文件工具测试统一为“绑定工作区根目录 + 相对路径”契约。
- 用受控假进程替代平台相关的 `sleep` 超时命令。
- 更新 AgentLoop 终止状态与 session message 时间戳断言。
- 在 POSIX 上识别并拒绝 Windows 盘符、盘根和 UNC 绝对路径。

## Behavior

工作区绑定工具现在跨平台拒绝所有 anchored/absolute path 写法，避免 Linux 将 `C:/outside.txt` 当作普通相对路径。没有协议、配置或持久化格式变化。

## Validation

- WSL2 / Python 3.12：`uv run pytest tests/unit -q -p no:cacheprovider` → **629 passed**
- WSL2 相关回归集（6 个文件）→ **82 passed**
- Windows / Python 3.12 同一回归集 → **82 passed**
- `uv run ruff check`（7 个改动文件）→ **All checks passed**
- `uv run mypy src/sztu_code/core/tools/workspace.py` → **Success**
- `git diff --check` → **passed**

仓库当前尚无 GitHub Actions workflow（见 #25）；以上命令均在隔离 WSL 副本及 Windows 本地环境实际执行。

## Risk

风险较低。行为变化仅收紧工作区路径入口：此前可能接受的工作区内绝对路径现在也会被拒绝，符合工具声明的相对路径契约。回滚可直接 revert 本提交。

## UI evidence

N/A（无 TUI/Desktop 视觉改动）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A：未修改协议模型）
- [x] 用户文档、配置示例和迁移说明已同步。（N/A：无用户配置或迁移变化）
- [x] 提交包含 `Signed-off-by`（DCO）。