### PR TITLE
fix(eval): SWE-bench 适配器从事件顶层读取 token usage

### DIFF
--- a/eval/swebench/adapter.py
+++ b/eval/swebench/adapter.py
@@ -25,7 +25,6 @@ import argparse
 import asyncio
 import json
 import logging
-import os
 import shutil
 import subprocess
 import sys
@@ -41,7 +40,6 @@ SZTU_SRC = Path(__file__).resolve().parents[2] / "src"
 sys.path.insert(0, str(SZTU_SRC))
 
 from sztu_code.core.transport.socket_client import IpcError, SocketClient  # noqa: E402
-
 
 # ──────────────────── 数据模型 ────────────────────
 
@@ -85,6 +83,8 @@ class RunResult:
     status: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
     events_log: list[dict] = field(default_factory=list)
 
     def to_pred_dict(self) -> dict:
@@ -93,6 +93,28 @@ class RunResult:
             "model_patch": self.model_patch,
             "model_name_or_path": self.model_name_or_path,
         }
+
+
+@dataclass
+class TokenUsage:
+    """一次运行的 LLM token 用量汇总"""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
+
+# 汇总事件流中的 llm.usage 顶层字段，缺失按 0 处理且忽略无关事件
+def summarize_token_usage(events: list[dict[str, Any]]) -> TokenUsage:
+    usage = TokenUsage()
+    for ev in events:
+        if ev.get("type") != "llm.usage":
+            continue
+        usage.input_tokens += ev.get("input_tokens", 0) or 0
+        usage.output_tokens += ev.get("output_tokens", 0) or 0
+        usage.cache_read_input_tokens += ev.get("cache_read_input_tokens", 0) or 0
+        usage.cache_creation_input_tokens += ev.get("cache_creation_input_tokens", 0) or 0
+    return usage
 
 
 # ──────────────────── Prompt 构造 ────────────────────
@@ -105,7 +127,8 @@ Here is an issue that needs to be fixed:
 
 {instance.problem_statement}
 
-Please analyze the issue, locate the problematic code in the repository, and make the necessary changes to fix it.
+Please analyze the issue, locate the problematic code in the repository, and make the necessary \
+changes to fix it.
 
 Guidelines:
 - Read the relevant source files first to understand the codebase structure
@@ -133,7 +156,10 @@ def clone_repo(instance: SWEbenchInstance, workspace: Path) -> Path:
 
     # 浅拷贝元数据 + 按需拉取 blob，显著加快大仓库克隆；checkout 需要的提交历史仍会拉取
     subprocess.run(
-        ["git", "clone", "--quiet", "--filter=blob:none", "--single-branch", repo_url, str(repo_dir)],
+        [
+            "git", "clone", "--quiet", "--filter=blob:none",
+            "--single-branch", repo_url, str(repo_dir),
+        ],
         check=True,
         timeout=600,
     )
