### PR TITLE
fix(ci): wrap over-long lines to satisfy ruff E501

### DIFF
--- a/src/sztu_code/core/app.py
+++ b/src/sztu_code/core/app.py
@@ -783,19 +783,33 @@ class CoreApp:
     def _activate_model_profile(self, profile: dict[str, Any]) -> None:
         assert self._config is not None
         self._config.llm.provider = str(profile["provider"])
-        self._config.llm.api_format = normalize_api_format(profile.get("api_format"), profile.get("provider"))
+        self._config.llm.api_format = normalize_api_format(
+            profile.get("api_format"), profile.get("provider")
+        )
         self._config.llm.provider = provider_for_api_format(self._config.llm.api_format)
         self._config.llm.default_model = str(profile["model"])
         self._config.llm.base_url = str(profile.get("base_url", ""))
         self._config.llm.api_key = str(profile.get("api_key", ""))
         self._config.llm.api_key_env = str(profile.get("api_key_env", ""))
         self._config.llm.keyless = bool(profile.get("keyless"))
-        for name, default in (("context_window", 0), ("max_output_tokens", 8192), ("max_retries", 2)):
+        for name, default in (
+            ("context_window", 0),
+            ("max_output_tokens", 8192),
+            ("max_retries", 2),
+        ):
             value = profile.get(name, default)
             setattr(self._config.llm, name, int(default if value is None else value))
-        for name, default in (("temperature", None), ("top_p", None), ("timeout_s", 120.0)):
+        for name, default in (
+            ("temperature", None),
+            ("top_p", None),
+            ("timeout_s", 120.0),
+        ):
             value = profile.get(name, default)
-            setattr(self._config.llm, name, None if value is None and name != "timeout_s" else float(value or default))
+            setattr(
+                self._config.llm,
+                name,
+                None if value is None and name != "timeout_s" else float(value or default),
+            )
         self._config.llm.reasoning_effort = str(profile.get("reasoning_effort", ""))
         self._config.llm.cache_control = bool(profile.get("cache_control", True))
         if self._sessions is not None:
@@ -831,32 +845,71 @@ class CoreApp:
                 headers["authorization"] = f"Bearer {cmd.api_key}"
         if cmd.api_format == "anthropic_messages":
             url = f"{base_url}/messages"
-            body: dict[str, Any] = {"model": cmd.model, "max_tokens": 1, "messages": [{"role": "user", "content": "Reply OK."}]}
+            body: dict[str, Any] = {
+                "model": cmd.model,
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "Reply OK."}],
+            }
         elif cmd.api_format == "openai_responses":
             url = f"{base_url}/responses"
             body = {"model": cmd.model, "input": "Reply OK.", "max_output_tokens": 1}
         else:
             url = f"{base_url}/chat/completions"
-            body = {"model": cmd.model, "messages": [{"role": "user", "content": "Reply OK."}], "max_completion_tokens": 1}
+            body = {
+                "model": cmd.model,
+                "messages": [{"role": "user", "content": "Reply OK."}],
+                "max_completion_tokens": 1,
+            }
         try:
             async with httpx.AsyncClient(timeout=cmd.timeout_s, trust_env=False) as client:
                 response = await client.post(url, headers=headers, json=body)
                 response.raise_for_status()
                 usage = response.json().get("usage") or {}
             elapsed = (time.perf_counter() - started) * 1000
-            return ModelTestResult(success=True, api_format=cmd.api_format, model=cmd.model, elapsed_ms=elapsed, input_tokens=int(usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0), output_tokens=int(usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0))
+            return ModelTestResult(
+                success=True,
+                api_format=cmd.api_format,
+                model=cmd.model,
+                elapsed_ms=elapsed,
+                input_tokens=int(
+                    usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
+                ),
+                output_tokens=int(
+                    usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0
+                ),
+            )
         except (httpx.HTTPError, ValueError) as error:
-            return ModelTestResult(success=False, api_format=cmd.api_format, model=cmd.model, elapsed_ms=(time.perf_counter() - started) * 1000, error=str(error))
+            return ModelTestResult(
+                success=False,
+                api_format=cmd.api_format,
+                model=cmd.model,
+                elapsed_ms=(time.perf_counter() - started) * 1000,
+                error=str(error),
+            )
 
     # 重复运行端点探测并汇总延迟，供模型管理页比较可用性与稳定性
     # 接收单次连通性测试请求并返回可展示的耗时、用量或错误信息
     async def _model_benchmark_handler(self, params: dict[str, Any]) -> ModelBenchmarkResult:
         cmd = ModelBenchmarkCommand.model_validate(params)
