### PR TITLE
fix(desktop): 修复右侧功能区全屏功能展开异常

### DIFF
--- a/desktop/src/components/Inspector/ProjectInspector.vue
+++ b/desktop/src/components/Inspector/ProjectInspector.vue
@@ -325,6 +325,7 @@ function closeToolMenuOnEscape(event: KeyboardEvent) {
   if (event.key === "Escape") {
     toolMenuOpen.value = false;
     closePreview();
+    if (expandedPanel.value) expandedPanel.value = false; // 全屏态按 Esc 退出全屏
   }
 }
 
@@ -384,7 +385,7 @@ onBeforeUnmount(() => {
       </nav>
       <button type="button" class="workspace-browser-add" aria-label="新建浏览器标签页" @click="createBrowserTab"><Plus :size="16" /></button>
       <span class="workspace-header-divider" />
-      <button type="button" class="workspace-expand" :aria-label="expandedPanel ? '还原功能区' : '展开功能区'" @click="expandedPanel = !expandedPanel"><Minimize2 v-if="expandedPanel" :size="15" /><Maximize2 v-else :size="15" /></button>
+      <button type="button" class="workspace-expand" :aria-label="expandedPanel ? '退出全屏' : '全屏'" @click="expandedPanel = !expandedPanel"><Minimize2 v-if="expandedPanel" :size="15" /><Maximize2 v-else :size="15" /></button>
       <button type="button" class="workspace-panel-close" aria-label="退出分屏布局" @click="emit('close')"><PanelRightClose :size="16" /></button>
     </header>
 

--- a/desktop/src/file-rail.css
+++ b/desktop/src/file-rail.css
@@ -15,7 +15,14 @@
   border-radius: 10px;
   box-shadow: 0 2px 8px rgb(27 35 31 / 4%);
 }
-.project-inspector.file-rail.is-expanded { position: fixed; z-index: 210; inset: 7px 7px 7px 276px; width: auto; max-height: none; margin: 0; box-shadow: 0 12px 40px rgb(27 35 31 / 14%); }
+/* 展开态进入真正全屏：功能区独占整个窗口（无边框/圆角/阴影），其余窗口功能全部隐藏，而非用层级遮挡 */
+.project-inspector.file-rail.is-expanded { position: fixed; inset: 0; z-index: 210; width: auto; max-height: none; margin: 0; border: 0; border-radius: 0; box-shadow: none; }
+/* 全屏时隐藏标题栏、导航、会话区与分隔条，让功能区独占窗口 */
+.kimi-shell:has(.project-inspector.file-rail.is-expanded) .kimi-titlebar,
+.kimi-shell:has(.project-inspector.file-rail.is-expanded) .sidebar-viewport,
+.kimi-shell:has(.project-inspector.file-rail.is-expanded) .sidebar-resizer,
+.kimi-shell:has(.project-inspector.file-rail.is-expanded) .task-canvas,
+.kimi-shell:has(.project-inspector.file-rail.is-expanded) .layout-divider { display: none; }
 
 .workspace-tab-strip {
   position: relative;

--- a/desktop/tests/visual/workbench.spec.ts
+++ b/desktop/tests/visual/workbench.spec.ts
@@ -378,3 +378,54 @@ test("settings remains available from the workbench footer", async ({ page }) =>
   await expect(page.getByRole("heading", { name: "设置" })).toBeVisible();
   await expect(page.getByText("系统设置")).toBeVisible();
 });
+
+// 功能：验证右侧功能区"全屏"是真正的全屏——其余窗口功能全部隐藏，功能区独占整个视口，而非浮层遮挡
+// 设计：复用 collapse 测试的 Vue 状态注入让会话区/功能区出现，点「全屏」后用 getBoundingClientRect 与 offsetParent
+// 断言面板铺满视口且标题栏/导航/会话区真的 display:none，再按 Esc 验证恢复，避免只验证类名导致语义倒退
+test("workspace panel fullscreen hides all other windows and fills the viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.locator("#app").evaluate((root) => {
+    const app = (root as HTMLElement & { __vue_app__?: { _instance?: { setupState?: Record<string, unknown> } } }).__vue_app__;
+    const state = app?._instance?.setupState;
+    if (!state) throw new Error("Vue application state is unavailable");
+    state.workspace = { workspace_id: "workspace-fixture", name: "Fixture", path: "F:/fixture", archived: false };
+    state.sessions = [{ session_id: "session-fixture", title: "Fixture task", status: "active", updated_at: "", archived: false, pinned: false, workspace_id: "workspace-fixture" }];
+    state.activeId = "session-fixture";
+  });
+
+  const inspector = page.locator(".project-inspector");
+  const expandButton = page.getByRole("button", { name: "全屏", exact: true });
+  await expect(expandButton).toBeVisible();
+  await expandButton.click();
+  await expect(inspector).toHaveClass(/is-expanded/);
+
+  const geometry = await page.evaluate(() => {
+    const panel = document.querySelector<HTMLElement>(".project-inspector.is-expanded")!;
+    const rect = panel.getBoundingClientRect();
+    return {
+      panel: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      titlebarGone: !document.querySelector<HTMLElement>(".kimi-titlebar")?.offsetParent,
+      sidebarGone: !document.querySelector<HTMLElement>(".sidebar-viewport")?.offsetParent,
+      canvasGone: !document.querySelector<HTMLElement>(".task-canvas")?.offsetParent,
+      dividerGone: !document.querySelector<HTMLElement>(".layout-divider")?.offsetParent,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+    };
+  });
+
+  expect(geometry.panel.x).toBe(0);
+  expect(geometry.panel.y).toBe(0);
+  expect(geometry.panel.width).toBeCloseTo(geometry.viewport.width, 0);
+  expect(geometry.panel.height).toBeCloseTo(geometry.viewport.height, 0);
+  expect(geometry.titlebarGone).toBe(true);
+  expect(geometry.sidebarGone).toBe(true);
+  expect(geometry.canvasGone).toBe(true);
+  expect(geometry.dividerGone).toBe(true);
+
+  // Esc 退出全屏：其余窗口功能恢复
+  await page.keyboard.press("Escape");
+  await expect(inspector).not.toHaveClass(/is-expanded/);
+  await expect(page.locator(".kimi-titlebar")).toBeVisible();
+  await expect(page.locator(".sidebar-viewport")).toBeVisible();
+  await expect(page.locator(".task-canvas")).toBeVisible();
+});


