### PR TITLE
fix: 隔离工具 Schema 缓存副本

### DIFF
--- a/docs/superpowers/plans/2026-08-09-tool-schema-cache-isolation.md
+++ b/docs/superpowers/plans/2026-08-09-tool-schema-cache-isolation.md
@@ -1,0 +1,194 @@
+# 工具 Schema 缓存隔离 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `ToolRegistry.tool_schemas()` 返回可独立修改的深拷贝，同时保留内部缓存及注册后的失效行为。
+
+**Architecture:** `_schema_cache` 继续保存 Registry 私有的规范 Schema。`tool_schemas()` 只在缓存为空时构建，所有公开返回都对缓存执行 `deepcopy`；测试通过修改顶层和嵌套对象验证调用方隔离，并验证注册后缓存替换和旧快照稳定。
+
+**Tech Stack:** Python 3.12、`copy.deepcopy`、pytest、Ruff、Mypy。
+
+---
+
+### Task 1: 添加公开快照隔离的失败测试
+
+**Files:**
+- Modify: `tests/unit/test_tool_registry.py`
+
+- [ ] **Step 1: 为假工具加入可识别的嵌套属性**
+
+将 `_FakeTool.input_schema` 调整为包含一个实际参数：
+
+```python
+input_schema: dict[str, object] = {
+    "type": "object",
+    "properties": {"value": {"type": "string"}},
+    "required": [],
+}
+```
+
+- [ ] **Step 2: 写顶层和嵌套修改隔离测试**
+
+```python
+# 功能：验证调用方修改公开 Schema 的任意可变层级都不会污染后续调用
+# 设计：同时追加顶层列表、改写工具字典并清空嵌套 properties，覆盖浅拷贝无法隔离的边界
+def test_tool_schemas_returns_isolated_provider_snapshots() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool())
+
+    provider_a_schemas = registry.tool_schemas()
+    provider_a_schemas.append({"name": "injected"})
+    provider_a_schemas[0]["description"] = "changed"
+    input_schema = provider_a_schemas[0]["input_schema"]
+    assert isinstance(input_schema, dict)
+    properties = input_schema["properties"]
+    assert isinstance(properties, dict)
+    properties.clear()
+
+    provider_b_schemas = registry.tool_schemas()
+    assert len(provider_b_schemas) == 1
+    assert provider_b_schemas[0]["name"] == "fake"
+    assert provider_b_schemas[0]["description"] == "A fake tool"
+    provider_b_input_schema = provider_b_schemas[0]["input_schema"]
+    assert isinstance(provider_b_input_schema, dict)
+    provider_b_properties = provider_b_input_schema["properties"]
+    assert isinstance(provider_b_properties, dict)
+    assert set(provider_b_properties) == {"value", "description"}
+```
+
+- [ ] **Step 3: 运行测试并确认 RED 原因**
+
+Run:
+
+```text
+pytest tests/unit/test_tool_registry.py::test_tool_schemas_returns_isolated_provider_snapshots -q
+```
+
+Expected: FAIL，第二次调用仍包含注入的工具或被修改的字段，证明公开返回泄露内部缓存。
+
+### Task 2: 验证内部缓存复用与注册失效
+
+**Files:**
+- Modify: `tests/unit/test_tool_registry.py`
+
+- [ ] **Step 1: 替换依赖公开对象身份的旧测试**
+
+将 `test_tool_schemas_are_cached_until_registration` 改为验证私有缓存身份和公开副本隔离：
+
+```python
+# 功能：验证连续调用复用内部缓存，但每次公开结果都是独立快照
+# 设计：分别比较 `_schema_cache` 与公开结果的对象身份，避免把缓存实现误当成公开所有权契约
+def test_tool_schemas_reuses_internal_cache_without_sharing_results() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool())
+
+    first = registry.tool_schemas()
+    cached = registry._schema_cache
+    second = registry.tool_schemas()
+
+    assert registry._schema_cache is cached
+    assert second == first
+    assert second is not first
+    assert second[0] is not first[0]
+    assert second[0]["input_schema"] is not first[0]["input_schema"]
+```
+
+- [ ] **Step 2: 添加注册后新旧快照测试**
+
+```python
+# 功能：验证注册新工具会替换内部缓存，且不会反向修改注册前取得的快照
+# 设计：保留旧快照和旧缓存引用，注册另一工具后同时比较名称集合与缓存身份
+def test_registration_invalidates_cache_without_changing_old_snapshot() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool())
+    old_snapshot = registry.tool_schemas()
+    old_cache = registry._schema_cache
+
+    registry.register(_AnotherTool())
+    new_snapshot = registry.tool_schemas()
+
+    assert {schema["name"] for schema in old_snapshot} == {"fake"}
+    assert {schema["name"] for schema in new_snapshot} == {"fake", "another"}
+    assert registry._schema_cache is not old_cache
+```
+
+- [ ] **Step 3: 运行三个新测试并确认现有实现仍为 RED**
+
+Run:
+
+```text
+pytest tests/unit/test_tool_registry.py -k "isolated_provider_snapshots or internal_cache or invalidates_cache" -q
+```
+
+Expected: 快照隔离测试和公开结果身份断言失败；注册失效行为本身通过。
+
+### Task 3: 实现安全副本契约
+
+**Files:**
+- Modify: `src/sztu_code/core/tools/registry.py:88-118`
+
+- [ ] **Step 1: 让所有返回路径深拷贝内部缓存**
+
+移除缓存命中时直接返回的分支，把现有构建逻辑放在 `_schema_cache is None` 条件内，并在方法末尾统一返回：
+
+```python
+# 返回工具 schema 的独立深拷贝，内部缓存仅由注册表持有
+def tool_schemas(self) -> list[dict[str, object]]:
+    if self._schema_cache is None:
+        schemas: list[dict[str, object]] = []
+        # 保留现有 Schema 构建循环
+        self._schema_cache = schemas
+    return deepcopy(self._schema_cache)
+```
+
+- [ ] **Step 2: 运行专项测试验证 GREEN**
+
+Run:
+
+```text
+pytest tests/unit/test_tool_registry.py -q
+```
+
+Expected: 全部测试通过。
+
+### Task 4: 全量验证与发布准备
+
+**Files:**
+- Modify: no additional files
+
+- [ ] **Step 1: 运行静态检查和完整单元测试**
+
+Run:
+
+```text
+ruff check src/sztu_code/core/tools/registry.py tests/unit/test_tool_registry.py
+mypy src/sztu_code/core/tools/registry.py
+pytest tests/unit -q
+git diff --check
+```
+
+Expected: 专项 Ruff、Mypy 和差异检查通过；完整单元测试不新增相对 `upstream/main` 的失败。
+
+- [ ] **Step 2: 检查最终变更范围**
+
+Run:
+
+```text
+git status --short
+git diff --stat upstream/main...HEAD
+git diff -- src/sztu_code/core/tools/registry.py tests/unit/test_tool_registry.py
+```
+
+Expected: 只包含 Registry、对应单元测试以及本 issue 的两份过程文档。
+
+- [ ] **Step 3: 创建中文签名提交并发布 PR**
+
+Run:
+
+```text
+git add src/sztu_code/core/tools/registry.py tests/unit/test_tool_registry.py docs/superpowers/specs/2026-08-09-tool-schema-cache-isolation-design.md docs/superpowers/plans/2026-08-09-tool-schema-cache-isolation.md
+git commit -s -m "fix: 隔离工具 Schema 缓存"
+git push -u origin fix/78-tool-schema-cache
+```
+
+Expected: 提交包含 `Signed-off-by`，分支推送到个人 fork；随后创建中文 Draft PR、核对 CI，并在检查通过后设为 Ready for review。

