### PR TITLE
fix: 隔离 SWE-bench 适配器的运行事件

### DIFF
--- a/docs/superpowers/plans/2026-08-08-swebench-event-scope.md
+++ b/docs/superpowers/plans/2026-08-08-swebench-event-scope.md
@@ -242,7 +242,7 @@ python -m uv run --offline mypy eval/swebench/adapter.py
 git diff --check
 ```
 
-Expected: adapter changes introduce no new failures; any pre-existing unrelated failure is recorded explicitly. Mypy and diff checks exit with code 0.
+Expected: full unit tests report only the known unrelated Windows path-separator assertion; compare Mypy output with the unchanged `upstream/main` adapter and ensure no new errors are introduced. `git diff --check` exits with code 0.
 
 - [ ] **Step 2: 检查变更范围和工作树**
 

--- a/docs/superpowers/plans/2026-08-08-swebench-event-scope.md
+++ b/docs/superpowers/plans/2026-08-08-swebench-event-scope.md
@@ -1,0 +1,268 @@
+# SWE-bench 运行事件隔离 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 SWE-bench 适配器只消费当前 RPC run 的事件，避免其他 run 的完成事件、日志和 token 统计污染当前结果。
+
+**Architecture:** 在 `eval/swebench/adapter.py` 中提取私有 `_RunEventCollector`，先缓存尚未绑定 run ID 的事件，绑定后按 run ID 接受事件；只有匹配的 `run.finished` 更新最终状态并唤醒等待。`run_instance_via_rpc` 使用 collector 的过滤结果，并显式注册事件回调，不改变 SocketClient 或事件协议。
+
+**Tech Stack:** Python 3.11+, `asyncio.Event`, `dataclasses`, pytest, Ruff。
+
+---
+
+### Task 1: 添加事件隔离的失败测试
+
+**Files:**
+- Modify: `tests/unit/test_swebench_adapter.py`，在现有适配器测试导入和 token 测试附近增加 collector 行为测试
+
+- [ ] **Step 1: 导入适配器模块而不依赖尚不存在的类**
+
+在现有 `from eval.swebench.adapter import (...)` 导入旁增加：
+
+```python
+from eval.swebench import adapter as swebench_adapter  # noqa: E402
+```
+
+测试通过模块属性访问 `_RunEventCollector`，这样 RED 阶段可以完成收集并因缺少行为失败，而不是因导入语法错误失败。
+
+- [ ] **Step 2: 写交错事件过滤和 token 统计测试**
+
+```python
+def test_run_event_collector_filters_interleaved_events() -> None:
+    collector = swebench_adapter._RunEventCollector()
+    collector.record({"type": "run.finished", "run_id": "other", "status": "success", "steps": 99})
+    collector.record({"type": "step.started", "run_id": "current", "step": 1})
+    collector.record({"type": "llm.usage", "run_id": "other", "input_tokens": 900})
+    collector.record({"type": "tool.call_started", "run_id": "current", "tool_name": "bash"})
+    collector.record({"type": "llm.usage", "run_id": "current", "input_tokens": 12, "output_tokens": 3})
+
+    collector.set_run_id("current")
+    assert not collector.finished.is_set()
+
+    collector.record({"type": "run.finished", "run_id": "other", "status": "failure", "steps": 100})
+    assert not collector.finished.is_set()
+
+    collector.record({"type": "run.finished", "run_id": "current", "status": "success", "steps": 2})
+
+    assert collector.finished.is_set()
+    assert collector.finished_event == {
+        "type": "run.finished", "run_id": "current", "status": "success", "steps": 2,
+    }
+    assert [event["run_id"] for event in collector.events] == ["current"] * 4
+    usage = summarize_token_usage(collector.events)
+    assert usage.input_tokens == 12
+    assert usage.output_tokens == 3
+```
+
+- [ ] **Step 3: 写绑定前完成事件的竞态测试**
+
+```python
+def test_run_event_collector_replays_current_finished_event_after_binding() -> None:
+    collector = swebench_adapter._RunEventCollector()
+    current_finished = {"type": "run.finished", "run_id": "current", "status": "failure", "steps": 4}
+    collector.record(current_finished)
+    collector.record({"type": "run.finished", "run_id": "other", "status": "success", "steps": 8})
+
+    assert not collector.finished.is_set()
+    collector.set_run_id("current")
+
+    assert collector.finished.is_set()
+    assert collector.finished_event == current_finished
+    assert collector.events == [current_finished]
+```
+
+- [ ] **Step 4: 覆盖四种终止状态和无 run ID 事件**
+
+```python
+@pytest.mark.parametrize("status", ["success", "failure", "cancelled", "max_steps"])
+def test_run_event_collector_accepts_all_terminal_statuses(status: str) -> None:
+    collector = swebench_adapter._RunEventCollector()
+    collector.set_run_id("current")
+
+    collector.record({"type": "run.finished", "run_id": "other", "status": status, "steps": 8})
+    assert not collector.finished.is_set()
+
+    collector.record({"type": "run.finished", "run_id": "current", "status": status, "steps": 3})
+
+    assert collector.finished.is_set()
+    assert collector.finished_event["status"] == status
+    assert collector.finished_event["steps"] == 3
+
+
+def test_run_event_collector_ignores_events_without_run_id() -> None:
+    collector = swebench_adapter._RunEventCollector()
+    collector.set_run_id("current")
+
+    collector.record({"type": "run.finished", "status": "success", "steps": 1})
+    collector.record({"type": "llm.usage", "input_tokens": 50})
+
+    assert collector.events == []
+    assert not collector.finished.is_set()
+```
+
+- [ ] **Step 5: 运行 RED 测试并确认失败原因是缺少 collector**
+
+Run:
+
+```text
+python -m uv run --offline pytest tests/unit/test_swebench_adapter.py -k run_event_collector -v
+```
+
+Expected: collection succeeds, then the new tests fail with `AttributeError: module ... has no attribute '_RunEventCollector'`. No daemon, model, or network is started.
+
+### Task 2: 实现最小的 `_RunEventCollector`
+
+**Files:**
+- Modify: `eval/swebench/adapter.py`，在 `TokenUsage` 定义后增加私有 collector
+
+- [ ] **Step 1: 添加 collector 状态和过滤方法**
+
+```python
+@dataclass
+class _RunEventCollector:
+    run_id: str | None = None
+    events: list[dict[str, Any]] = field(default_factory=list)
+    finished_event: dict[str, Any] | None = None
+    finished: asyncio.Event = field(default_factory=asyncio.Event)
+    _pending_events: list[dict[str, Any]] = field(default_factory=list)
+
+    def record(self, event: dict[str, Any]) -> None:
+        event_run_id = str(event.get("run_id", ""))
+        if not event_run_id:
+            return
+        if self.run_id is None:
+            self._pending_events.append(event)
+            return
+        self._accept(event, event_run_id)
+
+    def set_run_id(self, run_id: str) -> None:
+        normalized_run_id = str(run_id)
+        if not normalized_run_id:
+            raise ValueError("run_id must be non-empty")
+        self.run_id = normalized_run_id
+        pending_events, self._pending_events = self._pending_events, []
+        for event in pending_events:
+            self._accept(event, str(event.get("run_id", "")))
+
+    def _accept(self, event: dict[str, Any], event_run_id: str) -> None:
+        if event_run_id != self.run_id:
+            return
+        self.events.append(event)
+        if event.get("type") == "run.finished":
+            self.finished_event = event
+            self.finished.set()
+```
+
+- [ ] **Step 2: 运行 RED 测试确认最小实现方向**
+
+Run:
+
+```text
+python -m uv run --offline pytest tests/unit/test_swebench_adapter.py -k run_event_collector -v
+```
+
+Expected: all collector tests pass.
+
+### Task 3: 将 collector 接入 RPC 适配器
+
+**Files:**
+- Modify: `eval/swebench/adapter.py:205-300`，替换临时事件状态并绑定当前 run
+
+- [ ] **Step 1: 用 collector 替换三个局部状态**
+
+将 `collected_events`、`run_finished`、`run_status` 替换为：
+
+```python
+    collector = _RunEventCollector()
+
+    async def on_event(event: dict[str, Any]) -> None:
+        collector.record(event)
+        event_type = event.get("type", "")
+        if collector.run_id != str(event.get("run_id", "")):
+            return
+```
+
+保留已有 step/tool 日志分支，但只对 collector 当前 run 的事件执行。连接成功后、创建 `loop_task` 前注册：
+
+```python
+    client.on_event(on_event)
+```
+
+- [ ] **Step 2: 绑定 RPC 返回的 run ID 并使用过滤结果**
+
+将发送消息后的等待和结果提取改为：
+
+```python
+        run_id = str(send_result.get("run_id", ""))
+        collector.set_run_id(run_id)
+        logger.info(f"  Run started: {run_id}")
+
+        try:
+            await asyncio.wait_for(collector.finished.wait(), timeout=timeout)
+        except TimeoutError:
+            result.error = f"Timeout after {timeout}s"
+            try:
+                await client.send_command("run.cancel", {"run_id": run_id})
+            except Exception:
+                pass
+
+        finished_event = collector.finished_event or {}
+        result.status = finished_event.get("status", "")
+        result.steps = finished_event.get("steps", 0)
+        result.events_log = collector.events
+
+        usage = summarize_token_usage(collector.events)
+```
+
+保留现有 diff 条件，但改为检查 `result.status`。这样其他 run 的完成事件不能提前唤醒，当前 run 在 `set_run_id` 前完成时会由 collector 立即设置等待事件。
+
+- [ ] **Step 3: 运行专项测试和静态检查**
+
+Run:
+
+```text
+python -m uv run --offline pytest tests/unit/test_swebench_adapter.py -v
+python -m uv run --offline ruff check eval/swebench/adapter.py tests/unit/test_swebench_adapter.py
+```
+
+Expected: the adapter unit test file passes and Ruff exits with code 0.
+
+### Task 4: 全量验证并准备提交
+
+**Files:**
+- Modify: no additional files
+
+- [ ] **Step 1: 运行完整单元测试和类型/差异检查**
+
+Run:
+
+```text
+python -m uv run --offline pytest tests/unit -q
+python -m uv run --offline mypy eval/swebench/adapter.py
+git diff --check
+```
+
+Expected: adapter changes introduce no new failures; any pre-existing unrelated failure is recorded explicitly. Mypy and diff checks exit with code 0.
+
+- [ ] **Step 2: 检查变更范围和工作树**
+
+Run:
+
+```text
+git status --short
+git diff --stat upstream/main...HEAD
+git diff -- eval/swebench/adapter.py tests/unit/test_swebench_adapter.py
+```
+
+Expected: only the adapter, its unit tests, and the two process documents are changed; no generated cache or unrelated source changes appear.
+
+- [ ] **Step 3: 提交实现**
+
+Run:
+
+```text
+git add eval/swebench/adapter.py tests/unit/test_swebench_adapter.py
+git commit -s -m "fix: 隔离 SWE-bench 运行事件"
+```
+
+Expected: commit contains the implementation and regression tests with a `Signed-off-by` trailer.

--- a/docs/superpowers/specs/2026-08-08-swebench-event-scope-design.md
+++ b/docs/superpowers/specs/2026-08-08-swebench-event-scope-design.md
@@ -1,0 +1,99 @@
+# SWE-bench 运行事件隔离设计
+
+## 背景
+
+SWE-bench 适配器通过全局事件订阅等待 daemon 的一次 `session.send_message` 运行完成。全局订阅可能同时收到其他运行的事件。当前 `run_instance_via_rpc` 在回调中无条件收集事件，并把任意 `run.finished` 当作当前任务的结束信号，因此其他运行可能污染 `events_log`、token 统计和状态，甚至提前结束当前等待。
+
+Issue #33 要求适配器只消费当前运行的事件，同时保留现有单次运行流程和终止状态语义。
+
+## 目标与验收标准
+
+- 仅当前 `run_id` 的事件进入本次 `RunResult.events_log`。
+- 仅当前 `run_id` 的 `llm.usage` 事件参与 token 统计。
+- 其他运行的 `run.finished` 不得更新当前状态，也不得唤醒等待。
+- 当前运行的 `success`、`failure`、`cancelled`、`max_steps` 完成事件都能结束等待，并正确写入状态和步骤数。
+- 处理 `session.send_message` 返回当前 `run_id` 前已经到达的事件，不能丢失当前运行的完成事件，也不能误收集其他运行事件。
+- 测试只使用内存事件和假的异步等待，不启动 daemon、模型或网络。
+
+## 非目标
+
+- 不实现多个 SWE-bench 实例的并行调度。
+- 不修改 `SocketClient`、RPC 事件协议或 daemon 的全局订阅行为。
+- 不改变 `RunResult` 或公开命令行接口。
+- 不改变 token 字段的计算规则，只改变传入统计函数的事件集合。
+
+## 方案比较
+
+### 方案一：在现有回调中直接过滤
+
+在 `on_event` 中增加 `run_id` 判断，并额外处理当前 run ID 尚未返回的阶段。代码改动最少，但回调会同时承担缓存、过滤和完成状态管理，难以单独验证竞态，后续修改容易重新引入提前唤醒问题。
+
+### 方案二：等待完成后再过滤
+
+先收集所有事件，等待任意 `run.finished`，最后按 `run_id` 过滤。这种方式无法阻止其他运行提前结束等待，违反 issue 的核心行为，予以排除。
+
+### 方案三：提取有状态的 `_RunEventCollector`（推荐）
+
+把事件接收、运行 ID 绑定、过滤、完成状态和待处理事件缓存集中到一个轻量对象。回调只把事件交给 collector，适配器在收到 `send_message` 返回值后绑定当前 `run_id`，再从 collector 读取过滤后的事件和最终状态。对象不依赖 daemon 或网络，可用交错事件序列直接测试。
+
+推荐原因是它明确隔离了“事件到达时间”和“当前 run ID 可用时间”这两个状态，并能覆盖两者竞态，而不改变现有 RPC 流程。
+
+## 详细设计
+
+### 组件与状态
+
+在 `eval/swebench/adapter.py` 中新增私有 `_RunEventCollector`，维护：
+
+- `run_id: str | None`：尚未绑定时为 `None`。
+- `events: list[dict[str, Any]]`：只保存已确认属于当前运行的事件。
+- `finished_event: dict[str, Any] | None`：当前运行的 `run.finished`。
+- `finished: asyncio.Event`：仅由当前运行的完成事件设置。
+- 绑定前的待处理事件：用于暂存事件，绑定后一次性按 `run_id` 过滤。
+
+`record(event)` 在任何时刻都不抛出异常：
+
+1. 若事件没有 `run_id`，直接忽略，避免无法归属的全局事件污染本次结果。
+2. 若当前 `run_id` 尚未绑定，暂存事件。
+3. 若事件的 `run_id` 与当前 ID 不同，忽略。
+4. 若匹配，追加到 `events`；匹配的 `run.finished` 更新 `finished_event` 并设置 `finished`。
+
+`set_run_id(run_id)` 只允许绑定非空 ID，并重新处理之前暂存的事件。重新处理使用同一套过滤规则，因此当前完成事件即使先到达也会唤醒等待，其他运行事件仍会被丢弃。适配器在绑定后若 collector 已经完成，不需要额外等待。
+
+### 适配器集成
+
+`run_instance_via_rpc` 用 collector 替换当前的 `collected_events`、`run_finished` 和 `run_status` 回调状态：
+
+1. 创建 collector 并把 `on_event` 注册给 `SocketClient`。
+2. `session.send_message` 返回后调用 `set_run_id(send_result["run_id"])`。
+3. 等待 collector 的完成事件，超时逻辑保持不变。
+4. 从 collector 的 `finished_event` 读取 `status`、`steps` 和 `run_id`，从 `events` 填充 `events_log` 并汇总 token。
+5. 只有状态为 `success`、`max_steps` 或 `cancelled` 时继续获取 diff，保持现有行为。
+
+事件日志中的顺序仍按到达顺序保留；绑定前属于当前 run 的事件会在绑定时追加，因此不会改变事件相对顺序。
+
+### 状态与异常处理
+
+- 空的 RPC `run_id` 不被当作有效当前运行 ID；适配器保持原有结果错误处理，不会把无归属事件当作完成信号。
+- 其他运行的 `run.finished` 既不写入 `finished_event`，也不设置 `finished`。
+- 超时后仍尝试 `run.cancel`，随后只使用当前 run 已过滤的事件计算统计。
+- `failure`、`cancelled` 和 `max_steps` 是完成状态，不改变现有 diff 获取条件。
+
+## 测试设计
+
+在 `tests/unit/test_swebench_adapter.py` 增加 collector 的离线单元测试：
+
+1. 交错记录其他 run 的 `run.finished`、当前 run 的 `step.*`、`tool.*`、`llm.usage`，绑定当前 ID 后断言日志只含当前事件、token 只累计当前 usage，且其他完成事件没有设置完成事件。
+2. 在绑定当前 ID 前记录当前 run 的 `run.finished`，绑定后断言该事件被恢复、状态和步骤正确、完成事件已设置。
+3. 参数化验证当前 run 的 `success`、`failure`、`cancelled`、`max_steps` 都能设置完成状态；其他 run 的同名状态不能结束等待。
+4. 验证缺少 `run_id` 的事件被忽略，不影响日志和完成状态。
+
+测试直接实例化 collector 并调用 `record`/`set_run_id`，不创建 `SocketClient`，不访问网络或 daemon。现有 `summarize_token_usage` 测试继续保留，用过滤后的事件列表验证集成契约。
+
+## 验收命令
+
+```text
+uv run pytest tests/unit/test_swebench_adapter.py -v
+uv run ruff check eval/swebench/adapter.py tests/unit/test_swebench_adapter.py
+```
+
+实现完成后另外运行完整 `tests/unit`、类型检查和 `git diff --check`，并在创建 PR 前重新执行全部验证命令。

--- a/eval/swebench/adapter.py
+++ b/eval/swebench/adapter.py
@@ -96,6 +96,43 @@ class RunResult:
 
 
 @dataclass
+class _RunEventCollector:
+    """Scope daemon events to the run currently evaluated by the adapter."""
+
+    run_id: str | None = None
+    events: list[dict[str, Any]] = field(default_factory=list)
+    finished_event: dict[str, Any] | None = None
+    finished: asyncio.Event = field(default_factory=asyncio.Event)
+    _pending_events: list[dict[str, Any]] = field(default_factory=list)
+
+    def record(self, event: dict[str, Any]) -> None:
+        event_run_id = str(event.get("run_id", ""))
+        if not event_run_id:
+            return
+        if self.run_id is None:
+            self._pending_events.append(event)
+            return
+        self._accept(event, event_run_id)
+
+    def set_run_id(self, run_id: str) -> None:
+        normalized_run_id = str(run_id)
+        if not run_id or not normalized_run_id:
+            raise ValueError("run_id must be non-empty")
+        self.run_id = normalized_run_id
+        pending_events, self._pending_events = self._pending_events, []
+        for event in pending_events:
+            self._accept(event, str(event.get("run_id", "")))
+
+    def _accept(self, event: dict[str, Any], event_run_id: str) -> None:
+        if event_run_id != self.run_id:
+            return
+        self.events.append(event)
+        if event.get("type") == "run.finished":
+            self.finished_event = event
+            self.finished.set()
+
+
+@dataclass
 class TokenUsage:
     """一次运行的 LLM token 用量汇总"""
     input_tokens: int = 0
@@ -203,19 +240,13 @@ async def run_instance_via_rpc(
     client = SocketClient(host, port)
 
     # 收集的事件
-    collected_events: list[dict] = []
-    run_finished = asyncio.Event()
-    run_status = {"status": "", "steps": 0, "run_id": ""}
+    collector = _RunEventCollector()
 
     async def on_event(event: dict[str, Any]) -> None:
+        collector.record(event)
         event_type = event.get("type", "")
-        collected_events.append(event)
-
-        if event_type == "run.finished":
-            run_status["status"] = event.get("status", "unknown")
-            run_status["steps"] = event.get("steps", 0)
-            run_status["run_id"] = event.get("run_id", "")
-            run_finished.set()
+        if collector.run_id != str(event.get("run_id", "")):
+            return
 
         # 日志关键事件
         if event_type == "step.started":
@@ -235,6 +266,7 @@ async def run_instance_via_rpc(
         return result
 
     # 启动事件循环
+    client.on_event(on_event)
     loop_task = asyncio.create_task(client.run_event_loop())
 
     try:
@@ -270,12 +302,16 @@ async def run_instance_via_rpc(
             "session_id": session_id,
             "content": prompt,
         })
-        run_id = send_result.get("run_id", "")
+        raw_run_id = send_result.get("run_id")
+        if not raw_run_id:
+            raise ValueError("daemon returned an empty run_id")
+        run_id = str(raw_run_id)
+        collector.set_run_id(run_id)
         logger.info(f"  Run started: {run_id}")
 
         # 6. 等待 run.finished
         try:
-            await asyncio.wait_for(run_finished.wait(), timeout=timeout)
+            await asyncio.wait_for(collector.finished.wait(), timeout=timeout)
         except TimeoutError:
             result.error = f"Timeout after {timeout}s"
             # 尝试取消
@@ -284,19 +320,20 @@ async def run_instance_via_rpc(
             except Exception:
                 pass
 
-        result.status = run_status["status"]
-        result.steps = run_status["steps"]
-        result.events_log = collected_events
+        finished_event = collector.finished_event or {}
+        result.status = finished_event.get("status", "")
+        result.steps = finished_event.get("steps", 0)
+        result.events_log = collector.events
 
         # 提取 token usage（顶层字段，缺失按 0）
-        usage = summarize_token_usage(collected_events)
+        usage = summarize_token_usage(collector.events)
         result.input_tokens = usage.input_tokens
         result.output_tokens = usage.output_tokens
         result.cache_read_input_tokens = usage.cache_read_input_tokens
         result.cache_creation_input_tokens = usage.cache_creation_input_tokens
 
         # 7. 获取 diff
-        if run_status["status"] in ("success", "max_steps", "cancelled"):
+        if result.status in ("success", "max_steps", "cancelled"):
             try:
                 diff_result = await client.send_command("change.diff", {
                     "workspace_id": workspace_id,

--- a/tests/unit/test_swebench_adapter.py
+++ b/tests/unit/test_swebench_adapter.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import subprocess
 import sys
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -13,6 +16,7 @@ _SRC_ROOT = Path(__file__).resolve().parents[2]
 if str(_SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(_SRC_ROOT))
 
+from eval.swebench import adapter as swebench_adapter  # noqa: E402
 from eval.swebench.adapter import (  # noqa: E402
     RunResult,
     SWEbenchInstance,
@@ -308,3 +312,198 @@ def test_consumes_lm_usage_event_serialization() -> None:
     assert usage.output_tokens == 7
     assert usage.cache_read_input_tokens == 3
     assert usage.cache_creation_input_tokens == 1
+
+
+# 功能：交错事件只保留当前 run，且其他 run 的完成事件不能唤醒等待
+# 设计：先记录未绑定 run_id 的混合事件，再绑定当前 run 并继续交错记录，验证日志和 token 统计均已隔离
+def test_run_event_collector_filters_interleaved_events() -> None:
+    collector = swebench_adapter._RunEventCollector()
+    collector.record({
+        "type": "run.finished", "run_id": "other", "status": "success", "steps": 99,
+    })
+    collector.record({"type": "step.started", "run_id": "current", "step": 1})
+    collector.record({"type": "llm.usage", "run_id": "other", "input_tokens": 900})
+    collector.record({
+        "type": "tool.call_started", "run_id": "current", "tool_name": "bash",
+    })
+    collector.record({
+        "type": "llm.usage", "run_id": "current", "input_tokens": 12, "output_tokens": 3,
+    })
+
+    collector.set_run_id("current")
+    assert not collector.finished.is_set()
+
+    collector.record({
+        "type": "run.finished", "run_id": "other", "status": "failure", "steps": 100,
+    })
+    assert not collector.finished.is_set()
+
+    collector.record({
+        "type": "run.finished", "run_id": "current", "status": "success", "steps": 2,
+    })
+
+    assert collector.finished.is_set()
+    assert collector.finished_event == {
+        "type": "run.finished", "run_id": "current", "status": "success", "steps": 2,
+    }
+    assert [event["run_id"] for event in collector.events] == ["current"] * 4
+    usage = summarize_token_usage(collector.events)
+    assert usage.input_tokens == 12
+    assert usage.output_tokens == 3
+
+
+# 功能：run_id 返回前到达的当前完成事件不会丢失
+# 设计：缓存当前和其他 run 的完成事件，绑定后只重放当前 run 的事件并立即设置完成信号
+def test_run_event_collector_replays_current_finished_event_after_binding() -> None:
+    collector = swebench_adapter._RunEventCollector()
+    current_finished = {
+        "type": "run.finished", "run_id": "current", "status": "failure", "steps": 4,
+    }
+    collector.record(current_finished)
+    collector.record({
+        "type": "run.finished", "run_id": "other", "status": "success", "steps": 8,
+    })
+
+    assert not collector.finished.is_set()
+    collector.set_run_id("current")
+
+    assert collector.finished.is_set()
+    assert collector.finished_event == current_finished
+    assert collector.events == [current_finished]
+
+
+# 功能：当前 run 的所有终止状态都能结束等待，其他 run 的同名状态不能结束等待
+# 设计：参数化覆盖 SWE-bench 适配器接受的四种 run.finished 状态
+@pytest.mark.parametrize("status", ["success", "failure", "cancelled", "max_steps"])
+def test_run_event_collector_accepts_all_terminal_statuses(status: str) -> None:
+    collector = swebench_adapter._RunEventCollector()
+    collector.set_run_id("current")
+
+    collector.record({
+        "type": "run.finished", "run_id": "other", "status": status, "steps": 8,
+    })
+    assert not collector.finished.is_set()
+
+    collector.record({
+        "type": "run.finished", "run_id": "current", "status": status, "steps": 3,
+    })
+
+    assert collector.finished.is_set()
+    assert collector.finished_event is not None
+    assert collector.finished_event["status"] == status
+    assert collector.finished_event["steps"] == 3
+
+
+# 功能：无法归属 run 的事件不会污染日志，也不会结束当前等待
+# 设计：当前 run 已绑定时记录缺少 run_id 的完成和 token 事件，断言均被忽略
+def test_run_event_collector_ignores_events_without_run_id() -> None:
+    collector = swebench_adapter._RunEventCollector()
+    collector.set_run_id("current")
+
+    collector.record({"type": "run.finished", "status": "success", "steps": 1})
+    collector.record({"type": "llm.usage", "input_tokens": 50})
+
+    assert collector.events == []
+    assert not collector.finished.is_set()
+
+
+# 功能：空的 RPC run_id 不会被转换成可用的字符串 ID
+# 设计：空字符串和 JSON null 都必须拒绝，防止无效 ID 接收其他事件
+@pytest.mark.parametrize("run_id", ["", None])
+def test_run_event_collector_rejects_empty_run_id(run_id: str | None) -> None:
+    collector = swebench_adapter._RunEventCollector()
+
+    with pytest.raises(ValueError, match="run_id must be non-empty"):
+        collector.set_run_id(run_id)  # type: ignore[arg-type]
+
+
+# 功能：RPC 适配器只用当前 run 的完成事件、日志和 token 生成结果
+# 设计：假的 SocketClient 先发送其他 run 的完成事件，返回当前 run_id 后再发送当前事件，全程不连接 daemon 或网络
+@pytest.mark.asyncio
+async def test_run_instance_via_rpc_ignores_other_run_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    other_finished = {
+        "type": "run.finished", "run_id": "other", "status": "failure", "steps": 99,
+    }
+    current_events = [
+        {"type": "step.started", "run_id": "current", "step": 1},
+        {
+            "type": "llm.usage",
+            "run_id": "current",
+            "input_tokens": 12,
+            "output_tokens": 3,
+        },
+        {
+            "type": "run.finished",
+            "run_id": "current",
+            "status": "success",
+            "steps": 2,
+        },
+    ]
+
+    class FakeSocketClient:
+        def __init__(self, host: str, port: int) -> None:
+            del host, port
+            self._handler: Callable[[dict[str, Any]], Awaitable[None]] | None = None
+            self._message_sent = asyncio.Event()
+
+        async def connect(self) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+        def on_event(
+            self,
+            handler: Callable[[dict[str, Any]], Awaitable[None]],
+        ) -> None:
+            self._handler = handler
+
+        async def run_event_loop(self) -> None:
+            await self._message_sent.wait()
+            await asyncio.sleep(0.01)
+            assert self._handler is not None
+            for event in current_events:
+                await self._handler(event)
+            await asyncio.Event().wait()
+
+        async def send_command(
+            self,
+            method: str,
+            params: dict[str, Any],
+        ) -> dict[str, Any]:
+            del params
+            if method == "workspace.open":
+                return {"workspace": {"workspace_id": "workspace-1"}}
+            if method == "session.create":
+                return {"session_id": "session-1"}
+            if method == "session.send_message":
+                assert self._handler is not None
+                await self._handler(other_finished)
+                self._message_sent.set()
+                return {"run_id": "current"}
+            if method == "change.diff":
+                return {"diff": "diff --git a/file.py b/file.py\n"}
+            return {"ok": True}
+
+    monkeypatch.setattr(swebench_adapter, "SocketClient", FakeSocketClient)
+    instance = swebench_adapter.SWEbenchInstance(
+        instance_id="owner__repo-1",
+        repo="owner/repo",
+        base_commit="abc123",
+        problem_statement="Fix the failing behavior.",
+    )
+
+    result = await swebench_adapter.run_instance_via_rpc(
+        instance,
+        tmp_path,
+        timeout=1,
+    )
+
+    assert result.status == "success"
+    assert result.steps == 2
+    assert result.events_log == current_events
+    assert result.input_tokens == 12
+    assert result.output_tokens == 3


### PR DESCRIPTION
## 背景

SWE-bench 适配器使用全局事件订阅。原回调会无条件收集事件，并将任意 `run.finished` 视为当前任务完成，导致其他 run 的事件可能污染 `events_log`、token 统计和终止状态，甚至提前唤醒等待。

## 变更

- 新增 `_RunEventCollector`，在当前 `run_id` 返回前缓存事件，绑定后只保留匹配事件。
- 只有当前 run 的 `run.finished` 才更新状态并唤醒等待，兼容完成事件先于 RPC 响应到达的竞态。
- 使用过滤后的事件生成 `events_log` 和 token 汇总，并显式注册 `SocketClient` 事件回调。
- 拒绝缺失、空字符串或 `null` 的 RPC `run_id`，避免无效 ID 被当作当前运行。
- 添加纯离线单元测试，覆盖交错事件、绑定前完成、四种终态、无 run ID 事件和 RPC 集成，不启动 daemon、模型或网络。

## 验证

- `pytest tests/unit/test_swebench_adapter.py -q`：30 passed
- `ruff check eval/swebench/adapter.py tests/unit/test_swebench_adapter.py`：通过
- `pytest tests/unit -q`：757 passed，1 个既有 Windows 路径分隔符断言失败（`test_main_reports_and_exits_nonzero`），与本次修改无关
- `git diff --check`：通过
- GitHub Actions `Python 3.12 checks`：通过

## 非目标

- 不修改 `SocketClient`、事件协议或 daemon 的全局订阅行为。
- 不实现多实例并行调度。

Closes #33
