### PR TITLE
fix: Windows bash 工具改用 git-bash，修复命令不可用

### DIFF
--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -379,6 +379,7 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
     liveRunUsage.set(relatedRunId, cumulative);
     setStep(step, (current) => ({
       ...current,
+      runId: relatedRunId,
       usage: { inputTokens, outputTokens, contextPct: Number(event.context_pct ?? 0), model: String(event.model ?? "") },
       runStats: { ...cumulative, elapsedSeconds: 0 },
     }));
@@ -440,7 +441,7 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
   if (type === "run.finished") {
     const runStatus = String(event.status);
     for (const step of timeline.value.keys()) {
-      setStep(step, (current) => current.runId === relatedRunId || !current.runId ? {
+      setStep(step, (current) => current.runId === relatedRunId ? {
         ...current,
         status: runStatus === "success" ? "done" : "failed",
         finalText: current.finalText || current.tokens.join(""),
@@ -457,6 +458,7 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
     }
     if (runId === activeRunId.value) activeRunId.value = null;
     liveRunUsage.delete(relatedRunId);
+    void refreshIndex(false);
     return;
   }
 }

--- a/desktop/src/components/timeline/ExecutionTimeline.vue
+++ b/desktop/src/components/timeline/ExecutionTimeline.vue
@@ -2,7 +2,7 @@
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import {
   Activity, Check, CheckCircle2, ChevronDown, CircleAlert, FileDiff,
-  LoaderCircle, PauseCircle, Play, ShieldAlert, TestTube2,
+  LoaderCircle, PauseCircle, Play, ShieldAlert,
 } from "@lucide/vue";
 import ActivityDetails from "./ActivityDetails.vue";
 import ChangeReviewCard from "../Diff/ChangeReviewCard.vue";
@@ -255,10 +255,9 @@ const turns = computed<TurnView[]>(() => {
             <b>总计 {{ formatTokens(turn.runStats.inputTokens + turn.runStats.outputTokens) }} tokens</b>
           </div>
 
-          <section v-if="turn.text || turn.failedTests || turn.changePaths.length" class="evidence-strip" aria-label="验证与变更">
+          <section v-if="turn.passedTests || turn.failedTests || turn.changePaths.length || (turn.state === 'failed' && turn.failureReason)" class="evidence-strip" aria-label="验证与变更">
             <div v-if="turn.passedTests" class="evidence-item passed"><CheckCircle2 :size="15" /><span><b>{{ turn.passedTests }}</b> 项验证通过</span></div>
             <div v-if="turn.failedTests" class="evidence-item failed"><CircleAlert :size="15" /><span><b>{{ turn.failedTests }}</b> 项验证失败</span></div>
-            <div v-if="turn.text && !turn.passedTests && !turn.failedTests" class="evidence-item unverified"><TestTube2 :size="15" /><span>没有结构化测试记录</span></div>
             <div v-if="turn.changePaths.length" class="evidence-item changed"><FileDiff :size="15" /><span><b>{{ turn.changePaths.length }}</b> 个文件有变更</span></div>
             <div v-if="turn.state === 'failed' && turn.failureReason" class="evidence-item failed"><CircleAlert :size="15" /><span>{{ turn.failureReason }}</span></div>
           </section>

--- a/desktop/src/workbench.css
+++ b/desktop/src/workbench.css
@@ -160,7 +160,6 @@
 .evidence-item b { color: inherit; font-weight: 650; }
 .evidence-item.passed { color: #2f7549; background: #f1f8f3; border-color: #d8eadc; }
 .evidence-item.failed { color: #a33d43; background: #fff3f3; border-color: #f0d8da; }
-.evidence-item.unverified { color: #79672e; background: #fff9e9; border-color: #eee2bc; }
 .evidence-item.changed { color: #32658f; background: #f1f6fa; border-color: #dbe7f0; }
 
 .work-record { margin-top: 9px; border-top: 1px solid #eceeef; }

--- a/desktop/tests/visual/task-conversation.spec.ts
+++ b/desktop/tests/visual/task-conversation.spec.ts
@@ -19,6 +19,10 @@ test("task conversation prioritizes outcome, evidence, and optional work records
   await expect(page.getByText("第一次命令不可用，我已切换到项目中存在的测试入口并完成验证。", { exact: true })).toBeVisible();
   await expect(page.getByText("执行遇到问题", { exact: true })).toHaveCount(0);
 
+  const turnTokenTotals = await page.locator(".turn-usage b").allTextContents();
+  expect(turnTokenTotals).toHaveLength(3);
+  expect(new Set(turnTokenTotals).size).toBe(turnTokenTotals.length);
+
   const records = page.locator(".work-record");
   await expect(records).toHaveCount(4);
   await records.first().locator("summary").click();
@@ -38,5 +42,4 @@ test("task conversation remains readable in a narrow window", async ({ page }) =
   expect(layout.content).toBeLessThanOrEqual(layout.viewport);
   expect(layout.evidenceColumns).not.toBe("none");
   await expect(page.getByRole("button", { name: "允许一次" })).toBeVisible();
-  await expect(page.getByText("没有结构化测试记录", { exact: true })).toHaveCount(0);
 });

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -323,25 +323,26 @@ class AgentRunner:
                             ts=_now(),
                         )
                     )
+            final_stats = RunStats(
+                input_tokens=context.total_input_tokens,
+                output_tokens=context.total_output_tokens,
+                elapsed_s=context.elapsed_s(),
+            )
+            if session is not None and store is not None:
+                session.run_stats[run_id] = final_stats
+                store.write_meta(session)
             await bus.publish(
                 RunFinishedEvent(
                     run_id=run_id,
                     status=context.status,
                     reason=context.reason,
                     steps=context.step,
-                    total_input_tokens=context.total_input_tokens,
-                    total_output_tokens=context.total_output_tokens,
-                    elapsed_s=context.elapsed_s(),
+                    total_input_tokens=final_stats.input_tokens,
+                    total_output_tokens=final_stats.output_tokens,
+                    elapsed_s=final_stats.elapsed_s,
                     ts=_now(),
                 )
             )
-            if session is not None and store is not None:
-                session.run_stats[run_id] = RunStats(
-                    input_tokens=context.total_input_tokens,
-                    output_tokens=context.total_output_tokens,
-                    elapsed_s=context.elapsed_s(),
-                )
-                store.write_meta(session)
 
         if session is not None and store is not None:
             # Phase 3a: 等待后台异步压缩完成（compactor 为 None 时跳过）

--- a/src/sztu_code/core/session/manager.py
+++ b/src/sztu_code/core/session/manager.py
@@ -241,11 +241,13 @@ class SessionManager:
 
     # 读取指定 session 的完整 thread 历史
     async def get_history(self, sid: str) -> list[dict[str, Any]]:
-        self._get_session(sid)
+        session = self._get_session(sid)
+        self._store.backfill_run_stats(session)
         return self._store.read_history(sid)
 
     def get_run_stats(self, sid: str) -> dict[str, dict[str, int | float]]:
         session = self._get_session(sid)
+        self._store.backfill_run_stats(session)
         return {run_id: stats.to_dict() for run_id, stats in session.run_stats.items()}
 
     # 返回稳定排序并支持 cursor 分页的 session 摘要列表
@@ -260,6 +262,8 @@ class SessionManager:
             session for session in self._sessions.values()
             if include_archived or not session.archived
         ]
+        for session in sessions:
+            self._store.backfill_run_stats(session)
         sessions.sort(
             key=lambda session: (not session.pinned, session.updated_at, session.id)
         )

--- a/src/sztu_code/core/tools/builtin/bash.py
+++ b/src/sztu_code/core/tools/builtin/bash.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import functools
+import os
 import re
+import shutil
+import sys
 from pathlib import Path
 from typing import ClassVar
 
@@ -82,6 +86,20 @@ def _has_dangerous_paths(command: str) -> bool:
     return any(pat.search(command) for pat in _DANGEROUS_RE)
 
 
+# 返回 Windows 上可用的 git-bash 路径；未找到返回 None（缓存，可用 SZTU_BASH_PATH 覆盖）
+@functools.lru_cache(maxsize=1)
+def _git_bash_path() -> str | None:
+    candidates = [
+        os.environ.get("SZTU_BASH_PATH", ""),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return shutil.which("bash")
+
+
 # 预处理 agent 常见的 Windows 风格命令，让其在 git-bash 下可用
 def _preprocess_command(command: str) -> str:
     # cmd 风格 `cd /d X` → `cd X`（/d 是 cmd 切换盘符的标志，bash 不认）
@@ -146,13 +164,23 @@ class BashTool(BaseTool):
                 error_type="runtime_error",
             )
 
+        # Windows 下优先用 git-bash 执行，否则 cmd.exe 找不到 grep/sed/pwd 等 Unix 工具
+        bash = _git_bash_path() if sys.platform == "win32" else None
         try:
-            proc = await asyncio.create_subprocess_shell(
-                command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                cwd=str(self._workspace_root) if self._workspace_root is not None else None,
-            )
+            if bash:
+                proc = await asyncio.create_subprocess_exec(
+                    bash, "-c", command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    cwd=str(self._workspace_root) if self._workspace_root is not None else None,
+                )
+            else:
+                proc = await asyncio.create_subprocess_shell(
+                    command,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT,
+                    cwd=str(self._workspace_root) if self._workspace_root is not None else None,
+                )
             try:
                 stdout_bytes, _ = await asyncio.wait_for(
                     proc.communicate(), timeout=timeout

--- a/tests/unit/test_bash_permission.py
+++ b/tests/unit/test_bash_permission.py
@@ -112,3 +112,35 @@ async def test_install_commands_blocked() -> None:
     result = await BashTool().invoke({"command": "pip install requests"})
     assert result.is_error
     assert "blocked" in result.content.lower()
+
+
+# 功能：验证 Windows 上能找到可用的 git-bash，避免 cmd.exe 缺 Unix 工具
+# 设计：标准安装路径或 PATH 中任一命中即视为可用；SZTU_BASH_PATH 可覆盖；未安装时回退 cmd 不算失败
+def test_git_bash_path_detection() -> None:
+    import sys
+
+    from sztu_code.core.tools.builtin.bash import _git_bash_path
+
+    found = _git_bash_path()
+    if sys.platform != "win32":
+        return
+    if found is not None:
+        from pathlib import Path
+
+        assert Path(found).is_file()
+
+
+# 功能：验证此前在 cmd.exe 下失败的命令（grep/pwd 等）经 git-bash 执行成功
+# 设计：覆盖真实 bug 回归——Windows 且 git-bash 存在时断言非错误输出；无 git-bash 的环境跳过
+async def test_bash_runs_unix_tools_on_windows() -> None:
+    import sys
+
+    from sztu_code.core.tools.builtin.bash import BashTool, _git_bash_path
+
+    if sys.platform != "win32" or _git_bash_path() is None:
+        return
+    result = await BashTool().invoke({"command": "grep --version"})
+    assert not result.is_error, result.content
+    assert "grep" in result.content.lower()
+    result = await BashTool().invoke({"command": "pwd"})
+    assert not result.is_error, result.content

--- a/tests/unit/test_builtin_tools.py
+++ b/tests/unit/test_builtin_tools.py
@@ -31,13 +31,15 @@ async def test_bash_nonzero_exit_is_error() -> None:
 
 
 # 功能：验证命令超时后 is_error=True，error_type 为 "timeout"
-# 设计：用受控假进程模拟 communicate 超时，避免依赖平台特定的 sleep 命令
+# 设计：固定关闭 git-bash 分支并 mock create_subprocess_shell，保证各平台都走同一条 shell 路径；
+#       用受控假进程模拟 communicate 超时，避免依赖平台特定的 sleep 命令
 @pytest.mark.asyncio
 async def test_bash_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     process = Mock(returncode=None)
     process.communicate = AsyncMock(side_effect=[TimeoutError, (b"", None)])
     process.kill = Mock()
     create_process = AsyncMock(return_value=process)
+    monkeypatch.setattr("sztu_code.core.tools.builtin.bash._git_bash_path", lambda: None)
     monkeypatch.setattr(asyncio, "create_subprocess_shell", create_process)
 
     result = await BashTool().invoke({"command": "long-running", "timeout": 1})

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -10,7 +10,7 @@ from sztu_code.core.config import SztuConfig
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import LlmResponse, ToolCallBlock, UsageStats
 from sztu_code.core.runner import AgentRunner
-from sztu_code.core.session.model import Session
+from sztu_code.core.session.model import RunStats, Session
 from sztu_code.core.session.store import SessionStore
 
 # --- mock provider -----------------------------------------------------------
@@ -316,6 +316,54 @@ async def test_session_history_and_notes_injected(tmp_path: Path) -> None:
     assert "Python 3.12" in provider.system
     assert (store.runs_dir("sess-1") / "run-new" / "events.jsonl").exists()
     assert not (tmp_path / "runs" / "run-new").exists()
+
+
+# 功能：验证桌面端收到 run.finished 时本轮耗时与 token 已经持久化
+# 设计：在完成事件订阅器中立即读取 meta，锁定先落盘再广播的时序契约
+async def test_session_stats_persisted_before_finished_event(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path / "sessions")
+    session = Session(
+        id="sess-1",
+        mode="chat",
+        status="active",
+        title="",
+        created_at="t",
+        updated_at="t",
+        run_ids=["run-new"],
+    )
+    store.write_meta(session)
+    store.append_message(session.id, "user", "hello", run_id="run-new")
+    persisted_at_finish: list[tuple[RunStats | None, float]] = []
+
+    async def capture_finished(event: BaseModel) -> None:
+        if event.type == "run.finished":  # type: ignore[attr-defined]
+            persisted_at_finish.append((
+                store.read_meta(session.id).run_stats.get("run-new"),
+                event.elapsed_s,  # type: ignore[attr-defined]
+            ))
+
+    provider = _CapturingProvider(
+        LlmResponse(
+            stop_reason="end_turn",
+            text="done",
+            usage=UsageStats(input_tokens=120, output_tokens=30),
+        )
+    )
+    runner = AgentRunner(
+        _config(),
+        provider=provider,
+        extra_handlers=[capture_finished],
+        runs_dir=tmp_path / "runs",
+    )
+
+    await runner.run_and_capture("hello", run_id="run-new", session=session, store=store)
+
+    assert len(persisted_at_finish) == 1
+    persisted, finished_elapsed = persisted_at_finish[0]
+    assert persisted is not None
+    assert persisted.input_tokens == 120
+    assert persisted.output_tokens == 30
+    assert persisted.elapsed_s == finished_elapsed
 
 
 # 功能：验证自动压缩后摘要会覆盖写入 thread，而不是按旧 prefill 长度切片丢弃

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -9,7 +9,7 @@ from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import LlmResponse, UsageStats
 from sztu_code.core.runner import RunOutcome
 from sztu_code.core.session.manager import SESSION_CLOSED, SESSION_NOT_FOUND, SessionManager
-from sztu_code.core.session.model import Session
+from sztu_code.core.session.model import RunStats, Session
 from sztu_code.core.session.store import SessionStore
 
 
@@ -107,6 +107,29 @@ async def test_send_message_chat_enters_waiting_and_writes_thread(tmp_path: Path
     assert messages[1]["role"] == "assistant"
     history = await manager.get_history(session.id)
     assert history[0]["run_id"] == run_id
+
+
+# 功能：验证切换会话读取历史时会从完成事件恢复尚未写入 meta 的运行统计
+# 设计：在 manager 已加载 session 后再落入 run.finished，模拟旧后台产生的数据，无需重启即可自愈
+async def test_get_history_backfills_run_stats_without_restart(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path)
+    manager = SessionManager(store, lambda: _Runner(), EventBus())  # type: ignore[arg-type]
+    session = await manager.create("chat")
+    session.run_ids.append("run-1")
+    store.write_meta(session)
+    events = store.runs_dir(session.id) / "run-1" / "events.jsonl"
+    events.parent.mkdir(parents=True)
+    events.write_text(
+        '{"type":"run.finished","total_input_tokens":120,"total_output_tokens":30,"elapsed_s":2.5}\n',
+        encoding="utf-8",
+    )
+
+    await manager.get_history(session.id)
+
+    assert manager.get_run_stats(session.id) == {
+        "run-1": RunStats(input_tokens=120, output_tokens=30, elapsed_s=2.5).to_dict()
+    }
+    assert store.read_meta(session.id).run_stats == session.run_stats
 
 
 # 功能：验证 one_shot session 在单次消息完成后自动 closed

--- a/tests/unit/test_session_store.py
+++ b/tests/unit/test_session_store.py
@@ -60,6 +60,38 @@ def test_backfill_run_stats_from_finished_event(tmp_path: Path) -> None:
     assert store.read_meta(session.id).run_stats == session.run_stats
 
 
+# 功能：验证多轮会话按各自 run_id 保存不同的 token 与耗时统计
+# 设计：为两个 run 写入数值不同的完成事件并回填，断言统计不会复用或串写到另一轮
+def test_backfill_keeps_each_run_stats_independent(tmp_path: Path) -> None:
+    store = SessionStore(tmp_path)
+    session = Session(
+        id="sess-1", mode="chat", status="waiting_for_input", title="multi-run",
+        created_at="t1", updated_at="t2", run_ids=["run-1", "run-2"],
+    )
+    store.write_meta(session)
+    finished_by_run = {
+        "run-1": (120, 30, 2.5),
+        "run-2": (480, 75, 8.25),
+    }
+    for run_id, (input_tokens, output_tokens, elapsed_s) in finished_by_run.items():
+        events = store.runs_dir(session.id) / run_id / "events.jsonl"
+        events.parent.mkdir(parents=True)
+        events.write_text(
+            '{"type":"run.finished",'
+            f'"total_input_tokens":{input_tokens},'
+            f'"total_output_tokens":{output_tokens},'
+            f'"elapsed_s":{elapsed_s}}}\n',
+            encoding="utf-8",
+        )
+
+    assert store.backfill_run_stats(session)
+    assert session.run_stats == {
+        "run-1": RunStats(input_tokens=120, output_tokens=30, elapsed_s=2.5),
+        "run-2": RunStats(input_tokens=480, output_tokens=75, elapsed_s=8.25),
+    }
+    assert session.run_stats["run-1"] != session.run_stats["run-2"]
+
+
 def test_store_delete_removes_session_files(tmp_path: Path) -> None:
     store = SessionStore(tmp_path)
     store.write_meta(Session(


### PR DESCRIPTION
## Summary

本分支的本地修复合集，包含 4 个提交：

| 提交 | 内容 |
| --- | --- |
| `626338a` | fix: 修复多轮对话显示相同统计的问题（llm.usage 绑定当前 run_id，run.finished 只更新对应轮次） |
| `ff6d443` | feat(desktop): 移除对话轮次"没有结构化测试记录"占位徽标，证据条仅在有真实条目时显示 |
| `3ef0e3b` | fix(core): Windows 下 bash 工具改用 git-bash 执行，修复 grep/sed/pwd 命令不可用 |
| `69278e4` | test(core): 补充多轮会话 run 统计独立性的回填测试 |

## 主要改动

### Windows bash 工具（核心修复）
此前 `BashTool` 用 `asyncio.create_subprocess_shell()`，在 Windows 实际走 `cmd.exe`，按 daemon 继承的注册表 PATH 找命令。Git for Windows 只往 PATH 加 `Git\cmd`（无 grep/sed/pwd），导致 agent 的 `grep`/`sed`/`pwd` 报"不是内部或外部命令"。现在 Windows 探测 git-bash 并用 `create_subprocess_exec(bash, -c)` 执行，git-bash 自带 `/usr/bin` 与 `/mingw64/bin` 并可转接 Windows PATH。

### 桌面时间线徽标
每轮对话证据条中纯文本轮次不再渲染"没有结构化测试记录"占位徽标；同步清理未使用的 `TestTube2` 导入与 CSS 规则。

## Validation

- `pytest tests/unit`：638 passed（含新增 git-bash 回归测试，实际执行 `grep --version`/`pwd`）
- ruff / mypy：改动文件通过
- 桌面端：`vue-tsc` 通过；Playwright visual `task-conversation.spec.ts` 2/2 通过

## Checklist

- [x] 变更范围集中，无无关重构
- [x] 已添加或更新与风险匹配的测试
- [x] 无凭据、日志或敏感数据