@@ -214,7 +240,7 @@ async def run_instance_via_rpc(
     try:
         # 1. 设置权限模式为 auto
         await client.send_command("permission.set_mode", {"mode": "auto"})
-        logger.info(f"  Permission mode: auto")
+        logger.info("  Permission mode: auto")
 
         # 2. 打开 workspace
         ws_result = await client.send_command("workspace.open", {
@@ -250,7 +276,7 @@ async def run_instance_via_rpc(
         # 6. 等待 run.finished
         try:
             await asyncio.wait_for(run_finished.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             result.error = f"Timeout after {timeout}s"
             # 尝试取消
             try:
@@ -262,12 +288,12 @@ async def run_instance_via_rpc(
         result.steps = run_status["steps"]
         result.events_log = collected_events
 
-        # 提取 token usage
-        for ev in collected_events:
-            if ev.get("type") == "llm.usage":
-                usage = ev.get("usage", {})
-                result.input_tokens += usage.get("input_tokens", 0)
-                result.output_tokens += usage.get("output_tokens", 0)
+        # 提取 token usage（顶层字段，缺失按 0）
+        usage = summarize_token_usage(collected_events)
+        result.input_tokens = usage.input_tokens
+        result.output_tokens = usage.output_tokens
+        result.cache_read_input_tokens = usage.cache_read_input_tokens
+        result.cache_creation_input_tokens = usage.cache_creation_input_tokens
 
         # 7. 获取 diff
         if run_status["status"] in ("success", "max_steps", "cancelled"):
@@ -317,7 +343,8 @@ def _find_local_parquet(dataset_name: str, split: str) -> Path | None:
     """定位本地 SWE-bench parquet（含常见别名），不存在返回 None"""
     candidates = [
         Path(f"data/{dataset_name.replace('/', '_')}_{split}.parquet"),
-        Path(f"data/swebench_{dataset_name.split('/')[-1].replace('SWE-bench_', '').lower()}_{split}.parquet"),
+        Path(f"data/swebench_{dataset_name.split('/')[-1].replace('SWE-bench_', '').lower()}_"
+             f"{split}.parquet"),
     ]
     for path in candidates:
         if path.exists():
@@ -387,7 +414,10 @@ async def run_batch_async(
         )
         results.append(result)
 
-        status_str = result.model_patch[:50] + "..." if result.model_patch else f"FAIL: {result.error}"
+        if result.model_patch:
+            status_str = result.model_patch[:50] + "..."
+        else:
+            status_str = f"FAIL: {result.error}"
         logger.info(
             f"[{i+1}/{total}] {instance.instance_id} -> "
             f"{'PATCHED' if result.model_patch else 'FAILED'} "
@@ -413,6 +443,8 @@ async def run_batch_async(
                 "elapsed_seconds": result.elapsed_seconds,
                 "input_tokens": result.input_tokens,
                 "output_tokens": result.output_tokens,
+                "cache_read_input_tokens": result.cache_read_input_tokens,
+                "cache_creation_input_tokens": result.cache_creation_input_tokens,
                 "error": result.error,
                 "has_patch": bool(result.model_patch),
                 "patch_length": len(result.model_patch),
@@ -441,7 +473,10 @@ def main():
     )
     parser.add_argument("--split", default="test", help="数据集 split")
     parser.add_argument("--max-instances", type=int, default=None, help="最多运行多少个实例")
-    parser.add_argument("--instance-ids", default="", help="逗号分隔的 instance_id 列表，只运行这些")
+    parser.add_argument(
+        "--instance-ids", default="",
+        help="逗号分隔的 instance_id 列表，只运行这些",
+    )
     parser.add_argument(
         "--workspace", default="eval/reports/swebench-workspace",
         help="工作目录（存放克隆的仓库）"
@@ -495,7 +530,7 @@ def main():
 
     # 提示下一步
     run_id = time.strftime("%Y%m%d-%H%M%S")
-    logger.info(f"\nNext step — run official harness to score:")
+    logger.info("\nNext step — run official harness to score:")
     logger.info(
         f"  uv run python -m swebench.harness.run_evaluation \\\n"
         f"    --dataset_name {args.dataset} \\\n"

--- a/tests/unit/test_swebench_adapter.py
+++ b/tests/unit/test_swebench_adapter.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# eval 不在安装包内（pyproject 仅打包 src/sztu_code），将仓库根目录加入导入路径
+_SRC_ROOT = Path(__file__).resolve().parents[2]
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
+from eval.swebench.adapter import TokenUsage, summarize_token_usage  # noqa: E402
+
+from sztu_code.core.bus.events import LlmUsageEvent  # noqa: E402
+
+
+# 功能：多个 llm.usage 事件按顶层字段正确累计输入、输出与缓存 token
+# 设计：构造两个与 LlmUsageEvent 形状一致的事件，断言四类 token 分别相加，覆盖 issue 根因场景
+def test_sums_top_level_usage_across_multiple_events() -> None:
+    events = [
+        {
+            "type": "llm.usage", "run_id": "r1", "ts": "t1",
+            "input_tokens": 100, "output_tokens": 10,
+            "cache_read_input_tokens": 50, "cache_creation_input_tokens": 5,
+        },
+        {
+            "type": "llm.usage", "run_id": "r2", "ts": "t2",
+            "input_tokens": 200, "output_tokens": 20,
+            "cache_read_input_tokens": 60, "cache_creation_input_tokens": 6,
+        },
+    ]
+    usage = summarize_token_usage(events)
+    assert usage.input_tokens == 300
+    assert usage.output_tokens == 30
+    assert usage.cache_read_input_tokens == 110
+    assert usage.cache_creation_input_tokens == 11
+
+
+# 功能：缺失字段按 0 处理，不抛出异常
+# 设计：事件只带部分字段，断言其余字段为 0，验证 get 默认值兜底路径
+def test_missing_fields_default_to_zero() -> None:
+    events = [{"type": "llm.usage", "run_id": "r1", "input_tokens": 7}]
+    usage = summarize_token_usage(events)
+    assert usage.input_tokens == 7
+    assert usage.output_tokens == 0
+    assert usage.cache_read_input_tokens == 0
+    assert usage.cache_creation_input_tokens == 0
+
+
+# 功能：字段显式为 None 时按 0 处理，不抛出异常
+# 设计：事件序列化可能带 None 空值，or 0 兜底保证加法恒为 int
+def test_none_fields_default_to_zero() -> None:
+    events = [
+        {
+            "type": "llm.usage", "run_id": "r1", "ts": "t1",
+            "input_tokens": None, "output_tokens": None,
+            "cache_read_input_tokens": None, "cache_creation_input_tokens": None,
+        },
+    ]
+    usage = summarize_token_usage(events)
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+    assert usage.cache_read_input_tokens == 0
+    assert usage.cache_creation_input_tokens == 0
+
+
+# 功能：非 llm.usage 事件（即使带相似字段名）不影响统计
+# 设计：混入 run.finished / tool.* 事件并携带 input_tokens 字段，断言全零，防止类型误判
+def test_ignores_non_usage_events() -> None:
+    events = [
+        {"type": "run.finished", "run_id": "r1", "status": "success", "input_tokens": 999},
+        {"type": "tool.call_started", "tool_name": "bash", "input_tokens": 1},
+        {"type": "step.started", "step": 1},
+    ]
+    usage = summarize_token_usage(events)
+    assert usage == TokenUsage()
+
+
+# 功能：空事件列表返回全零汇总
+# 设计：无事件是最简输入，断言 dataclass 相等即可覆盖默认值
+def test_empty_events_yield_zero_usage() -> None:
+    assert summarize_token_usage([]) == TokenUsage()
+
+
+# 功能：直接消费 LlmUsageEvent 模型序列化产物，与现行协议字段保持一致
+# 设计：用真实 pydantic 模型 model_dump 喂给函数，字段改名或形状变化时此测试会失败，
+#      防止模型升级后统计静默归零
+def test_consumes_lm_usage_event_serialization() -> None:
+    ev = LlmUsageEvent(
+        run_id="r1",
+        input_tokens=42,
+        output_tokens=7,
+        cache_read_input_tokens=3,
+        cache_creation_input_tokens=1,
+        context_pct=0.5,
+        model="test-model",
+        ts="t1",
+    )
+    usage = summarize_token_usage([ev.model_dump()])
+    assert usage.input_tokens == 42
+    assert usage.output_tokens == 7
+    assert usage.cache_read_input_tokens == 3
+    assert usage.cache_creation_input_tokens == 1


### PR DESCRIPTION
## Summary
SWE-bench 适配器原从 `event["usage"]` 子对象读取 token，但 `LlmUsageEvent` 的
`input_tokens`/`output_tokens`/`cache_*` 字段位于事件顶层，导致 `preds_detail.jsonl`
中 token 统计恒为 0。提取 `summarize_token_usage()` 纯函数从顶层汇总。

Fixes #32

## Behavior
- llm.usage 事件顶层字段正确累计输入/输出/缓存 token
- 缺失或 None 字段按 0 处理，非 usage 事件不影响统计
- `_detail.jsonl` 新增 cache token 字段

## Validation
uv run pytest tests/unit/test_swebench_adapter.py -v        # 6 passed
uv run ruff check eval/swebench/adapter.py tests/unit/test_swebench_adapter.py  # 通过

## Risk
低。仅改 usage 事件解析路径；无协议、权限变化；顺带修复 adapter.py 全部历史 lint 遗留
（issue 验收要求 ruff 全绿，纯机械修复）。

## Checklist
- [x] 变更范围与关联 Issue 一致
- [x] 没有提交凭据、日志、缓存、私有源码或评测产物
- [x] 已添加与风险匹配的测试（含真实模型序列化反喂测试）
- [ ] 协议变化已重新生成 wire-protocol.md（无协议变化）
- [x] 提交包含 Signed-off-by（DCO）