--- a/docs/superpowers/specs/2026-08-09-tool-schema-cache-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-09-tool-schema-cache-isolation-design.md
@@ -1,0 +1,81 @@
+# 工具 Schema 缓存隔离设计
+
+## 背景
+
+`ToolRegistry.tool_schemas()` 会缓存构建完成的工具 Schema，但当前公开方法直接返回 `_schema_cache`。调用方因此获得 Registry 内部可变对象的所有权：修改返回列表、其中的工具字典或更深层的 `input_schema.properties`，都会污染后续调用以及其他 Provider 看到的 Schema。
+
+Issue #78 要求保留缓存和现有 Schema 格式，同时让每个调用方获得可以独立修改的安全快照。
+
+## 目标与验收标准
+
+- 调用方修改第一次返回值的顶层列表、工具字典和嵌套 `properties` 后，下一次调用仍返回完整原始 Schema。
+- Registry 未发生注册变更时继续复用内部缓存，但不同公开返回值不共享可变对象。
+- 注册新工具后缓存失效，新结果包含新工具，注册前取得的旧快照不被反向修改。
+- 不同 Provider 依次获取和转换 Schema 时，各自的修改不会影响 Registry 或其他 Provider。
+- `tests/unit/test_tool_registry.py` 的专项测试通过。
+
+## 非目标
+
+- 不重构 `ToolRegistry` 的注册、别名或权限逻辑。
+- 不移除 Schema 缓存，也不把整个缓存改造成不可变数据模型。
+- 不改变对外 Schema 的字段、顺序或内容。
+- 不修改 Provider API 或引入新的 Provider 抽象。
+
+## 方案比较
+
+### 方案一：公开返回深拷贝（推荐）
+
+Registry 继续用可变的 `list[dict]` 保存内部缓存；首次调用构建缓存，之后每次公开返回时对缓存执行 `deepcopy`。该方案同时隔离顶层和任意深度的嵌套对象，改动集中在 `tool_schemas()`，不会改变调用方类型或 Schema 格式。
+
+代价是每次调用仍需复制 Schema，但缓存继续避免重复遍历工具和补齐字段。工具 Schema 规模有限，相比跨请求共享状态的风险，这一成本可接受。
+
+### 方案二：只复制列表或顶层字典
+
+浅拷贝成本较低，但 `input_schema.properties` 等嵌套对象仍会共享，不能满足验收标准，予以排除。
+
+### 方案三：缓存不可变结构，在 Provider 边界转换
+
+把内部缓存改为递归不可变结构，再由每个 Provider 转回可变字典，可以建立更强约束，但需要新增转换逻辑并改变多个边界，超出本 issue 的最小范围，予以排除。
+
+## 详细设计
+
+### 缓存所有权
+
+`_schema_cache` 仍是 Registry 私有的规范副本，只能在 `tool_schemas()` 构建、在 `register()` 中失效。公开方法不再把该对象本身交给调用方。
+
+`tool_schemas()` 的流程调整为：
+
+1. `_schema_cache` 为 `None` 时，按现有逻辑构建 Schema 并写入缓存。
+2. `_schema_cache` 已存在时跳过构建。
+3. 无论缓存是新建还是复用，都返回 `deepcopy(self._schema_cache)`。
+
+方法上方的中文注释明确说明返回值是独立深拷贝、内部缓存只由 Registry 持有，避免后续代码重新依赖对象身份。
+
+### 注册失效
+
+`register()` 继续把 `_schema_cache` 设为 `None`。注册前已经返回的快照与缓存没有共享可变对象，因此注册新工具既不会修改旧快照，也会让下一次调用重新构建包含新工具的缓存。
+
+### Provider 边界
+
+Anthropic 和 OpenAI Provider 每次从 Agent Loop 获得的是独立 Registry 快照。现有转换代码不需要修改；即使某个转换结果或其嵌套参数随后被修改，也只能影响该次快照，下一次 `tool_schemas()` 会从未污染的内部缓存生成新副本。
+
+## 测试设计
+
+在 `tests/unit/test_tool_registry.py` 中增加或调整三类行为测试：
+
+1. 修改第一次返回值的列表、工具字典和嵌套 `properties`，断言第二次调用的工具数量、名称、描述和属性仍完整。
+2. 检查连续调用复用同一个 `_schema_cache`，但公开结果及其嵌套对象不是同一对象。
+3. 注册第二个工具后，断言旧快照仍只含原工具，新快照包含两个工具，并且内部缓存已替换。
+
+这些测试直接验证公开所有权契约，不依赖网络、模型或 daemon。
+
+## 验收命令
+
+```text
+pytest tests/unit/test_tool_registry.py -q
+ruff check src/sztu_code/core/tools/registry.py tests/unit/test_tool_registry.py
+mypy src/sztu_code/core/tools/registry.py
+git diff --check
+```
+
+实现完成后还会运行完整 `tests/unit`，并把 `upstream/main` 已存在的无关失败与本次结果对照记录。

