### PR TITLE
fix(swebench): include untracked files in git fallback

### DIFF
--- a/eval/swebench/adapter.py
+++ b/eval/swebench/adapter.py
@@ -218,7 +218,27 @@ def get_diff_via_git(repo_dir: Path) -> str:
         text=True,
         timeout=30,
     )
-    return result.stdout
+    patches = [result.stdout]
+
+    untracked_result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    for file_path in untracked_result.stdout.splitlines():
+        new_file_result = subprocess.run(
+            ["git", "diff", "--no-index", "--", "/dev/null", file_path],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if new_file_result.returncode in (0, 1):
+            patches.append(new_file_result.stdout)
+
+    return "".join(patches)
 
 
 # ──────────────────── RPC 调用 ────────────────────

--- a/tests/unit/test_swebench_adapter.py
+++ b/tests/unit/test_swebench_adapter.py
@@ -194,6 +194,55 @@ def test_get_diff_via_git_returns_tracked_file_changes(tmp_path: Path) -> None:
     assert "-value = 1" in patch
     assert "+value = 2" in patch
 
+# 功能：get_diff_via_git 将未跟踪的新建文件纳入 unified diff
+# 设计：在真实临时仓库中新建但不暂存文件，验证 Git fallback 返回标准新文件补丁
+def test_get_diff_via_git_includes_untracked_new_file(tmp_path: Path) -> None:
+    repo = _create_git_repo(tmp_path)
+    (repo / "new_file.py").write_text("value = 42\n", encoding="utf-8")
+
+    patch = get_diff_via_git(repo)
+
+    assert "diff --git a/new_file.py b/new_file.py" in patch
+    assert "new file mode 100644" in patch
+    assert "+value = 42" in patch
+
+# 功能：get_diff_via_git 同时保留修改、删除和新建文件，并忽略被 Git ignore 的文件
+# 设计：在真实临时仓库中构造多类变更，验证补丁可应用且调用前后 Git 状态保持不变
+def test_get_diff_via_git_includes_all_supported_changes(tmp_path: Path) -> None:
+    repo = _create_git_repo(tmp_path)
+    (repo / "deleted.py").write_text("deleted = True\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("*.tmp\n", encoding="utf-8")
+    _run_git(repo, "add", "deleted.py", ".gitignore")
+    _run_git(repo, "commit", "--quiet", "-m", "add deletion fixture")
+
+    (repo / "sample.py").write_text("value = 2\n", encoding="utf-8")
+    (repo / "new_file.py").write_text("value = 42\n", encoding="utf-8")
+    (repo / "deleted.py").unlink()
+    (repo / "ignored.tmp").write_text("ignore me\n", encoding="utf-8")
+    status_before = _run_git(repo, "status", "--porcelain=v1").stdout
+
+    patch = get_diff_via_git(repo)
+
+    assert "diff --git a/sample.py b/sample.py" in patch
+    assert "-value = 1" in patch
+    assert "+value = 2" in patch
+    assert "diff --git a/new_file.py b/new_file.py" in patch
+    assert "new file mode 100644" in patch
+    assert "+value = 42" in patch
+    assert "diff --git a/deleted.py b/deleted.py" in patch
+    assert "deleted file mode 100644" in patch
+    assert "ignored.tmp" not in patch
+    assert _run_git(repo, "status", "--porcelain=v1").stdout == status_before
+
+    patch_path = tmp_path / "model.patch"
+    patch_path.write_text(patch, encoding="utf-8")
+    apply_target = tmp_path / "apply-target"
+    _run_git(tmp_path, "clone", "--quiet", str(repo), str(apply_target))
+    _run_git(apply_target, "apply", str(patch_path))
+
+    assert (apply_target / "sample.py").read_text(encoding="utf-8") == "value = 2\n"
+    assert (apply_target / "new_file.py").read_text(encoding="utf-8") == "value = 42\n"
+    assert not (apply_target / "deleted.py").exists()
 
 # 功能：load_dataset 存在本地 Parquet 时优先返回本地数据且不调用远程加载器
 # 设计：注入最小 pyarrow 与 datasets 内存模块，验证读取参数并以未调用断言阻止下载路径


### PR DESCRIPTION
## Summary

Fixes #34

- 修复 Git fallback 未将未跟踪的新建文件纳入补丁的问题。
- 保留原有 `git diff` 对已跟踪文件修改和删除的支持。
- 不修改被评测仓库的 Git index（暂存区）。

## Behavior

当 `change.diff` 不可用或未返回补丁时，SWE-bench 的 fallback 现在会：

- 使用 `git diff` 获取已跟踪文件的修改和删除；
- 使用 `git ls-files --others --exclude-standard` 查找未跟踪且未被忽略的文件；
- 为这些新建文件生成标准 unified diff，并合并到最终补丁中。

被 `.gitignore` 忽略的文件不会进入补丁。本次没有修改 RPC 协议、用户配置或数据格式。

## Validation

已实际执行并通过：

```text
uv run pytest tests/unit/test_swebench_adapter.py -v
# 32 passed

uv run ruff check eval/swebench/adapter.py tests/unit/test_swebench_adapter.py
# All checks passed!
```

新增测试覆盖：

- 已跟踪文件修改；
- 未跟踪新建文件；
- 已跟踪文件删除；
- `.gitignore` 忽略文件；
- 调用前后 Git 状态不变；
- 将生成的补丁应用到干净基线仓库。

未运行完整项目测试、`mypy` 和 Docker SWE-bench harness；这些不属于本次聚焦修复及 Issue #34 的目标范围。

## Risk

风险较低。fallback 只为未被 Git 忽略的普通文本新文件补充标准 diff，不会执行 `git add`、`git commit` 或永久修改目标仓库的暂存区。

二进制文件补丁仍属于本 Issue 的非目标范围。

## UI evidence

N/A：本次没有 TUI 或桌面端 UI 改动。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 无协议变化，不需要重新生成 `docs/reference/wire-protocol.md`。
- [x] 无用户可见配置或文档变化。
- [x] 提交包含 `Signed-off-by`（DCO）。