### PR TITLE
fix(desktop): smooth streaming and Windows workflows

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "tauri": "tauri",
-    "test:unit": "tsx --test tests/playwright-chromium.test.ts tests/platform.test.ts",
+    "test:unit": "tsx --test tests/playwright-chromium.test.ts tests/platform.test.ts tests/timeline-stream.test.ts",
     "test:visual": "playwright test"
   },
   "dependencies": {

--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -22,6 +22,7 @@ import SkillCenter from "./components/Skills/SkillCenter.vue";
 import { slashMenuItems } from "./components/CommandPalette/slash-menu";
 import type { PermissionDecision, PermissionState, PlanItem, TimelineEvent, TimelineStep, ToolCallEntry, WorkflowTaskEntry } from "./components/timeline/types";
 import { isMacOSPlatform } from "./lib/platform";
+import { appendTokenBatch, createTokenFrameBatcher } from "./utils/timelineStream";
 import {
   applyCcswitchProvider, cancelRun, connectRuntime, createSession, deleteWorkspace, getNativeSettings, getProviderStatus, getRuntimeSettings, listCcswitchProviders, listSessions,
   listWorkspaces, onRuntimeDisconnect, onRuntimeEvent, openWorkspace, readAttachments, respondPermission,
@@ -65,6 +66,11 @@ const workspace = ref<Workspace | null>(null);
 const sessions = ref<Session[]>([]);
 const activeId = ref<string | null>(null);
 const timeline = ref<Map<number, TimelineStep>>(new Map());
+const tokenBatcher = createTokenFrameBatcher(
+  ({ runId, step, tokens }) => setStep(step, (current) => appendTokenBatch({ ...current, runId }, tokens)),
+  (callback) => window.requestAnimationFrame(callback),
+  (handle) => window.cancelAnimationFrame(handle),
+);
 const activeRunId = ref<string | null>(null);
 // 当前会话是否正在执行 run（区别于 activeRunId：加载历史任务时 activeRunId 可能是已结束的 run）
 const runActive = ref(false);
@@ -433,6 +439,7 @@ function addUserMessage(content: string) {
   return step;
 }
 function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_tokens: number; output_tokens: number; elapsed_s: number }> = {}) {
+  tokenBatcher.clear();
   const next = new Map<number, TimelineStep>();
   let step = 0;
   for (const message of messages) {
@@ -508,11 +515,13 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
     });
   }
   timeline.value = next;
