### PR TITLE
fix(tools): grep_search 流式读取，避免整读大文件后截断

### DIFF
--- a/src/sztu_code/core/tools/builtin/grep_search.py
+++ b/src/sztu_code/core/tools/builtin/grep_search.py
@@ -104,7 +104,9 @@ class GrepSearchTool(BaseTool):
         root = (self._workspace_root or Path.cwd()).resolve()
         matches: list[str] = []
         for file in self._iter_files(target, p.glob):
-            raw = file.read_bytes()[:_MAX_BYTES]
+            # 流式读取最多 _MAX_BYTES 字节，避免 read_bytes 先加载完整文件
+            with file.open("rb") as fh:
+                raw = fh.read(_MAX_BYTES)
             if b"\x00" in raw[:8192]:
                 continue  # 跳过二进制文件
             text = raw.decode("utf-8", errors="replace")

--- a/tests/unit/test_grep_search.py
+++ b/tests/unit/test_grep_search.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import BinaryIO
 
 import pytest
 
-from sztu_code.core.tools.builtin.grep_search import GrepSearchTool
+from sztu_code.core.tools.builtin.grep_search import _MAX_BYTES, GrepSearchTool
 
 
 def _make_tree(root: Path) -> None:
@@ -130,3 +131,67 @@ async def test_no_matches(tmp_path: Path) -> None:
     result = await tool.invoke({"pattern": "nonexistent_symbol_xyz"})
     assert not result.is_error
     assert result.content == "No matches found."
+
+
+# 功能：超过 _MAX_BYTES 的文件只搜索前 _MAX_BYTES 字节，限制前文本可命中、限制后不返回
+# 设计：构造限制前后各一个目标词的大文件，分别搜索验证截断边界，不依赖进程内存统计
+async def test_only_bytes_within_limit_are_searched(tmp_path: Path) -> None:
+    big = tmp_path / "big.txt"
+    big.write_bytes(b"TARGET_BEFORE\n" + b"a" * _MAX_BYTES + b"\nTARGET_AFTER\n")
+    tool = GrepSearchTool(tmp_path)
+
+    before = await tool.invoke({"pattern": "TARGET_BEFORE"})
+    assert not before.is_error
+    assert "big.txt:1: TARGET_BEFORE" in before.content
+
+    after = await tool.invoke({"pattern": "TARGET_AFTER"})
+    assert not after.is_error
+    assert after.content == "No matches found."
+
+
+# 功能：流式读取以 _MAX_BYTES 为上限调用 read，避免先整读文件再切片
+# 设计：monkeypatch Path.open 返回记录 read(n) 的替身文件对象，断言读取参数含上限值且总读取字节不超限
+async def test_read_call_carries_byte_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    big = tmp_path / "big.txt"
+    big.write_bytes(b"x" * (_MAX_BYTES + 4096))
+
+    class _SpyFile:
+        # 替身文件对象：透传真实句柄，同时记录每次 read(n) 的调用参数
+        def __init__(self, fh: BinaryIO) -> None:
+            self._fh = fh
+            self.read_args: list[int] = []
+            self.total_bytes = 0
+
+        # 记录读取请求大小与返回字节数，供断言证明读取上限生效
+        def read(self, n: int = -1) -> bytes:
+            self.read_args.append(n)
+            data = self._fh.read(n)
+            self.total_bytes += len(data)
+            return data
+
+        def __enter__(self) -> _SpyFile:
+            return self
+
+        def __exit__(self, *_exc: object) -> None:
+            self._fh.close()
+
+    opened_spies: list[_SpyFile] = []
+    real_open = Path.open
+
+    # 替换 Path.open 使其返回替身，从而捕获真实读取行为
+    def spy_open(self: Path, *args: object, **kwargs: object) -> _SpyFile:
+        spy = _SpyFile(real_open(self, *args, **kwargs))
+        opened_spies.append(spy)
+        return spy
+
+    monkeypatch.setattr(Path, "open", spy_open)
+    tool = GrepSearchTool(tmp_path)
+    result = await tool.invoke({"pattern": "zzz_missing"})
+
+    assert not result.is_error
+    assert opened_spies
+    spy = opened_spies[0]
+    assert _MAX_BYTES in spy.read_args
+    assert spy.total_bytes <= _MAX_BYTES


### PR DESCRIPTION
## Summary
grep_search 之前用 `Path.read_bytes()[:_MAX_BYTES]`，会先把整个文件读入内存再切片，
_512KB 上限无法防止大文件带来的内存占用。改为 `open("rb")` + `read(_MAX_BYTES)` 流式读取。

Fixes #24

## Behavior
- 单文件最多读取 512KB，不再先整读再截断
- 512KB 内的文本仍可搜索，之后的内容不返回
- 二进制检测、UTF-8 容错、命中上限等行为不变

## Validation
uv run pytest tests/unit/test_grep_search.py -v        # 12 passed
uv run ruff check src/sztu_code/core/tools/builtin/grep_search.py tests/unit/test_grep_search.py  # 通过
（修复前替身测试 red：read(-1)；修复后 green：read(524288)）

## Risk
低。截断边界与原实现一致；无协议、权限、数据格式变化；回滚仅需还原该行。

## UI evidence
N/A

## Checklist
- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [ ] 协议变化已重新生成 docs/reference/wire-protocol.md。（无协议变化）
- [ ] 用户文档、配置示例和迁移说明已同步。（无用户文档变化）
- [x] 提交包含 Signed-off-by（DCO）。