### PR DESCRIPTION
## 背景

右侧功能区（ProjectInspector）的「全屏」按钮之前实现为**高 z-index 浮层遮挡**：面板浮在其它窗口之上，但标题栏、导航、会话区仍在背后；且浮层位置写死（`inset: 7px 7px 7px 276px`），与标题栏/侧栏宽度不匹配——会盖住标题栏、侧栏收起时左侧残留空白、侧栏加宽时盖住侧栏。

## 改动

改为**真正的全屏**：其余窗口功能全部隐藏，功能区独占整个窗口。

- `desktop/src/file-rail.css`：展开态 `position: fixed; inset: 0`，无边框/圆角/阴影；用 `kimi-shell:has(.project-inspector.is-expanded)` 把标题栏、导航、会话区、分隔条 `display: none` 真正隐藏（而非遮挡）。
- `desktop/src/components/Inspector/ProjectInspector.vue`：全屏态按 `Esc` 退出全屏；按钮文案改为「全屏 / 退出全屏」。
- `desktop/tests/visual/workbench.spec.ts`：新增回归测试。

## 验证

新增回归测试通过：面板 boundingBox 恰好等于视口 `(0,0,W,H)`；标题栏/导航/会话区/分隔条 `offsetParent` 为 null（确认 `display:none` 而非遮挡）；按 `Esc` 后全部恢复。

> 注：`tests/visual/workbench.spec.ts` 另有 4 个既有用例（collapses smoothly / keyboard shortcut / slash menu / 952px boundary）在本机因截图基线漂移失败，与本次改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