-}function applyRuntimeEvent(event: RuntimeEvent) {
+}
+function applyRuntimeEvent(event: RuntimeEvent) {
   const type = String(event.type ?? "");
   const runId = String(event.run_id ?? "");
   const relatedRunId = String(event.parent_run_id ?? runId);
   const timelineEvent = event.parent_run_id ? { ...event, run_id: relatedRunId } : event;
+  if (type !== "llm.token" && relatedRunId) tokenBatcher.flushRun(relatedRunId);
   if (type === "run.started" && !activeRunId.value && sending.value) activeRunId.value = runId;
   if (type === "session.created" || type === "session.closed" || type === "session.waiting_for_input") {
     void refreshIndex();
@@ -558,14 +567,7 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
   }
   if (type === "llm.token") {
     const step = stepFor(timelineEvent);
-    setStep(step, (current) => {
-      const token = String(event.token ?? "");
-      const events = [...(current.events ?? [])];
-      const last = events[events.length - 1];
-      if (last?.kind === "text") last.text = `${last.text ?? ""}${token}`;
-      else events.push({ id: `text-live-${runId}-${Date.now()}`, kind: "text", text: token });
-      return { ...current, status: "thinking", tokens: [...current.tokens, token], events };
-    });
+    tokenBatcher.enqueue(relatedRunId, step, String(event.token ?? ""));
     return;
   }
   if (type === "llm.thinking") {
@@ -742,7 +744,7 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
   }
   if (type === "step.finished") {
     const step = Number(event.step ?? stepFor(timelineEvent));
-    setStep(step, (current) => ({ ...current, status: current.status === "acting" ? "observing" : "done", finalText: current.finalText || current.tokens.join("") }));
+    setStep(step, (current) => ({ ...current, status: current.status === "acting" ? "observing" : "done", finalText: current.finalText || current.streamText || current.tokens.join("") }));
     return;
   }
   if (type === "run.finished") {
@@ -751,7 +753,7 @@ function hydrateTimeline(messages: unknown[], runStats: Record<string, { input_t
       setStep(step, (current) => current.runId === relatedRunId ? {
         ...current,
         status: runStatus === "success" ? "done" : "failed",
-        finalText: current.finalText || current.tokens.join(""),
+        finalText: current.finalText || current.streamText || current.tokens.join(""),
         outcome: {
           status: runStatus === "interrupted" ? "interrupted" : (runStatus === "success" ? "success" : "failed"),
           reason: String(event.reason ?? "") || undefined,
@@ -1141,7 +1143,7 @@ function chooseStarterTask(id: string, value: string) {
   prompt.value = value;
   void nextTick(() => launcherPrompt.value?.focus());
 }
-function closeActiveSession() { historyLoadSeq += 1; activeId.value = null; timeline.value = new Map(); activeRunId.value = null; runActive.value = false; void refreshIndex(false); }
+function closeActiveSession() { historyLoadSeq += 1; tokenBatcher.clear(); activeId.value = null; timeline.value = new Map(); activeRunId.value = null; runActive.value = false; void refreshIndex(false); }
 async function loadNativeSettings() {
   try {
     const settings = await getNativeSettings();
@@ -1415,6 +1417,7 @@ onMounted(() => {
   void refreshIndex(true).then(() => { stopEvents = onRuntimeEvent(applyRuntimeEvent); });
 });
 onBeforeUnmount(() => {
+  tokenBatcher.clear();
   stopSidebarDragListeners?.();
   stopMacTitlebandDragArm?.();
   window.clearTimeout(sidebarAnimTimer);

--- a/desktop/src/components/timeline/ExecutionTimeline.vue
+++ b/desktop/src/components/timeline/ExecutionTimeline.vue
@@ -88,7 +88,7 @@ function aggregateStep(steps: TimelineStep[]): TimelineStep {
 
 function hasAssistantContent(step: TimelineStep): boolean {
   return Boolean(
-    step.finalText || step.tokens.length || step.thinking || step.toolCalls.length ||
+    step.finalText || step.streamText || step.tokens.length || step.thinking || step.toolCalls.length ||
     step.plan?.length || step.tests?.length || step.changes?.length ||
     step.logs?.length || step.subagents?.length || step.skills?.length ||
     step.runStartedAt || step.runStats || step.workflowTasks?.length ||
@@ -185,7 +185,7 @@ async function copyTurnSummary(turn: TurnView) {
 }
 
 function stepText(step: TimelineStep): string {
-  return step.finalText || step.tokens.join("");
+  return step.finalText || step.streamText || step.tokens.join("");
 }
 
 function stepHasDetails(step: TimelineStep): boolean {
@@ -232,7 +232,7 @@ function stateOf(steps: TimelineStep[], pending: PermissionState | undefined, ca
   const last = steps[steps.length - 1];
   if (last && last.status !== "done") {
     if (last.status === "observing") return { state: "running" as const, label: "正在检查" };
-    if (last.tokens.length && !last.finalText) return { state: "running" as const, label: "整理中" };
+    if ((last.streamText || last.tokens.length) && !last.finalText) return { state: "running" as const, label: "整理中" };
     return { state: "running" as const, label: calls.length ? "规划中" : "正在思考" };
   }
   const tests = steps.flatMap((step) => step.tests ?? []);
@@ -258,7 +258,7 @@ const turns = computed<TurnView[]>(() => {
     const model = steps.find((step) => step.usage?.model)?.usage?.model ?? "";
     const runStats = [...steps].reverse().find((step) => step.runStats)?.runStats;
     const runStartedAt = steps.find((step) => step.runStartedAt)?.runStartedAt ?? group.userMessageTime;
-    const text = steps.map((step) => step.finalText || step.tokens.join("")).filter(Boolean).join("\n\n");
+    const text = steps.map((step) => step.finalText || step.streamText || step.tokens.join("")).filter(Boolean).join("\n\n");
     const allToolCalls = toolCallsOf(steps);
     const thinkingText = thinkingTextOf(steps);
     const aggregatedStep = aggregateStep(steps);

--- a/desktop/src/components/timeline/types.ts
+++ b/desktop/src/components/timeline/types.ts
@@ -100,6 +100,7 @@ export interface TimelineStep {
   status: TimelineStatus;
   thinking?: string;
   tokens: string[];
+  streamText?: string;
   toolCalls: ToolCallEntry[];
   events?: TimelineEvent[];
   permission?: PermissionState;

--- a/desktop/src/utils/timelineStream.ts
+++ b/desktop/src/utils/timelineStream.ts
@@ -1,0 +1,93 @@
+import type { TimelineStep } from "../components/timeline/types";
+
+export type TokenBatch = {
+  runId: string;
+  step: number;
+  tokens: string[];
+};
+
+type ScheduleFrame = (callback: () => void) => number;
+type CancelFrame = (handle: number) => void;
+
+export function appendTokenBatch(step: TimelineStep, tokens: string[]): TimelineStep {
+  if (!tokens.length) return step;
+
+  const text = tokens.join("");
+  const events = [...(step.events ?? [])];
+  const lastIndex = events.length - 1;
+  const last = events[lastIndex];
+
+  if (last?.kind === "text") {
+    events[lastIndex] = { ...last, text: `${last.text ?? ""}${text}` };
+  } else {
+    events.push({
+      id: `text-live-${step.runId ?? "run"}-${Date.now()}`,
+      kind: "text",
+      text,
+    });
+  }
+
+  return {
+    ...step,
+    status: "thinking",
+    streamText: `${step.streamText ?? step.tokens.join("")}${text}`,
+    events,
+  };
+}
+
+export function createTokenFrameBatcher(
+  onBatch: (batch: TokenBatch) => void,
+  scheduleFrame: ScheduleFrame,
+  cancelFrame: CancelFrame,
+) {
+  const pending = new Map<string, TokenBatch>();
+  let frameHandle: number | undefined;
+
+  function drain(matches: (batch: TokenBatch) => boolean) {
+    for (const [key, batch] of pending) {
+      if (!matches(batch)) continue;
+      pending.delete(key);
+      onBatch({ ...batch, tokens: [...batch.tokens] });
+    }
+  }
+
+  function cancelEmptyFrame() {
+    if (pending.size || frameHandle === undefined) return;
+    cancelFrame(frameHandle);
+    frameHandle = undefined;
+  }
+
+  function flushAll() {
+    if (frameHandle !== undefined) cancelFrame(frameHandle);
+    frameHandle = undefined;
+    drain(() => true);
+  }
+
+  return {
+    enqueue(runId: string, step: number, token: string) {
+      const key = `${runId}\u0000${step}`;
+      const batch = pending.get(key);
+      if (batch) batch.tokens.push(token);
+      else pending.set(key, { runId, step, tokens: [token] });
+
+      if (frameHandle !== undefined) return;
+      frameHandle = scheduleFrame(() => {
+        frameHandle = undefined;
+        drain(() => true);
+      });
+    },
+
+    flushRun(runId: string) {
+      drain((batch) => batch.runId === runId);
+      cancelEmptyFrame();
+    },
+
+    flushAll,
+
+    clear() {
+      pending.clear();
+      if (frameHandle !== undefined) cancelFrame(frameHandle);
+      frameHandle = undefined;
+    },
+  };
+}

--- a/desktop/tests/timeline-stream.test.ts
+++ b/desktop/tests/timeline-stream.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TimelineStep } from "../src/components/timeline/types";
+import { appendTokenBatch, createTokenFrameBatcher } from "../src/utils/timelineStream";
+
+function emptyStep(): TimelineStep {
+  return { step: 1, runId: "run-1", status: "thinking", tokens: [], toolCalls: [] };
+}
+
+test("appends a token batch without mutating the previous timeline step", () => {
+  const previous = {
+    ...emptyStep(),
+    streamText: "Hello",
+    events: [{ id: "text-1", kind: "text" as const, text: "Hello" }],
+  };
+
+  const next = appendTokenBatch(previous, [",", " world"]);
+
+  assert.equal(next.streamText, "Hello, world");
+  assert.equal(next.events?.at(-1)?.text, "Hello, world");
+  assert.equal(previous.streamText, "Hello");
+  assert.equal(previous.events.at(-1)?.text, "Hello");
+});
+
+test("coalesces tokens into one scheduled batch and preserves their order", () => {
+  const scheduled: Array<() => void> = [];
+  const batches: Array<{ runId: string; step: number; tokens: string[] }> = [];
+  const batcher = createTokenFrameBatcher(
+    (batch) => batches.push(batch),
+    (callback) => { scheduled.push(callback); return scheduled.length; },
+    () => undefined,
+  );
+
+  batcher.enqueue("run-1", 3, "A");
+  batcher.enqueue("run-1", 3, "B");
+  batcher.enqueue("run-1", 3, "C");
+
+  assert.equal(scheduled.length, 1);
+  assert.deepEqual(batches, []);
+  scheduled[0]();
+  assert.deepEqual(batches, [{ runId: "run-1", step: 3, tokens: ["A", "B", "C"] }]);
+});
+
+test("flushes pending tokens synchronously before a later run event", () => {
+  const batches: Array<{ runId: string; step: number; tokens: string[] }> = [];
+  const batcher = createTokenFrameBatcher(
+    (batch) => batches.push(batch),
+    () => 1,
+    () => undefined,
+  );
+
+  batcher.enqueue("run-1", 2, "first");
+  batcher.flushRun("run-1");
+
+  assert.deepEqual(batches, [{ runId: "run-1", step: 2, tokens: ["first"] }]);
+});

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -180,7 +180,7 @@ def main(argv: list[str] | None = None) -> int:
                 location: Path = link.doc.relative_to(root)
             except ValueError:
                 location = link.doc
-            print(f"{location}:{link.line} -> {link.target}", file=sys.stderr)
+            print(f"{location.as_posix()}:{link.line} -> {link.target}", file=sys.stderr)
         print(
             f"ERROR: 共检查 {len(documents)} 个文件，发现 {len(broken)} 条坏链。",
             file=sys.stderr,

--- a/src/sztu_code/core/tools/builtin/bash.py
+++ b/src/sztu_code/core/tools/builtin/bash.py
@@ -194,7 +194,7 @@ class BashTool(BaseTool):
         try:
             if bash:
                 proc = await asyncio.create_subprocess_exec(
-                    bash, "-c", command,
+                    bash, "--login", "-c", command,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.STDOUT,
                     cwd=str(self._workspace_root) if self._workspace_root is not None else None,

--- a/tests/unit/test_openai_provider.py
+++ b/tests/unit/test_openai_provider.py
@@ -514,10 +514,11 @@ def test_deepseek_v4_flash_context_window() -> None:
 # --- error handling tests ----------------------------------------------------
 
 
-# 功能：验证缺少 OPENAI_API_KEY 时 provider 初始化立即 SystemExit
-# 设计：清除环境变量后实例化，确认 fail-fast 行为
+# 功能：验证既缺少 OPENAI_API_KEY、又未配置免 key 端点时 provider 初始化立即 SystemExit
+# 设计：同时清除凭证和自定义端点，隔离其他配置测试加载 .env 后留下的环境状态
 async def test_missing_api_key_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     with pytest.raises(SystemExit):
         OpenAIProvider(model="any")
 


### PR DESCRIPTION
## Summary

- Batch streamed LLM tokens once per animation frame instead of cloning the reactive timeline for every token.
- Flush pending text before later runtime events so completion state cannot overtake the final response fragment.
- Introduce additive `streamText` compatibility while retaining the existing token-array fallback.
- Load the Git Bash login environment on Windows so bundled Unix tools are available.
- Normalize Markdown link diagnostics to repository-style `/` paths on every platform.
- Isolate the OpenAI provider missing-credential test from custom-endpoint environment state.

Closes #89

## Behavior

- Tokens received in the same animation frame are applied as one ordered batch.
- A non-token event for the same run synchronously flushes pending text before changing step or run state.
- Historical timeline data that only contains `tokens` continues to render unchanged.
- Windows Bash invocations load Git Bash's standard tool path, fixing commands such as `grep --version` and `pwd`.
- Markdown checker failures use stable POSIX-style repository-relative paths.

## Validation

```text
npm.cmd run test:unit
9 passed

npm.cmd run build
passed (Vite reports the existing >500 kB chunk advisory)

uv run pytest tests/unit -q
785 passed

uv run ruff check src/sztu_code/core/tools/builtin/bash.py scripts/check_markdown_links.py tests/unit/test_openai_provider.py
All checks passed!

uv run mypy src/sztu_code
Success: no issues found in 181 source files
```

## Risk

Low to moderate. Desktop output updates are delayed by at most one animation frame, and later runtime events explicitly flush pending tokens to preserve ordering. `streamText` is additive and existing token-array consumers remain supported. Loading the Git Bash login profile can expose user-defined shell initialization, which matches normal Git Bash behavior and is required for its Unix tool path. Rollback is a revert of commit `da1f7e9`.

No runtime wire-protocol, persisted-data, dependency-version, or configuration contract changes are included.

## UI evidence

N/A — this changes streaming responsiveness and event ordering without changing the visual layout.

## Checklist

- [x] 变更范围与关联 Issue #89 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A — no protocol changes.）
- [x] 用户文档、配置示例和迁移说明已同步。（N/A — no documentation or configuration changes.）
- [x] 提交包含 `Signed-off-by`（DCO）。