--- a/src/sztu_code/core/tools/registry.py
+++ b/src/sztu_code/core/tools/registry.py
@@ -85,36 +85,35 @@ class ToolRegistry:
         enriched["description"] = title
         return enriched
 
-    # 返回所有工具的 Anthropic 格式 schema，并要求模型提供时间线标题
+    # 返回工具 schema 的独立深拷贝，内部缓存仅由注册表持有
     def tool_schemas(self) -> list[dict[str, object]]:
-        if self._schema_cache is not None:
-            return self._schema_cache
-        schemas: list[dict[str, object]] = []
-        for tool in self._tools.values():
-            input_schema = deepcopy(tool.input_schema)
-            raw_properties = input_schema.get("properties", {})
-            properties = dict(raw_properties) if isinstance(raw_properties, dict) else {}
-            properties["description"] = {
-                "type": "string",
-                "description": "用简短中文说明本次调用的具体目的，作为执行时间线标题。",
-            }
-            input_schema["properties"] = properties
-            raw_required = input_schema.get("required", [])
-            required = (
-                [str(item) for item in raw_required]
-                if isinstance(raw_required, list)
-                else []
-            )
-            if "description" not in required:
-                required.append("description")
-            input_schema["required"] = required
-            schemas.append({
-                "name": tool.name,
-                "description": tool.description,
-                "input_schema": input_schema,
-            })
-        self._schema_cache = schemas
-        return schemas
+        if self._schema_cache is None:
+            schemas: list[dict[str, object]] = []
+            for tool in self._tools.values():
+                input_schema = deepcopy(tool.input_schema)
+                raw_properties = input_schema.get("properties", {})
+                properties = dict(raw_properties) if isinstance(raw_properties, dict) else {}
+                properties["description"] = {
+                    "type": "string",
+                    "description": "用简短中文说明本次调用的具体目的，作为执行时间线标题。",
+                }
+                input_schema["properties"] = properties
+                raw_required = input_schema.get("required", [])
+                required = (
+                    [str(item) for item in raw_required]
+                    if isinstance(raw_required, list)
+                    else []
+                )
+                if "description" not in required:
+                    required.append("description")
+                input_schema["required"] = required
+                schemas.append({
+                    "name": tool.name,
+                    "description": tool.description,
+                    "input_schema": input_schema,
+                })
+            self._schema_cache = schemas
+        return deepcopy(self._schema_cache)
 
     # 返回所有已注册工具的迭代器
     def __iter__(self) -> Iterator[BaseTool]:

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -7,10 +7,23 @@ from sztu_code.core.tools.registry import ToolRegistry
 class _FakeTool(BaseTool):
     name = "fake"
     description = "A fake tool"
