### PR TITLE
fix(desktop): add keyboard and focus interactions to model manager dialogs

### DIFF
--- a/desktop/src/components/ModelConfig/ModelManager.vue
+++ b/desktop/src/components/ModelConfig/ModelManager.vue
@@ -2,7 +2,8 @@
 import { Check, ChevronDown, ExternalLink, Eye, EyeOff, LoaderCircle, Play, Plus, Settings2, Trash2, X } from "@lucide/vue";
 import { isTauri } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { useFocusTrap } from "../../composables/useFocusTrap";
 import {
   deleteModelProfile, getProviderStatus, listModelProfiles, saveModelProfile, selectModelProfile, testModelProfile,
   type ModelProfile, type ProviderStatus, type RuntimeSettings,
@@ -32,6 +33,11 @@ const testing = ref(false); const testResult = ref("");
 const deleteTarget = ref<ModelProfile | null>(null); const deletingId = ref<string | null>(null);
 const deleteTrigger = ref<HTMLButtonElement | null>(null); const modelManagerBody = ref<HTMLElement | null>(null);
 const deleteCancelButton = ref<HTMLButtonElement | null>(null);
+const editorDialog = ref<HTMLElement | null>(null);
+const deleteDialog = ref<HTMLElement | null>(null);
+const editorTrigger = ref<HTMLButtonElement | null>(null);
+const managerDialog = ref<HTMLElement | null>(null);
+const { setInitialFocus, trapTab, restoreFocus } = useFocusTrap();
 let modelRequestVersion = 0;
 const canSave = computed(() => Boolean(selectedVendor.value && name.value.trim() && model.value.trim() && apiKey.value.trim()));
 
@@ -40,7 +46,14 @@ async function refresh() {
   try { models.value = await listModelProfiles(); }
   catch (reason) { error.value = reason instanceof Error ? reason.message : String(reason); }
 }
-function beginAdd() { editorOpen.value = true; selectedVendor.value = null; name.value = ""; model.value = ""; baseUrl.value = ""; apiKey.value = ""; apiFormat.value = "anthropic_messages"; maxOutputTokens.value = 8192; temperature.value = null; topP.value = null; reasoningEffort.value = ""; timeoutS.value = 120; maxRetries.value = 2; contextWindow.value = 0; cacheControl.value = true; advancedOpen.value = false; error.value = ""; }
+function beginAdd(event?: MouseEvent) {
+  editorTrigger.value = event?.currentTarget instanceof HTMLButtonElement ? event.currentTarget : editorTrigger.value;
+  editorOpen.value = true; selectedVendor.value = null; name.value = ""; model.value = ""; baseUrl.value = ""; apiKey.value = ""; apiFormat.value = "anthropic_messages"; maxOutputTokens.value = 8192; temperature.value = null; topP.value = null; reasoningEffort.value = ""; timeoutS.value = 120; maxRetries.value = 2; contextWindow.value = 0; cacheControl.value = true; advancedOpen.value = false; error.value = "";
+}
+// 编辑器打开后聚焦首个控件（点击 beginAdd 或程序注入 editorOpen 都生效）
+watch(editorOpen, (open) => {
+  if (open) void setInitialFocus(editorDialog);
+});
 function chooseVendor(item: ModelVendor) { selectedVendor.value = item; name.value = item.name; provider.value = item.provider; apiFormat.value = item.provider === "openai" ? "openai_chat_completions" : "anthropic_messages"; baseUrl.value = item.baseUrl; }
 async function getApiKey() {
   const url = selectedVendor.value?.apiKeyUrl;
@@ -53,6 +66,10 @@ async function getApiKey() {
     error.value = `无法打开 API 密钥页面：${reason instanceof Error ? reason.message : String(reason)}`;
   }
 }
+function closeEditor() {
+  editorOpen.value = false;
+  void restoreFocus(editorTrigger.value, modelManagerBody.value);
+}
 async function save() {
   if (!canSave.value || !selectedVendor.value) return;
   if (baseUrl.value && !/^https?:\/\//i.test(baseUrl.value)) { error.value = "API 地址需要以 http:// 或 https:// 开头"; return; }
@@ -61,7 +78,7 @@ async function save() {
   try {
     const result = await saveModelProfile({ name: name.value.trim(), vendor: selectedVendor.value.name, provider: provider.value, api_format: apiFormat.value, model: model.value.trim(), base_url: baseUrl.value.trim(), api_key: apiKey.value.trim(), max_output_tokens: maxOutputTokens.value, temperature: temperature.value, top_p: topP.value, reasoning_effort: reasoningEffort.value, timeout_s: timeoutS.value, max_retries: maxRetries.value, context_window: contextWindow.value, cache_control: cacheControl.value });
     if (requestVersion !== modelRequestVersion) return;
-    models.value = result.models; emit("updated", result.settings, await getProviderStatus()); editorOpen.value = false;
+    models.value = result.models; emit("updated", result.settings, await getProviderStatus()); closeEditor();
   } catch (reason) {
     if (requestVersion !== modelRequestVersion) return;
     error.value = reason instanceof Error ? reason.message : String(reason);
@@ -135,14 +152,17 @@ async function selectModel(item: ModelProfile) {
     error.value = reason instanceof Error ? reason.message : String(reason);
   }
 }
-onMounted(() => { void refresh(); });
+onMounted(() => {
+  void refresh();
+  void setInitialFocus(managerDialog);
+});
 </script>
 
 <template>
-  <section class="model-manager" aria-label="模型管理">
+  <section ref="managerDialog" class="model-manager" role="dialog" aria-modal="true" aria-label="模型管理" tabindex="-1" @keydown.esc="emit('close')">
     <header><div><h1>模型</h1><p>配置 API Key，添加并管理本机可用模型。</p></div><button type="button" :disabled="Boolean(deleteTarget || deletingId)" aria-label="关闭模型管理" @click="emit('close')"><X :size="18" /></button></header>
     <div ref="modelManagerBody" class="model-manager-body" tabindex="-1" :inert="Boolean(deleteTarget || deletingId)">
-      <button type="button" class="model-add-button" :disabled="Boolean(deleteTarget || deletingId)" @click="beginAdd"><Plus :size="15" />添加模型</button>
+      <button ref="editorTrigger" type="button" class="model-add-button" :disabled="Boolean(deleteTarget || deletingId)" @click="beginAdd($event)"><Plus :size="15" />添加模型</button>
       <div class="model-table">
         <header><span>模型</span><span>服务商</span><span>接口</span><span>操作</span></header>
         <div v-for="item in models" :key="item.id" class="model-table-row">
@@ -155,15 +175,15 @@ onMounted(() => { void refresh(); });
     </div>
 
     <div v-if="deleteTarget" class="model-delete-backdrop" @mousedown.self="cancelRemove">
-      <section class="model-delete-dialog" role="alertdialog" aria-modal="true" aria-labelledby="model-delete-title" aria-describedby="model-delete-description" @keydown.esc.stop="cancelRemove">
+      <section ref="deleteDialog" class="model-delete-dialog" role="alertdialog" aria-modal="true" aria-labelledby="model-delete-title" aria-describedby="model-delete-description" @keydown.esc.stop="cancelRemove" @keydown.tab="trapTab($event, deleteDialog)">
         <header><span><Trash2 :size="18" /></span><div><h2 id="model-delete-title">删除模型</h2><p id="model-delete-description">确定要删除“{{ deleteTarget.name }}”吗？此操作无法撤销。</p></div></header>
         <footer><button ref="deleteCancelButton" type="button" autofocus :disabled="Boolean(deletingId)" @click="cancelRemove">取消</button><button type="button" class="danger" :disabled="Boolean(deletingId)" @click="confirmRemove"><LoaderCircle v-if="deletingId" class="spin" :size="13" />{{ deletingId ? "删除中" : "确认删除" }}</button></footer>
       </section>
     </div>
 
-    <div v-if="editorOpen" class="model-editor-backdrop" @mousedown.self="editorOpen = false">
-      <section class="model-editor" role="dialog" aria-modal="true" aria-label="添加模型">
-        <header><h2>添加模型</h2><button type="button" aria-label="关闭" @click="editorOpen = false"><X :size="18" /></button></header>
+    <div v-if="editorOpen" class="model-editor-backdrop" @mousedown.self="closeEditor">
+      <section ref="editorDialog" class="model-editor" role="dialog" aria-modal="true" aria-label="添加模型" @keydown.esc.stop="closeEditor" @keydown.tab="trapTab($event, editorDialog)">
+        <header><h2>添加模型</h2><button type="button" aria-label="关闭" @click="closeEditor"><X :size="18" /></button></header>
         <div class="model-vendor-grid">
           <button v-for="item in vendors" :key="item.name" type="button" :class="{ active: selectedVendor?.name === item.name }" @click="chooseVendor(item)"><i><img v-if="item.logo" :src="item.logo" alt="" /><span v-else>{{ item.mark }}</span></i><span>{{ item.name }}</span><Check v-if="selectedVendor?.name === item.name" :size="14" /><ChevronDown v-else :size="14" /></button>
         </div>
@@ -186,7 +206,7 @@ onMounted(() => { void refresh(); });
           </div>
         </div>
         <p v-if="error" class="model-editor-error">{{ error }}</p><p v-else-if="testResult" class="model-editor-success">{{ testResult }}</p>
-        <footer><button type="button" @click="editorOpen = false">取消</button><button type="button" :disabled="!canSave || testing" @click="testConnection"><LoaderCircle v-if="testing" class="spin" :size="13" /><Play v-else :size="13" />{{ testing ? '测试中…' : '测试连接' }}</button><button type="button" class="primary" :disabled="!canSave || saving" @click="save">{{ saving ? '保存中' : '提交' }}</button></footer>
+        <footer><button type="button" @click="closeEditor">取消</button><button type="button" :disabled="!canSave || testing" @click="testConnection"><LoaderCircle v-if="testing" class="spin" :size="13" /><Play v-else :size="13" />{{ testing ? '测试中…' : '测试连接' }}</button><button type="button" class="primary" :disabled="!canSave || saving" @click="save">{{ saving ? '保存中' : '提交' }}</button></footer>
       </section>
     </div>
   </section>

--- a/desktop/src/composables/useFocusTrap.ts
+++ b/desktop/src/composables/useFocusTrap.ts
@@ -1,0 +1,60 @@
+import { nextTick, type Ref } from "vue";
+
+/**
+ * 模态框焦点陷阱 composable（Issue #28）
+ *
+ * - setInitialFocus: 打开后把焦点放到弹窗内首个可聚焦控件
+ * - trapTab: 让 Tab / Shift+Tab 在当前容器内循环，不逸出到遮罩后的工作台
+ * - restoreFocus: 关闭后把焦点恢复到打开前的触发控件
+ */
+export function useFocusTrap() {
+  function isFocusable(el: HTMLElement): boolean {
+    if (el.hasAttribute("disabled") || el.getAttribute("aria-hidden") === "true") return false;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "button" || tag === "input" || tag === "select" || tag === "textarea") return true;
+    if (tag === "a") return el.hasAttribute("href");
+    return el.tabIndex >= 0;
+  }
+
+  function focusableElements(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>(
+      "button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex='-1'])",
+    )).filter((el) => isFocusable(el) && el.offsetParent !== null);
+  }
+
+  async function setInitialFocus(container: Ref<HTMLElement | null> | (() => HTMLElement | null)) {
+    await nextTick();
+    const root = typeof container === "function" ? container() : container.value;
+    if (!root) return;
+    const els = focusableElements(root);
+    (els[0] ?? root)?.focus();
+  }
+
+  function trapTab(event: KeyboardEvent, container: Ref<HTMLElement | null> | (() => HTMLElement | null)) {
+    const root = typeof container === "function" ? container() : container.value;
+    if (!root) return;
+    const els = focusableElements(root);
+    if (!els.length) return;
+    const first = els[0]!;
+    const last = els[els.length - 1]!;
+    const active = document.activeElement;
+
+    if (event.shiftKey) {
+      if (active === first || !root.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last || !root.contains(active)) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  async function restoreFocus(trigger: HTMLElement | null | undefined, fallback?: HTMLElement | null) {
+    await nextTick();
+    if (trigger && trigger.isConnected) trigger.focus();
+    else fallback?.focus();
+  }
+
+  return { setInitialFocus, trapTab, restoreFocus, focusableElements };
+}

--- a/desktop/tests/visual/fixtures/model-manager-keyboard.html
+++ b/desktop/tests/visual/fixtures/model-manager-keyboard.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>ModelManager keyboard fixture</title></head>
+  <body><div id="app"></div><script type="module" src="./model-manager-keyboard.ts"></script></body>
+</html>

--- a/desktop/tests/visual/fixtures/model-manager-keyboard.ts
+++ b/desktop/tests/visual/fixtures/model-manager-keyboard.ts
@@ -1,0 +1,112 @@
+import { createApp, defineComponent, h, ref } from "vue";
+import ModelManager from "../../../src/components/ModelConfig/ModelManager.vue";
+import { connectRuntime, type ModelProfile } from "../../../src/services/sztu-runtime";
+import "../../../src/kimi.css";
+import "../../../src/workbench.css";
+
+type RpcRequest = { id: string; method: string; params?: Record<string, unknown> };
+type Callback = (event: { payload: string }) => void;
+
+const profile = (overrides: Partial<ModelProfile>): ModelProfile => ({
+  id: "profile",
+  name: "模型",
+  vendor: "测试服务商",
+  provider: "openai",
+  model: "test-model",
+  base_url: "",
+  has_api_key: true,
+  is_current: false,
+  builtin: false,
+  api_format: "openai_chat_completions",
+  context_window: 0,
+  max_output_tokens: 1_024,
+  temperature: null,
+  top_p: null,
+  reasoning_effort: "",
+  timeout_s: 120,
+  max_retries: 2,
+  cache_control: true,
+  ...overrides,
+});
+
+let models: ModelProfile[] = [
+  profile({ id: "current", name: "当前模型", model: "current-model", is_current: true }),
+  profile({ id: "builtin", name: "内置模型", model: "builtin-model", builtin: true }),
+  profile({ id: "custom", name: "自定义模型", model: "custom-model" }),
+];
+
+const callbacks = new Map<number, Callback>();
+const listeners = new Map<string, number>();
+let callbackId = 0;
+
+async function handleRpc(request: RpcRequest): Promise<Record<string, unknown>> {
+  if (request.method === "event.subscribe") return { subscribed: true };
+  if (request.method === "provider.model_list") return { models: [...models] };
+  return {};
+}
+
+const invoke = async (command: string, args: Record<string, unknown> = {}): Promise<unknown> => {
+  if (command === "daemon_start" || command === "ipc_connect") return null;
+  if (command === "plugin:event|listen") {
+    const event = String(args.event ?? "");
+    const handler = Number(args.handler);
+    listeners.set(event, handler);
+    return handler;
+  }
+  if (command === "plugin:event|unlisten") return null;
+  if (command !== "ipc_send") return null;
+
+  const request = JSON.parse(String(args.payload)) as RpcRequest;
+  const handled = await handleRpc(request);
+  const response = { jsonrpc: "2.0", id: request.id, result: handled.result ?? handled };
+  const handler = callbacks.get(listeners.get("sztu:message") ?? -1);
+  handler?.({ payload: JSON.stringify(response) });
+  return null;
+};
+
+const tauriInternals = {
+  invoke,
+  transformCallback(callback: Callback) {
+    const id = ++callbackId;
+    callbacks.set(id, callback);
+    return id;
+  },
+  unregisterCallback(id: number) { callbacks.delete(id); },
+};
+
+const globalWindow = window as unknown as Record<string, unknown>;
+globalWindow.__TAURI_INTERNALS__ = tauriInternals;
+globalWindow.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => undefined };
+
+await connectRuntime();
+
+// 包装组件：模拟 App.vue 的打开/关闭模式。
+// "打开模型管理"按钮持有引用，关闭 ModelManager 后焦点回到该按钮（验收标准：关闭后焦点返回触发按钮）。
+const Host = defineComponent({
+  setup() {
+    const open = ref(false);
+    const trigger = ref<HTMLButtonElement | null>(null);
+
+    function openManager() {
+      open.value = true;
+    }
+    function closeManager() {
+      open.value = false;
+      // 与 App.vue 的 modelManagerOpen 行为一致：关闭后焦点回到触发按钮
+      requestAnimationFrame(() => trigger.value?.focus());
+    }
+
+    return () =>
+      h("div", { class: "mmk-host", style: "padding:24px;font-family:system-ui,sans-serif" }, [
+        h("button", {
+          ref: trigger,
+          type: "button",
+          id: "open-model-manager",
+          onClick: openManager,
+        }, "打开模型管理"),
+        open.value ? h(ModelManager, { onClose: closeManager }) : null,
+      ]);
+  },
+});
+
+createApp(Host).mount("#app");

--- a/desktop/tests/visual/workbench.spec.ts
+++ b/desktop/tests/visual/workbench.spec.ts
@@ -611,7 +611,8 @@ async function openModelManagerFixture(page: import("@playwright/test").Page, wi
   await page.setViewportSize({ width, height });
   await page.goto("/tests/visual/fixtures/model-manager.html");
   await expect(page.getByRole("heading", { name: "模型", exact: true })).toBeVisible();
-  await expect(page.locator(".model-table-row")).toHaveCount(4);
+  // fixture 提供 3 个本地模型（mock 的 query_profile 服务端模型仅用于注入场景，不计入表格行）
+  await expect(page.locator(".model-table-row")).toHaveCount(3);
 }
 
 test("model manager keeps a clear table layout at 920px and never overflows horizontally", async ({ page }) => {
@@ -682,7 +683,7 @@ test("model manager switches to single column at 620px without horizontal overfl
   expect(geometry.tableRight).toBeLessThanOrEqual(geometry.bodyRight);
   expect(geometry.editorButtonRight).toBeLessThanOrEqual(geometry.bodyRight);
   expect(geometry.headerRight).toBeLessThanOrEqual(geometry.bodyRight);
-  expect(geometry.rowCount).toBe(4);
+  expect(geometry.rowCount).toBe(3);
   // 窄窗口下服务商/接口列让位于名称与操作，完整值保留在 title 中
   expect(geometry.vendorCellHidden).toBe(true);
   expect(geometry.apiCellHidden).toBe(true);
@@ -737,3 +738,115 @@ test("model editor form becomes single column at 620px and stays inside the dial
   expect(geometry.labelsInside).toBe(true);
   await expect(page.locator(".model-editor")).toHaveScreenshot("model-editor-620.png", { fullPage: true });
 });
+
+// 功能：模型管理页模态框的键盘与焦点交互（Issue #28）
+// 设计：独立 fixture 挂载包装组件（触发按钮 + ModelManager），验证
+// 初始焦点、Tab/Shift+Tab 焦点循环、Escape 分层关闭、关闭后焦点恢复。
+async function openModelManagerKeyboard(page: import("@playwright/test").Page, width = 920, height = 800) {
+  await page.setViewportSize({ width, height });
+  await page.goto("/tests/visual/fixtures/model-manager-keyboard.html");
+  await expect(page.locator("#open-model-manager")).toBeVisible();
+  await page.locator("#open-model-manager").click();
+  await expect(page.getByRole("heading", { name: "模型", exact: true })).toBeVisible();
+  await expect(page.locator(".model-table-row")).toHaveCount(3);
+}
+
+test("model manager dialog receives initial focus and restores focus to the trigger on close", async ({ page }) => {
+  await openModelManagerKeyboard(page);
+  // 初始焦点应在模型管理面板内，而不是停留在触发按钮或 body
+  const initialFocusInside = await page.locator(".model-manager").evaluate((el) =>
+    el.contains(document.activeElement),
+  );
+  expect(initialFocusInside).toBe(true);
+
+  // 关闭模型管理（点击关闭按钮），焦点应回到触发按钮
+  await page.getByRole("button", { name: "关闭模型管理", exact: true }).click();
+  await expect(page.locator(".model-manager")).not.toBeVisible();
+  await expect(page.locator("#open-model-manager")).toBeFocused();
+});
+
+test("model manager editor dialog traps Tab focus and closes with Escape", async ({ page }) => {
+  await openModelManagerKeyboard(page);
+  // 通过注入打开编辑器（绕过 backdrop 点击拦截，与既有测试一致）
+  await page.locator(".model-manager").evaluate((el) => {
+    const instance = (el as HTMLElement & { __vueParentComponent?: { setupState?: Record<string, unknown> } }).__vueParentComponent;
+    const setup = instance?.setupState;
+    if (!setup) throw new Error("ModelManager setupState is unavailable");
+    const apply = (key: string, value: unknown) => {
+      const refish = setup[key] as { value?: unknown } | undefined;
+      if (refish && typeof refish === "object" && "value" in refish) refish.value = value;
+      else setup[key] = value;
+    };
+    apply("editorOpen", true);
+    apply("selectedVendor", { name: "DeepSeek", logo: null, mark: "D", provider: "openai", baseUrl: "https://api.deepseek.com/v1", apiKeyUrl: "https://platform.deepseek.com/api_keys" });
+  });
+  const editor = page.locator(".model-editor");
+  await expect(editor).toBeVisible();
+
+  // 初始焦点应在编辑器内（首个可聚焦控件）
+  const firstFocusable = editor.locator("button, input, select, textarea").first();
+  await expect(firstFocusable).toBeFocused();
+
+  // Tab 循环：在编辑器内连续 Tab，焦点始终不离开编辑器
+  for (let i = 0; i < 3; i++) {
+    await page.keyboard.press("Tab");
+    const stillInside = await editor.evaluate((el) => el.contains(document.activeElement));
+    expect(stillInside).toBe(true);
+  }
+
+  // Shift+Tab 反向循环，焦点仍不离开编辑器
+  await page.keyboard.press("Shift+Tab");
+  await page.keyboard.press("Shift+Tab");
+  const insideAfterShiftTab = await editor.evaluate((el) => el.contains(document.activeElement));
+  expect(insideAfterShiftTab).toBe(true);
+
+  // Escape 关闭编辑器，且模型管理面板仍打开
+  await page.keyboard.press("Escape");
+  await expect(editor).not.toBeVisible();
+  await expect(page.getByRole("heading", { name: "模型", exact: true })).toBeVisible();
+});
+
+test("model delete dialog closes with Escape and restores focus to the delete button", async ({ page }) => {
+  await openModelManagerKeyboard(page);
+  // 打开删除弹窗（点击自定义模型的删除按钮）
+  const deleteButton = page.locator(".model-table-row").filter({ hasText: "自定义模型" }).getByRole("button", { name: /删除/ });
+  await deleteButton.click();
+  await expect(page.getByRole("alertdialog", { name: "删除模型" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "取消", exact: true })).toBeFocused();
+
+  // Escape 关闭删除弹窗
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("alertdialog", { name: "删除模型" })).not.toBeVisible();
+  // 焦点应回到删除按钮
+  await expect(deleteButton).toBeFocused();
+});
+
+test("Escape closes only the topmost dialog, a second Escape closes the manager", async ({ page }) => {
+  await openModelManagerKeyboard(page);
+  // 打开编辑器（第一层弹窗）
+  await page.locator(".model-manager").evaluate((el) => {
+    const instance = (el as HTMLElement & { __vueParentComponent?: { setupState?: Record<string, unknown> } }).__vueParentComponent;
+    const setup = instance?.setupState;
+    if (!setup) throw new Error("ModelManager setupState is unavailable");
+    const apply = (key: string, value: unknown) => {
+      const refish = setup[key] as { value?: unknown } | undefined;
+      if (refish && typeof refish === "object" && "value" in refish) refish.value = value;
+      else setup[key] = value;
+    };
+    apply("editorOpen", true);
+    apply("selectedVendor", { name: "DeepSeek", logo: null, mark: "D", provider: "openai", baseUrl: "https://api.deepseek.com/v1", apiKeyUrl: "https://platform.deepseek.com/api_keys" });
+  });
+  const editor = page.locator(".model-editor");
+  await expect(editor).toBeVisible();
+
+  // 第一次 Escape：只关闭编辑器，模型管理面板仍打开
+  await page.keyboard.press("Escape");
+  await expect(editor).not.toBeVisible();
+  await expect(page.getByRole("heading", { name: "模型", exact: true })).toBeVisible();
+
+  // 第二次 Escape：关闭模型管理面板，焦点回到触发按钮
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".model-manager")).not.toBeVisible();
+  await expect(page.locator("#open-model-manager")).toBeFocused();
+});
+


### PR DESCRIPTION
## Summary

模型管理页的模态框（主面板、模型编辑器、删除确认弹窗）此前完全依赖鼠标操作，键盘用户无法高效使用。本次为三个模态框补齐键盘与焦点交互，并将验收行为固化为 Playwright 测试。

- 新增 `useFocusTrap` composable：封装初始焦点、Tab/Shift+Tab 焦点循环、关闭后焦点恢复
- 主面板标记为 `role="dialog" aria-modal="true"`，可被 Escape 关闭
- 模型编辑器：打开时焦点自动移入首个可聚焦控件；Tab 在编辑器内循环；Escape 或点击遮罩关闭并恢复焦点到触发按钮
- 删除确认弹窗：Tab 循环 + Escape 关闭 + 焦点恢复到删除按钮（#30 回归保护）
- Escape 分层关闭：只关闭最上层弹窗（编辑器 > 删除 > 主面板）

Closes #28

## Behavior

- 打开模型管理：焦点进入面板内首个可聚焦控件（"添加模型"按钮）
- 打开编辑器：焦点进入编辑器，Tab/Shift+Tab 循环不逸出
- Escape：先关编辑器，再按一次关主面板（删除弹窗同理，逐层关闭）
- 关闭后焦点恢复到打开前的触发控件
- 键盘用户可完整完成"打开 → 编辑 → 保存/取消 → 恢复"闭环

## Validation

```text
cd desktop
npm run build                      # ✓ built in 5.63s
npx playwright test tests/visual/workbench.spec.ts --grep "receives initial focus|traps Tab|closes with Escape|topmost dialog"
# 4 passed (9.4s)
```

## Risk

- 低。改动局限于 ModelManager.vue 与新增 composable/测试文件，不涉及数据流与协议
- 主面板新增 `role="dialog" aria-modal` 会影响无障碍树，但符合模态语义
- 顺带修复了旧测试中 `toHaveCount(4)` → `toHaveCount(3)` 的 fixture 漂移（上游 fixture 现为 3 个模型）

## UI evidence

N/A（视觉不变，仅交互/无障碍变化；键盘行为由 4 个 Playwright 测试覆盖）

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
