### PR TITLE
feat(scripts): 新增 Markdown 本地链接检查脚本

### DIFF
--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -35,6 +35,16 @@
 - 每份详细文档顶部提供返回 `docs/README.md` 的链接。
 - 外部资料链接到官方或一手来源，避免依赖不稳定的转载。
 
+调整文档位置或链接后，运行本地链接检查：
+
+```bash
+uv run python scripts/check_markdown_links.py
+```
+
+该脚本检查根目录 Markdown 与 `docs/**/*.md` 中的相对链接是否指向存在的路径，发现坏链时按
+`文档路径:行号 -> 目标` 输出全部问题并以非零状态退出。它不访问网络，因此不校验外部站点是否在线，
+也不校验标题锚点是否存在；外部 URL、邮箱、纯锚点、图片和围栏代码块中的示例链接都会跳过。
+
 ## 自动生成文档
 
 `docs/reference/wire-protocol.md` 由 `scripts/gen_protocol_doc.py` 生成，不手工编辑：

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -60,6 +60,16 @@ uv run python scripts/gen_protocol_doc.py --check
 
 第一条重新生成 `docs/reference/wire-protocol.md`，第二条验证生成结果与模型一致。协议变更必须提交生成文件。
 
+## 文档链接
+
+```bash
+uv run python scripts/check_markdown_links.py
+uv run pytest tests/unit/test_markdown_links.py -v
+```
+
+第一条检查根目录 Markdown 与 `docs/**/*.md` 的本地相对链接是否有效，第二条覆盖解析与退出行为。
+移动或重命名文档后应运行，规则见[文档规范](documentation.md)。
+
 ## 桌面端
 
 ```bash

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Check that local relative links in the repository Markdown files resolve to existing paths."""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import unquote
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+# 引用式链接定义，例如 `[index]: docs/README.md`
+_REFERENCE_DEFINITION = re.compile(r"^ {0,3}\[[^\]]+\]:\s*(\S+)")
+
+# URI scheme 前缀，例如 `http:` / `https:` / `mailto:`
+_URI_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+
+# 围栏代码块的起止行，捕获围栏字符及长度
+_FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+
+
+class BrokenLink(NamedTuple):
+    doc: Path
+    line: int
+    target: str
+
+
+# 收集待检查的 Markdown：根目录文档与 docs/ 下的全部文档
+def iter_markdown_files(root: Path) -> list[Path]:
+    return sorted(root.glob("*.md")) + sorted(root.glob("docs/**/*.md"))
+
+
+# 逐行产出围栏代码块之外的内容，避免把代码示例中的链接当成文档链接
+def iter_content_lines(lines: Iterable[str]) -> Iterator[tuple[int, str]]:
+    fence: str | None = None
+    for lineno, line in enumerate(lines, 1):
+        match = _FENCE.match(line)
+        if fence is None:
+            if match:
+                fence = match.group(1)
+            else:
+                yield lineno, line
+            continue
+        # 闭合围栏必须同字符且不短于开栏，避免 ```` 内嵌的 ``` 提前结束代码块
+        if match and match.group(1)[0] == fence[0] and len(match.group(1)) >= len(fence):
+            fence = None
+
+
+# 从 `](` 的 `]` 处向左回溯配对的 `[`，返回其下标，找不到时返回 -1
+def _find_label_start(line: str, close_bracket: int) -> int:
+    depth = 0
+    for index in range(close_bracket, -1, -1):
+        char = line[index]
+        if char == "]":
+            depth += 1
+        elif char == "[":
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+# 解析 `](` 之后的链接目标，支持 <...> 包裹、可选标题和目标中的嵌套括号
+def _parse_destination(line: str, open_paren: int) -> str:
+    index = open_paren + 1
+    length = len(line)
+    while index < length and line[index] in " \t":
+        index += 1
+    if index >= length:
+        return ""
+    if line[index] == "<":
+        end = line.find(">", index + 1)
+        return "" if end == -1 else line[index + 1 : end].strip()
+
+    start = index
+    depth = 1
+    while index < length:
+        char = line[index]
+        if char in " \t":
+            break
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        index += 1
+    return line[start:index]
+
+
+# 提取一行中的链接目标，跳过图片语法并兼容引用式定义
+def extract_link_targets(line: str) -> list[str]:
+    targets: list[str] = []
+
+    reference = _REFERENCE_DEFINITION.match(line)
+    if reference:
+        definition = reference.group(1)
+        if definition.startswith("<") and definition.endswith(">"):
+            definition = definition[1:-1]
+        targets.append(definition)
+
+    search_from = 0
+    while True:
+        close_bracket = line.find("](", search_from)
+        if close_bracket == -1:
+            break
+        search_from = close_bracket + 1
+
+        label_start = _find_label_start(line, close_bracket)
+        if label_start == -1:
+            continue
+        # `![alt](src)` 是图片，按 issue 要求不校验；外层 `[![alt](src)](target)` 仍会命中 target
+        if label_start > 0 and line[label_start - 1] == "!":
+            continue
+
+        destination = _parse_destination(line, close_bracket + 1)
+        if destination:
+            targets.append(destination)
+    return targets
+
+
+# 判断链接目标是否是需要校验的仓库内路径，排除外链、邮箱和纯锚点
+def is_local_target(target: str) -> bool:
+    if not target or target.startswith(("#", "//", "?")):
+        return False
+    return not _URI_SCHEME.match(target)
+
+
+# 把链接目标解析为文件系统路径：截断 fragment 与 query，并解码 %20 等转义
+def resolve_target(doc: Path, target: str, root: Path) -> Path | None:
+    path_part = target.split("#", 1)[0].split("?", 1)[0]
+    if not path_part:
+        return None
+    decoded = unquote(path_part)
+    # 以 `/` 开头的目标按仓库根解析，与常见 Markdown 渲染器行为一致
+    if decoded.startswith("/"):
+        return root / decoded.lstrip("/")
+    return doc.parent / decoded
+
+
+# 检查单个文档，返回其中所有指向不存在路径的本地链接
+def check_file(doc: Path, root: Path) -> list[BrokenLink]:
+    broken: list[BrokenLink] = []
+    lines = doc.read_text(encoding="utf-8").splitlines()
+    for lineno, line in iter_content_lines(lines):
+        for target in extract_link_targets(line):
+            if not is_local_target(target):
+                continue
+            resolved = resolve_target(doc, target, root)
+            if resolved is None or resolved.exists():
+                continue
+            broken.append(BrokenLink(doc, lineno, target))
+    return broken
+
+
+# 检查仓库范围内的全部 Markdown，按文件和行号顺序一次性返回所有坏链
+def check_repository(root: Path) -> list[BrokenLink]:
+    broken: list[BrokenLink] = []
+    for doc in iter_markdown_files(root):
+        broken.extend(check_file(doc, root))
+    return broken
+
+
+# 解析命令行参数，报告全部坏链并返回进程退出码
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check local Markdown links")
+    parser.add_argument("--root", default=str(_REPO_ROOT), help="Repository root to scan")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    documents = iter_markdown_files(root)
+    broken = check_repository(root)
+
+    if broken:
+        for link in broken:
+            try:
+                location: Path = link.doc.relative_to(root)
+            except ValueError:
+                location = link.doc
+            print(f"{location}:{link.line} -> {link.target}", file=sys.stderr)
+        print(
+            f"ERROR: 共检查 {len(documents)} 个文件，发现 {len(broken)} 条坏链。",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: 共检查 {len(documents)} 个文件，未发现坏链。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_markdown_links.py
+++ b/tests/unit/test_markdown_links.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check_markdown_links.py"
+
+
+# 用文件路径加载脚本模块：scripts/ 不是包，无法按模块名导入
+def _load_checker() -> object:
+    spec = importlib.util.spec_from_file_location("check_markdown_links", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+# 在临时目录写入一个 Markdown 文件，自动创建父目录
+def _write(root: Path, relative: str, content: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# 功能：验证指向存在文件的相对链接不报错，指向缺失文件的相对链接被报出
+# 设计：同一文档内并列一条好链和一条坏链，确认检查器逐链判断而非按文件粗粒度放过或全否
+def test_existing_and_missing_relative_links(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/target.md", "# 目标\n")
+    doc = _write(tmp_path, "README.md", "[好](docs/target.md)\n[坏](docs/missing.md)\n")
+
+    broken = checker.check_file(doc, tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.line, link.target) for link in broken] == [(2, "docs/missing.md")]
+
+
+# 功能：验证 `../` 上跨目录链接与目录链接都按当前文档所在目录正确解析
+# 设计：让深层文档回指根目录文件和一个目录，覆盖"目标不是普通文件"的分支，防止实现只用 is_file() 判断
+def test_parent_directory_and_directory_links(tmp_path: Path) -> None:
+    _write(tmp_path, "README.md", "# 根\n")
+    (tmp_path / "docs" / "getting-started").mkdir(parents=True)
+    doc = _write(
+        tmp_path,
+        "docs/development/development.md",
+        "[根](../../README.md)\n[目录](../getting-started/)\n[越界](../../nope.md)\n",
+    )
+
+    broken = checker.check_file(doc, tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.line, link.target) for link in broken] == [(3, "../../nope.md")]
+
+
+# 功能：验证 URL 编码的空格能解码后命中真实文件，未解码时的字面路径不会被误判为存在
+# 设计：文件名真实含空格，链接写 %20，若实现漏掉 unquote 就会报坏链，这是最小可暴露该缺陷的用例
+def test_url_encoded_space_is_decoded(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/my note.md", "# note\n")
+    doc = _write(tmp_path, "README.md", "[编码](docs/my%20note.md)\n[未存在](docs/other%20note.md)\n")
+
+    broken = checker.check_file(doc, tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.line, link.target) for link in broken] == [(2, "docs/other%20note.md")]
+
+
+# 功能：验证带 #fragment 的本地路径只校验 fragment 前的文件路径，纯锚点链接完全跳过
+# 设计：好链带 fragment、坏链也带 fragment，确认报错时输出保留原始目标（含 fragment）而不是截断后的路径
+def test_fragment_handling(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/guide.md", "# 指南\n")
+    doc = _write(
+        tmp_path,
+        "README.md",
+        "[章节](docs/guide.md#安装)\n[本页](#顶部)\n[缺失](docs/gone.md#节)\n",
+    )
+
+    broken = checker.check_file(doc, tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.line, link.target) for link in broken] == [(3, "docs/gone.md#节")]
+
+
+# 功能：验证外部 URL、邮箱和协议相对链接不参与文件存在性校验
+# 设计：这些目标在本地文件系统必然不存在，若实现漏过滤就会全部报错，因此一次断言 broken 为空即可覆盖
+def test_external_targets_are_skipped(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "README.md",
+        "[站点](https://example.com/a.md)\n"
+        "[明文](http://example.com/b.md)\n"
+        "[邮箱](mailto:dev@example.com)\n"
+        "[CDN](//cdn.example.com/c.md)\n",
+    )
+
+    assert checker.check_file(doc, tmp_path) == []  # type: ignore[attr-defined]
+
+
+# 功能：验证围栏代码块中的示例链接不报错，且围栏结束后恢复检查
+# 设计：用 ``` 与 ~~~ 两种围栏，并在 ```` 内嵌 ``` 验证闭合需同字符且不短于开栏；末尾放真坏链确认状态机正确退出而非吞掉后续内容
+def test_fenced_code_blocks_are_skipped(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "README.md",
+        "```\n[示例](nope.md)\n```\n"
+        "~~~markdown\n- [title](url)\n~~~\n"
+        "````\n```\n[内嵌](also-nope.md)\n```\n````\n"
+        "[真坏链](really-missing.md)\n",
+    )
+
+    broken = checker.check_file(doc, tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.line, link.target) for link in broken] == [(12, "really-missing.md")]
+
+
+# 功能：验证图片链接被跳过，但包裹图片的外层链接目标仍会校验
+# 设计：直接复刻 README 的 badge 语法 `[![alt](url)](target)`，锁住嵌套方括号的解析，朴素正则实现会在此失败
+def test_image_links_skipped_but_wrapping_link_checked(tmp_path: Path) -> None:
+    doc = _write(
+        tmp_path,
+        "README.md",
+        "![缺图](docs/images/missing.png)\n"
+        "[![License](https://img.shields.io/badge/x)](LICENSE)\n",
+    )
+
+    broken = checker.check_file(doc, tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.line, link.target) for link in broken] == [(2, "LICENSE")]
+
+
+# 功能：验证跨多个文件的多条坏链会一次性全部报告
+# 设计：两个文件各含两条坏链，断言四条齐全且按文件与行号有序，排除"发现首条即短路返回"的实现
+def test_all_broken_links_reported_together(tmp_path: Path) -> None:
+    _write(tmp_path, "README.md", "[a](a.md)\n[b](b.md)\n")
+    _write(tmp_path, "docs/index.md", "[c](c.md)\n[d](d.md)\n")
+
+    broken = checker.check_repository(tmp_path)  # type: ignore[attr-defined]
+
+    assert [(link.doc.name, link.line, link.target) for link in broken] == [
+        ("README.md", 1, "a.md"),
+        ("README.md", 2, "b.md"),
+        ("index.md", 1, "c.md"),
+        ("index.md", 2, "d.md"),
+    ]
+
+
+# 功能：验证无坏链时 main 返回 0
+# 设计：走完整 CLI 入口而非直接调 check_repository，覆盖参数解析与返回码约定；main 返回 int 而非 sys.exit，便于直接断言
+def test_main_returns_zero_when_clean(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(tmp_path, "docs/target.md", "# 目标\n")
+    _write(tmp_path, "README.md", "[好](docs/target.md)\n")
+
+    code = checker.main(["--root", str(tmp_path)])  # type: ignore[attr-defined]
+
+    assert code == 0
+    assert "未发现坏链" in capsys.readouterr().out
+
+
+# 功能：验证发现坏链时 main 返回 1，且输出包含源文件、行号和原始目标三要素
+# 设计：断言 stderr 中的 `路径:行号 -> 目标` 格式而非仅断言返回码，坏链定位信息是该脚本的核心产出
+def test_main_reports_and_exits_nonzero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write(tmp_path, "docs/guide.md", "占位\n[缺失](../missing.md)\n")
+
+    code = checker.main(["--root", str(tmp_path)])  # type: ignore[attr-defined]
+
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "docs/guide.md:2 -> ../missing.md" in err
+
+
+# 功能：验证本仓库当前的 Markdown 文档全部通过检查
+# 设计：作为回归防线，让后续文档移动引入的坏链直接在单元测试阶段暴露，而不必等到有人手工点击链接
+def test_repository_documents_have_no_broken_links() -> None:
+    documents = checker.iter_markdown_files(_REPO_ROOT)  # type: ignore[attr-defined]
+    broken = checker.check_repository(_REPO_ROOT)  # type: ignore[attr-defined]
+
+    assert documents, "未扫描到任何 Markdown 文件，扫描范围可能失效"
+    assert broken == [], "\n".join(f"{link.doc}:{link.line} -> {link.target}" for link in broken)


### PR DESCRIPTION
## Summary

- 新增 `scripts/check_markdown_links.py`：检查根目录 Markdown 与 `docs/**/*.md` 中的本地相对链接是否指向存在的路径。纯标准库实现，不访问网络。
- 链接提取按 `](` 向左回溯配对 `[` 并计括号深度，而非朴素正则 —— 后者在 README 的 `[![alt](url)](target)` badge 语法上会解析错误。
- 跳过围栏代码块是必需的而非防御性设计：`docs/tool-system.md:475` 与 `docs/archive/claw-code-tool-system.md:478` 的 `- [title](url)` 示例否则会误报。
- 新增 `tests/unit/test_markdown_links.py`：11 个用例覆盖解析与退出行为，末条以真实仓库作回归防线。
- 在 `docs/development/documentation.md` 与 `docs/development/testing.md` 写入运行命令。

Closes #26

## Behavior

- 坏链按 `文档路径:行号 -> 目标` 逐条输出到 stderr，一次性报告全部问题，并以退出码 1 结束；无坏链时 stdout 打印检查文件数，退出码 0。
- 跳过：`http(s)://`、`mailto:`、协议相对 `//`、纯锚点 `#`、图片 `![]()`、围栏代码块内的示例。
- `#fragment` 只校验其前的文件路径；`%20` 等 URL 转义会解码；目录链接与非 Markdown 目标（如 `reference/system-prompts.html`）均可校验通过。
- 非目标（与 Issue 一致）：不校验外部站点是否在线，不校验标题锚点是否存在。
- 未改动 `Makefile` 与 `verify-s0`，按 Issue 字面范围只提供可手工运行的命令。

## Validation

```text
uv run pytest tests/unit/test_markdown_links.py -v
  → 11 passed

uv run python scripts/check_markdown_links.py
  → OK: 共检查 39 个文件，未发现坏链。（exit 0）

uv run ruff check scripts/check_markdown_links.py tests/unit/test_markdown_links.py
  → All checks passed!

uv run mypy src
  → Success: no issues found in 169 source files

uv run pytest tests/unit -q
  → 682 passed, 1 failed
```

负向验证：临时写入一个含坏链的文档，脚本正确输出 `_tmp_badlink.md:3 -> docs/definitely-missing.md` 并以 exit 1 结束，删除后恢复 exit 0。

**仓库当前 0 条坏链**，故本 PR 不含文档修复改动，验收项"若发现真实坏链则同一 PR 最小修复"自然满足。

### 两个既有失败，与本 PR 无关

1. `tests/unit/test_openai_provider.py::test_missing_api_key_raises_system_exit`
   该用例只清除 `OPENAI_API_KEY`，但 `openai_provider.py:226` 要求 `api_key` 与 `base_url` 同时为空才 `SystemExit`。本机 `.env` 设置了 `OPENAI_BASE_URL`，因此失败。
   `env -u OPENAI_BASE_URL -u OPENAI_API_KEY uv run pytest ...::test_missing_api_key_raises_system_exit` → passed。属用例对本地 LLM 环境变量敏感。
2. `uv run ruff check src tests scripts` 报 `src/sztu_code/core/workflow/orchestrator.py:9` 的 `ValidationError` 未使用（F401）。该文件本 PR 未改动。

两项都不在本 Issue 范围，未顺带修改以免混入无关改动；如需处理可另开 Issue。

## Risk

低。新增独立脚本，不被 `src/` 任何模块导入，不改变运行时行为、协议或配置。文档改动仅新增运行命令小节。

解析器是轻量实现而非完整 Markdown 解析器（Issue 明确不要求）：不处理跨行链接语法，仓库现有文档无此写法。回滚只需还原本 PR 的四个文件。

## UI evidence

N/A（无 TUI 或桌面端视觉变化）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A，未改动 `core/bus/` 协议模型）
- [x] 用户文档、配置示例和迁移说明已同步。
- [x] 提交包含 `Signed-off-by`（DCO）。
