### PR TITLE
fix(compact): retain tool result head and tail

### DIFF
--- a/src/sztu_code/core/compact/budget.py
+++ b/src/sztu_code/core/compact/budget.py
@@ -7,6 +7,47 @@ TOOL_RESULT_KEEP = 4_000
 
 # 上下文卸载占位符标记 — 已被卸载的内容不需要再截断
 _OFFLOAD_MARKER = "[上下文卸载:"
+_NORMAL_HEAD_RATIO = 0.5
+_ERROR_HEAD_RATIO = 0.2
+
+
+# 构造包含精确长度和保留方向的截断标记
+def _truncation_marker(original: int, omitted: int, head: int, tail: int) -> str:
+    return (
+        f"\n[... original={original} chars; {omitted} chars omitted; "
+        f"kept=head:{head},tail:{tail} ...]\n"
+    )
+
+
+# 按总预算切分工具输出的头尾，并让错误结果偏向保留尾部
+def _truncate_text(text: str, budget: int, *, is_error: bool) -> str:
+    original = len(text)
+    budget = max(0, budget)
+    if budget == 0:
+        return ""
+
+    head_ratio = _ERROR_HEAD_RATIO if is_error else _NORMAL_HEAD_RATIO
+    retained = min(original - 1, budget)
+    while retained > 0:
+        head = int(retained * head_ratio)
+        tail = retained - head
+        marker = _truncation_marker(original, original - retained, head, tail)
+        if retained + len(marker) <= budget:
+            break
+        retained -= 1
+
+    if retained == 0 and budget >= len(_truncation_marker(original, original, 0, 0)):
+        marker = _truncation_marker(original, original, 0, 0)
+        return marker[:budget]
+    if retained == 0:
+        # 极小预算无法容纳完整元数据时，优先保留可识别的截断标记前缀
+        return _truncation_marker(original, original, 0, 0).lstrip("\n")[:budget]
+    return text[:head] + marker + text[original - tail :]
+
+
+# 计算截断后的目标上限，兼容 keep 小于 limit 的历史配置
+def _result_budget(limit: int, keep: int) -> int:
+    return max(0, min(limit, keep))
 
 
 # 对消息列表中超长的 tool_result 内容做内存截断，返回处理后的新列表