-    input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
+    input_schema: dict[str, object] = {
+        "type": "object",
+        "properties": {"value": {"type": "string"}},
+        "required": [],
+    }
 
     async def invoke(self, params: dict[str, object]) -> ToolResult:
         return ToolResult(content="ok")
+
+
+class _AnotherTool(BaseTool):
+    name = "another"
+    description = "Another"
+    input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
+
+    async def invoke(self, params: dict[str, object]) -> ToolResult:
+        return ToolResult(content="")
 
 
 # 功能：验证注册工具后能通过名称检索到同一实例
@@ -46,14 +59,6 @@ def test_tool_schemas_contains_name_description_input_schema() -> None:
 # 功能：验证多工具注册后 tool_schemas() 包含所有工具，不遗漏
 # 设计：用 set 比较名称集合而非检查顺序，聚焦"完整性"而非"顺序"，确认 registry 不遗漏任何已注册工具
 def test_multiple_tools_all_appear_in_schemas() -> None:
-    class _AnotherTool(BaseTool):
-        name = "another"
-        description = "Another"
-        input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
-
-        async def invoke(self, params: dict[str, object]) -> ToolResult:
-            return ToolResult(content="")
-
     registry = ToolRegistry()
     registry.register(_FakeTool())
     registry.register(_AnotherTool())
@@ -61,16 +66,63 @@ def test_multiple_tools_all_appear_in_schemas() -> None:
     assert names == {"fake", "another"}
 
 
-# 功能：验证工具 schema 在注册表未变化时复用同一缓存对象
-# 设计：连续调用检查对象身份，再注册新工具确认缓存失效并包含新 schema
-def test_tool_schemas_are_cached_until_registration() -> None:
+# 功能：验证一个 Provider 修改公开 Schema 的任意可变层级都不会污染后续 Provider
+# 设计：同时追加顶层列表、改写工具字典并清空嵌套 properties，覆盖浅拷贝无法隔离的边界
+def test_tool_schemas_returns_isolated_provider_snapshots() -> None:
     registry = ToolRegistry()
     registry.register(_FakeTool())
-    first = registry.tool_schemas()
-    assert registry.tool_schemas() is first
 