-        results = [await self._probe_model(ModelTestCommand.model_validate(cmd.model_dump())) for _ in range(cmd.samples)]
+        results = [
+            await self._probe_model(ModelTestCommand.model_validate(cmd.model_dump()))
+            for _ in range(cmd.samples)
+        ]
         latencies = sorted(result.elapsed_ms for result in results if result.success)
         errors = [result.error for result in results if result.error]
         index = min(len(latencies) - 1, round((len(latencies) - 1) * .95)) if latencies else 0
-        return ModelBenchmarkResult(api_format=cmd.api_format, model=cmd.model, samples=cmd.samples, successful=len(latencies), failed=cmd.samples - len(latencies), min_ms=min(latencies) if latencies else None, median_ms=statistics.median(latencies) if latencies else None, p95_ms=latencies[index] if latencies else None, max_ms=max(latencies) if latencies else None, errors=errors)
+        return ModelBenchmarkResult(
+            api_format=cmd.api_format,
+            model=cmd.model,
+            samples=cmd.samples,
+            successful=len(latencies),
+            failed=cmd.samples - len(latencies),
+            min_ms=min(latencies) if latencies else None,
+            median_ms=statistics.median(latencies) if latencies else None,
+            p95_ms=latencies[index] if latencies else None,
+            max_ms=max(latencies) if latencies else None,
+            errors=errors,
+        )
 
     async def _model_test_handler(self, params: dict[str, Any]) -> ModelTestResult:
         return await self._probe_model(ModelTestCommand.model_validate(params))
@@ -890,7 +943,16 @@ class CoreApp:
             self._config.llm.api_key = cmd.api_key
             self._config.llm.api_key_env = ""
             updated.append("api_key")
-        for name in ("max_output_tokens", "temperature", "top_p", "reasoning_effort", "timeout_s", "max_retries", "context_window", "cache_control"):
+        for name in (
+            "max_output_tokens",
+            "temperature",
+            "top_p",
+            "reasoning_effort",
+            "timeout_s",
+            "max_retries",
+            "context_window",
+            "cache_control",
+        ):
             value = getattr(cmd, name)
             if value is not None and value != getattr(self._config.llm, name):
                 setattr(self._config.llm, name, value)