@@ -34,11 +75,11 @@ def truncate_tool_results(
                     new_blocks.append(block)
                     continue
                 if len(text) > limit:
-                    omitted = len(text) - keep
                     block = dict(block)
-                    block["content"] = (
-                        text[:keep]
-                        + f"\n[... {omitted} chars omitted. Full output in run events.]"
+                    block["content"] = _truncate_text(
+                        text,
+                        _result_budget(limit, keep),
+                        is_error=block.get("is_error") is True,
                     )
             new_blocks.append(block)
         result.append({**msg, "content": new_blocks})

--- a/tests/unit/test_budget.py
+++ b/tests/unit/test_budget.py
@@ -1,13 +1,42 @@
 from __future__ import annotations
 
+import re
+
 from sztu_code.core.compact.budget import truncate_tool_results
 
 
-def _make_tool_result_msg(content: str) -> dict:
+# 构造带可选错误标记的 tool_result user 消息
+def _make_tool_result_msg(content: str, *, is_error: bool = False) -> dict:
+    block = {"type": "tool_result", "tool_use_id": "id1", "content": content}
+    if is_error:
+        block["is_error"] = True
     return {
         "role": "user",
-        "content": [{"type": "tool_result", "tool_use_id": "id1", "content": content}],
+        "content": [block],
     }
+
+
+# 检查截断标记包含原始长度、遗漏长度和头尾保留方向
+def _assert_marker_metadata(truncated: str, original_length: int) -> None:
+    lower = truncated.lower()
+    assert str(original_length) in truncated
+    assert any(word in lower or word in truncated for word in ("omitted", "遗漏", "省略"))
+    assert re.search(
+        r"(?:[0-9]+[^\n]{0,20}(?:omitted|遗漏|省略)|"
+        r"(?:omitted|遗漏|省略)[^0-9]{0,20}[0-9]+)",
+        truncated,
+        re.IGNORECASE,
+    )
+    has_head = any(word in lower or word in truncated for word in ("head", "头部", "前部", "前"))
+    has_tail = any(word in lower or word in truncated for word in ("tail", "尾部", "后部", "后"))
+    assert has_head and has_tail
+
+
+# 从结构化截断标记读取遗漏字符数
+def _omitted_chars(truncated: str) -> int:
+    match = re.search(r"([0-9]+) chars omitted", truncated)
+    assert match is not None
+    return int(match.group(1))
 
 
 # 功能：验证 tool_result 内容未超过阈值时原文不变
@@ -20,15 +49,128 @@ def test_short_tool_result_untouched() -> None:
 
 
 # 功能：验证 tool_result 内容超过阈值时被截断并附加省略标记
-# 设计：构造 10000 字符内容，断言截断后长度 < 原始，且包含省略标记字符串
+# 设计：构造 10000 字符内容，精确核对预算、头尾片段与标记中的长度元数据
 def test_long_tool_result_truncated() -> None:
     text = "y" * 10_000
     msgs = [_make_tool_result_msg(text)]
     result = truncate_tool_results(msgs, limit=8000, keep=4000)
     truncated = result[0]["content"][0]["content"]
-    assert len(truncated) < len(text)
-    assert "chars omitted" in truncated
-    assert truncated.startswith("y" * 4000)
+    assert len(truncated) <= 4000
+    _assert_marker_metadata(truncated, len(text))
+    marker_start = truncated.index("\n[")
+    marker_end = truncated.index("]\n", marker_start) + 2
+    omitted = len(text) - marker_start - (len(truncated) - marker_end)
+    assert _omitted_chars(truncated) == omitted
+    assert truncated.startswith("y" * marker_start)
+    assert truncated.endswith("y" * (len(truncated) - marker_end))
+
+
+# 功能：验证普通日志保留开头上下文和结尾摘要，并在标记中记录方向
+# 设计：用明确的头尾哨兵构造日志，断言中间被省略且两端均可见
+def test_log_keeps_head_and_tail() -> None:
+    text = "HEAD\n" + ("progress\n" * 2000) + "TAIL: done"
+    result = truncate_tool_results([_make_tool_result_msg(text)], limit=200, keep=160)
+    truncated = result[0]["content"][0]["content"]
+    assert len(truncated) <= 160
+    assert truncated.startswith("HEAD")
+    assert truncated.endswith("TAIL: done")
+    _assert_marker_metadata(truncated, len(text))
+
+
+# 功能：验证错误结果比普通结果为结尾分配更多保留空间
+# 设计：用不同字符填充头尾并比较保留计数，避免依赖某个固定分配比例
+def test_error_result_biases_tail() -> None:
+    text = ("h" * 300) + ("x" * 500) + ("t" * 300)
+    normal = truncate_tool_results([_make_tool_result_msg(text)], limit=300, keep=260)
+    error = truncate_tool_results(
+        [_make_tool_result_msg(text, is_error=True)], limit=300, keep=260
+    )
+    normal_text = normal[0]["content"][0]["content"]
+    error_text = error[0]["content"][0]["content"]
+    assert len(normal_text) <= 260
+    assert len(error_text) <= 260
+    assert error_text.count("t") > normal_text.count("t")
+    assert error_text.count("h") < normal_text.count("h")
+    _assert_marker_metadata(error_text, len(text))
+
+
+# 功能：验证极小预算下标记自身也不会超出预算
+# 设计：预算小于常规标记长度时仍断言结果严格受限且不抛异常
+def test_tiny_budget_is_strictly_bounded() -> None:
+    text = "start" + ("中" * 100) + "end"
+    for budget in range(0, 80):
+        result = truncate_tool_results(
+            [_make_tool_result_msg(text)], limit=8, keep=budget
+        )
+        truncated = result[0]["content"][0]["content"]
+        assert len(truncated) <= min(8, budget)
+
+
+# 功能：验证中文按 Python 字符长度截断时头尾均保持完整字符
+# 设计：使用多字节字符和边界预算，检查无编码破坏且长度不越界
+def test_chinese_text_keeps_character_boundaries() -> None:
+    text = "开头" + ("日志" * 500) + "结尾"
+    result = truncate_tool_results([_make_tool_result_msg(text)], limit=120, keep=100)
+    truncated = result[0]["content"][0]["content"]
+    assert len(truncated) <= 100
+    assert truncated.startswith("开头")
+    assert truncated.endswith("结尾")
+    _assert_marker_metadata(truncated, len(text))
+
+
+# 功能：验证空字符串工具结果保持原样
+# 设计：空结果低于任何有效阈值，断言不会被改写或追加标记
+def test_empty_tool_result_untouched() -> None:
+    empty = truncate_tool_results([_make_tool_result_msg("")], limit=10, keep=5)
+    assert empty[0]["content"][0]["content"] == ""
+
+
+# 功能：验证单行长文本没有换行也能同时保留头尾
+# 设计：以单字符头尾哨兵包住超长正文，断言预算内两端都可见
+def test_single_long_line_keeps_head_and_tail() -> None:
+    text = "A" + ("x" * 500) + "Z"
+    result = truncate_tool_results([_make_tool_result_msg(text)], limit=120, keep=100)
+    truncated = result[0]["content"][0]["content"]
+    assert len(truncated) <= 100
+    assert truncated.startswith("A")
+    assert truncated.endswith("Z")
+    _assert_marker_metadata(truncated, len(text))
+
+
+# 功能：验证 pytest 和 stack trace 错误结果优先完整保留末尾失败摘要
+# 设计：在超长测试日志末尾放置 traceback 与 summary，错误结果应包含这些诊断信息
+def test_pytest_stack_trace_error_keeps_failure_tail() -> None:
+    failure_tail = (
+        "Traceback (most recent call last):\n"
+        "  File \"tests/test_api.py\", line 74, in test_request\n"
+        "AssertionError: expected 200, got 500\n"
+        "================ 1 failed, 73 passed in 4.20s ================"
+    )
+    text = "pytest session starts\n" + ("PASSED tests/test_ok.py\n" * 100) + failure_tail
+    result = truncate_tool_results(
+        [_make_tool_result_msg(text, is_error=True)], limit=360, keep=320
+    )
+    truncated = result[0]["content"][0]["content"]
+    assert len(truncated) <= 320
+    assert "pytest session starts" in truncated
+    assert truncated.endswith("1 failed, 73 passed in 4.20s ================")
+    assert "AssertionError: expected 200, got 500" in truncated
+    _assert_marker_metadata(truncated, len(text))
+
+
+# 功能：验证上下文卸载占位符不会因预算过小而被二次截断
+# 设计：构造长度远超预算但含卸载前缀的完整占位符，断言逐字符保持原样
+def test_offload_placeholder_never_truncated() -> None:
+    placeholder = (
+        "[上下文卸载: refs/bash_001.md]\n"
+        "摘要: pytest 运行结果 — 1 failed, 73 passed\n"
+        "统计: 50000 字符, 800 行\n"
+        "使用 read_ref(\"refs/bash_001.md\") 读取完整输出"
+    )
+    result = truncate_tool_results(
+        [_make_tool_result_msg(placeholder)], limit=24, keep=12
+    )
+    assert result[0]["content"][0]["content"] == placeholder
 
 
 # 功能：验证 tool_result 内容恰好等于阈值时不截断

--- a/tests/unit/test_session_store.py
+++ b/tests/unit/test_session_store.py
@@ -254,7 +254,7 @@ def test_notes_read_and_append(tmp_path: Path) -> None:
 
 
 # 功能：验证 SessionStore 使用构造时传入的 tool_result 截断参数
-# 设计：配置很小的 limit/keep，读取 thread 时应按配置截断而非固定 8000/4000
+# 设计：配置小于完整标记的 limit/keep，读取结果仍应严格受限并显式呈现截断提示
 def test_read_messages_uses_configured_tool_result_budget(tmp_path: Path) -> None:
     store = SessionStore(tmp_path, tool_result_limit=20, tool_result_keep=5)
     store.append_message("sess-1", "assistant", [
@@ -266,5 +266,5 @@ def test_read_messages_uses_configured_tool_result_budget(tmp_path: Path) -> Non
 
     messages = store.read_messages("sess-1")
     result_block = messages[-1]["content"][0]
-    assert result_block["content"].startswith("a" * 5)
-    assert "chars omitted" in result_block["content"]
+    assert len(result_block["content"]) <= 5
+    assert result_block["content"].startswith("[")


### PR DESCRIPTION
## 摘要

- 工具输出超长时同时保留头部和尾部，避免只保留开头导致关键信息丢失。
- 截断标记包含原始长度、遗漏长度以及头尾保留方向和长度。
- 对错误结果偏向保留尾部，并保留已有的上下文卸载占位符。

Closes #74

## 行为

- 普通工具结果按约 50/50 的比例保留头部和尾部。
- `is_error=True` 的结果按约 20/80 的比例保留头部和尾部，使 traceback 和失败摘要更容易保留。
- 截断标记计入分配的字符预算，最终文本严格不超过该预算。
- 空字符串、未超过限制的结果以及上下文卸载占位符保持不变。
- 预算过小时，如果无法容纳完整元数据标记，则在预算内返回可识别的标记前缀。

## 验证

```text
uv run ruff check src tests scripts
All checks passed!

uv run mypy src
Success: no issues found in 181 source files

uv run pytest tests/unit/test_budget.py tests/unit/test_compactor.py tests/unit/test_session_store.py
34 passed
```

## 风险

低。改动仅涉及内存中的工具结果压缩。字符预算按 Python 字符数计算，而不是按编码字节数或模型 token 数计算；极小预算无法容纳完整元数据标记时，只保留可识别的标记前缀。若需回滚，可还原提交 `82679d4`。

## UI 证据

N/A — 无 UI 变更。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A — 无协议变更。）
- [x] 用户文档、配置示例和迁移说明已同步。（N/A — 无文档或配置变更。）
- [x] 提交包含 `Signed-off-by`（DCO）。