+    provider_a_schemas = registry.tool_schemas()
+    provider_a_schemas.append({"name": "injected"})
+    provider_a_schemas[0]["description"] = "changed"
+    input_schema = provider_a_schemas[0]["input_schema"]
+    assert isinstance(input_schema, dict)
+    properties = input_schema["properties"]
+    assert isinstance(properties, dict)
+    properties.clear()
+
+    provider_b_schemas = registry.tool_schemas()
+    assert len(provider_b_schemas) == 1
+    assert provider_b_schemas[0]["name"] == "fake"
+    assert provider_b_schemas[0]["description"] == "A fake tool"
+    provider_b_input_schema = provider_b_schemas[0]["input_schema"]
+    assert isinstance(provider_b_input_schema, dict)
+    provider_b_properties = provider_b_input_schema["properties"]
+    assert isinstance(provider_b_properties, dict)
+    assert set(provider_b_properties) == {"value", "description"}
+
+
+# 功能：验证连续调用复用内部缓存，但每次公开结果都是独立快照
+# 设计：分别比较 `_schema_cache` 与公开结果的对象身份，避免把缓存实现误当成公开所有权契约
+def test_tool_schemas_reuses_internal_cache_without_sharing_results() -> None:
+    registry = ToolRegistry()
     registry.register(_FakeTool())
-    assert registry.tool_schemas() is not first
+
+    first = registry.tool_schemas()
+    cached = registry._schema_cache
+    second = registry.tool_schemas()
+
+    assert registry._schema_cache is cached
+    assert second == first
+    assert second is not first
+    assert second[0] is not first[0]
+    assert second[0]["input_schema"] is not first[0]["input_schema"]
+
+
+# 功能：验证注册新工具会替换内部缓存，且不会反向修改注册前取得的快照
+# 设计：保留旧快照和旧缓存引用，注册另一工具后同时比较名称集合与缓存身份
+def test_registration_invalidates_cache_without_changing_old_snapshot() -> None:
+    registry = ToolRegistry()
+    registry.register(_FakeTool())
+    old_snapshot = registry.tool_schemas()
+    old_cache = registry._schema_cache
+
+    registry.register(_AnotherTool())
+    new_snapshot = registry.tool_schemas()
+
+    assert {schema["name"] for schema in old_snapshot} == {"fake"}
+    assert {schema["name"] for schema in new_snapshot} == {"fake", "another"}
+    assert registry._schema_cache is not old_cache
 
 
 # 功能：验证重复注册同名工具时新版本覆盖旧版本（覆盖语义而非追加）


### PR DESCRIPTION
## 背景

`ToolRegistry.tool_schemas()` 会缓存构建后的工具 Schema，但原实现把内部可变缓存直接返回给调用方。任一 Provider 修改返回列表、工具字典或嵌套 `properties` 后，后续调用都会读取被污染的缓存，造成跨请求共享状态。

## 变更

- 保留 `_schema_cache` 和 `register()` 的失效机制，统一向调用方返回内部缓存的深拷贝。
- 明确 `tool_schemas()` 的所有权契约：Registry 独占内部缓存，调用方持有独立快照。
- 更新原有缓存测试，并覆盖顶层列表、工具字典、嵌套属性污染、内部缓存复用、注册失效和旧快照稳定。
- 补充中文设计文档与实施计划，记录方案比较、范围和验收标准。

## 验证

- `pytest tests/unit/test_tool_registry.py -q`：9 passed。
- Registry 与三个 Provider 相关测试：52 passed。
- `ruff check src/sztu_code/core/tools/registry.py tests/unit/test_tool_registry.py`：通过。
- `mypy src/sztu_code/core/tools/registry.py`：通过。
- 排除三项与本次改动无关的上游基线问题后，`pytest tests/unit -q`：766 passed，3 deselected。
- `git diff --check`：通过。

## 基线说明

- `test_auto_compact_by_token_count` 在修改前即可复现，mock 响应被压缩流程消耗后发生 `StopIteration`。
- `test_main_reports_and_exits_nonzero` 在 Windows 输出反斜杠，断言固定期待正斜杠。
- `test_history_merges_sliding_compaction_backups_without_duplicates` 按 `mtime` 和随机 UUID 文件名排序同秒备份，单独重复运行可随机失败；该测试和 SessionStore 均未被本 PR 修改。
- GitHub Actions 的全仓 Ruff 检查在未修改的 `src/sztu_code/core/app.py` 报告 14 个上游基线错误，因此当前 CI 为红；本 PR 修改文件的专项 Ruff 检查已通过。

## 非目标

- 不重构 ToolRegistry 的注册、别名或权限逻辑。
- 不改变对外 Schema 格式或 Provider API。
- 不处理上述无关基线测试问题。

Closes #78