@@ -912,7 +974,22 @@ class CoreApp:
         if updated:
             profiles, active_id = self._stored_model_profiles()
             if any(
-                field in updated for field in ("provider", "api_format", "model", "base_url", "api_key", "max_output_tokens", "temperature", "top_p", "reasoning_effort", "timeout_s", "max_retries", "context_window", "cache_control")
+                field in updated
+                for field in (
+                    "provider",
+                    "api_format",
+                    "model",
+                    "base_url",
+                    "api_key",
+                    "max_output_tokens",
+                    "temperature",
+                    "top_p",
+                    "reasoning_effort",
+                    "timeout_s",
+                    "max_retries",
+                    "context_window",
+                    "cache_control",
+                )
             ):
                 current = next(
                     (item for item in profiles if item.get("id") == active_id), None
@@ -941,10 +1018,27 @@ class CoreApp:
                     }
                 )
             save_client_settings(
-                self._config, models=profiles, active_model_id=active_id
+                self._config,
+                models=profiles,
+                active_model_id=active_id,
             )
         if self._sessions is not None and any(
-            field in updated for field in ("provider", "api_format", "model", "base_url", "api_key", "max_output_tokens", "temperature", "top_p", "reasoning_effort", "timeout_s", "max_retries", "context_window", "cache_control")
+            field in updated
+            for field in (
+                "provider",
+                "api_format",
+                "model",
+                "base_url",
+                "api_key",
+                "max_output_tokens",
+                "temperature",
+                "top_p",
+                "reasoning_effort",
+                "timeout_s",
+                "max_retries",
+                "context_window",
+                "cache_control",
+            )
         ):
             key_name = (
                 "OPENAI_API_KEY"

--- a/src/sztu_code/core/compact/context_usage.py
+++ b/src/sztu_code/core/compact/context_usage.py
@@ -31,28 +31,67 @@ def _is_summary_message(message: dict[str, object]) -> bool:
     if isinstance(content, str):
         return "This session is being continued" in content and "Summary:" in content
     if isinstance(content, list):
-        return any(isinstance(block, dict) and "continue from this summary" in str(block.get("text", "")).lower() for block in content)
+        return any(
+            isinstance(block, dict)
+            and "continue from this summary" in str(block.get("text", "")).lower()
+            for block in content
+        )
     return False
 
 
-def estimate_context_usage(*, messages: list[dict[str, object]], tool_schemas: list[dict[str, object]], system: str, actual_input_tokens: int, context_window: int, reserved_output_tokens: int) -> ContextUsageBreakdown:
+def estimate_context_usage(
+    *,
+    messages: list[dict[str, object]],
+    tool_schemas: list[dict[str, object]],
+    system: str,
+    actual_input_tokens: int,
+    context_window: int,
+    reserved_output_tokens: int,
+) -> ContextUsageBreakdown:
     """Estimate explainable context categories and reconcile them to provider usage."""
     counter = TokenCounter()
-    raw = {"system": _count(counter, system), "summary": 0, "conversation": 0, "tools": _count(counter, tool_schemas)}
+    raw = {
+        "system": _count(counter, system),
+        "summary": 0,
+        "conversation": 0,
+        "tools": _count(counter, tool_schemas),
+    }
     for message in messages:
         if _is_summary_message(message):
             raw["summary"] += _count(counter, message)
             continue
         content = message.get("content")
         if isinstance(content, list):
-            tool_blocks = [block for block in content if isinstance(block, dict) and block.get("type") in {"tool_use", "tool_result"}]
+            tool_blocks = [
+                block
+                for block in content
+                if isinstance(block, dict) and block.get("type") in {"tool_use", "tool_result"}
+            ]
             raw["tools"] += _count(counter, tool_blocks)
-            raw["conversation"] += _count(counter, [block for block in content if block not in tool_blocks])
+            raw["conversation"] += _count(
+                counter, [block for block in content if block not in tool_blocks]
+            )
         else:
             raw["conversation"] += _count(counter, content)
     estimated_total = sum(raw.values())
-    scale = actual_input_tokens / estimated_total if actual_input_tokens > 0 and estimated_total > 0 else 1.0
+    scale = (
+        actual_input_tokens / estimated_total
+        if actual_input_tokens > 0 and estimated_total > 0
+        else 1.0
+    )
     values = {key: max(0, round(value * scale)) for key, value in raw.items()}
-    values["conversation"] = max(0, values["conversation"] + actual_input_tokens - sum(values.values()))
-    reserved = min(max(0, reserved_output_tokens), max(0, context_window - actual_input_tokens))
-    return ContextUsageBreakdown(context_window, max(0, context_window - actual_input_tokens - reserved), reserved, values["system"], values["summary"], values["conversation"], values["tools"])
+    values["conversation"] = max(
+        0, values["conversation"] + actual_input_tokens - sum(values.values())
+    )
+    reserved = min(
+        max(0, reserved_output_tokens), max(0, context_window - actual_input_tokens)
+    )
+    return ContextUsageBreakdown(
+        context_window,
+        max(0, context_window - actual_input_tokens - reserved),
+        reserved,
+        values["system"],
+        values["summary"],
+        values["conversation"],
+        values["tools"],
+    )

--- a/src/sztu_code/core/workspace/manager.py
+++ b/src/sztu_code/core/workspace/manager.py
@@ -113,7 +113,11 @@ class WorkspaceManager:
         root = Path(workspace.path)
         branch = self._git(root, ["branch", "--show-current"]).strip()
         changes = self._git(root, ["status", "--short"])
-        changed_files = [line for line in changes.splitlines() if line and not self._is_ignored_status_line(line)]
+        changed_files = [
+            line
+            for line in changes.splitlines()
+            if line and not self._is_ignored_status_line(line)
+        ]
         return {
             "workspace": workspace,
             "branch": branch or None,


### PR DESCRIPTION
## Summary

修复 Python CI 的 Ruff 步骤持续失败问题（21 处 E501 行超长）。

上游 main 的 Python CI 自 8 月 8 日起持续失败，原因是 3 个功能型提交（b75a6b4 / 1a6bdd1 / d77cc7b）带入了超过 100 列的行，Ruff 检查随即变红，并阻塞了后续所有 PR 的 CI 验证。

本次将 21 处超长行全部按 100 列上限拆行，**纯格式变更，无任何逻辑/行为变化**。

## Behavior

- `ruff check src tests scripts` 从 21 errors 变为 All checks passed
- Python CI 的 Ruff / mypy / pytest / 协议文档检查步骤可恢复执行

## Validation

```text
ruff check src tests scripts   # All checks passed!
py_compile 3 个修改文件          # 语法通过
tests/unit/test_context_usage.py  # 2 passed（改动核心文件的测试）
```

本地 Windows 环境因 pytest 临时目录权限问题（WinError 5，CI 为 Linux 不受影响）无法跑全部测试，但改动为纯格式拆行，已用 py_compile + 直接相关测试验证。

## Risk

- 极低。改动仅拆行长行（元组换行、函数参数换行），不涉及任何执行逻辑
- 涉及文件：app.py（12 处）、context_usage.py（9 处）、workspace/manager.py（1 处）

## UI evidence

N/A

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。