### PR TITLE
feat(agent): add bounded read-only tool concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,8 @@ SZTU_LOG_FORMAT=text
 
 # ── Agent ─────────────────────────────────────────────────────
 # SZTU_MAX_STEPS=20
+# 同一轮全部明确只读时的最大工具并发数；设为 1 可恢复串行行为
+# SZTU_TOOL_MAX_CONCURRENCY=4
 
 # ── Multi-agent Workflow ─────────────────────────────────────
 # SZTU_WORKFLOW_MAX_CONCURRENCY=4

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -65,6 +65,7 @@ SztuCode 不内置厂商模型 ID。模型名称、上下文窗口和端点必�
 | `SZTU_LLM_CONTEXT_WINDOW` | Provider 默认 | 正整数上下文窗口 |
 | `SZTU_LLM_CACHE_CONTROL` | `true` | OpenAI 兼容端点是否发送 cache_control 断点（system + 最后一个 tool）；端点拒收未知字段时设 `false` |
 | `SZTU_MAX_STEPS` | `20` | 单次运行最大 Agent 步数 |
+| `SZTU_TOOL_MAX_CONCURRENCY` | `4` | 同轮全部明确只读时的最大工具并发数；`1` 表示串行 |
 | `SZTU_PERMISSION_MODE` | `normal` | `normal`、`plan`、`accept_edits`、`auto` |
 | `SZTU_PERMISSION_TIMEOUT_S` | `60` | 审批超时秒数；`0` 表示不超时 |
 | `SZTU_COMPACT_THRESHOLD` | `0` | 自动压缩阈值，范围 0–1；`0` 关闭 |
@@ -97,6 +98,7 @@ wrap_up_on_max_steps = true
 grace_step_on_max_steps = true
 stuck_max_failures = 3
 stuck_max_total = 0
+tool_max_concurrency = 4  # 仅当整批工具均明确为 read_only 且无需审批时生效
 
 [budget]
 max_tokens = 0

--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -4897,6 +4897,11 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
 | `tool_use_id` | `string` | yes |
 | `tool_name` | `string` | yes |
 | `params` | `object` | yes |
+| `batch_id` | `string` | no |
+| `scheduler_mode` | `string` | no |
+| `queue_ms` | `integer` | no |
+| `queued_at` | `string` | no |
+| `started_at` | `string` | no |
 | `ts` | `string` | yes |
 
 ```json
@@ -4924,6 +4929,35 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
       "additionalProperties": true,
       "title": "Params",
       "type": "object"
+    },
+    "batch_id": {
+      "default": "",
+      "title": "Batch Id",
+      "type": "string"
+    },
+    "scheduler_mode": {
+      "default": "serial",
+      "enum": [
+        "serial",
+        "concurrent"
+      ],
+      "title": "Scheduler Mode",
+      "type": "string"
+    },
+    "queue_ms": {
+      "default": 0,
+      "title": "Queue Ms",
+      "type": "integer"
+    },
+    "queued_at": {
+      "default": "",
+      "title": "Queued At",
+      "type": "string"
+    },
+    "started_at": {
+      "default": "",
+      "title": "Started At",
+      "type": "string"
     },
     "ts": {
       "title": "Ts",
@@ -4968,6 +5002,12 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
 | `tool_name` | `string` | yes |
 | `elapsed_ms` | `integer` | yes |
 | `output` | `string` | no |
+| `batch_id` | `string` | no |
+| `scheduler_mode` | `string` | no |
+| `queue_ms` | `integer` | no |
+| `queued_at` | `string` | no |
+| `started_at` | `string` | no |
+| `finished_at` | `string` | no |
 | `ts` | `string` | yes |
 
 ```json
@@ -4998,6 +5038,40 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
     "output": {
       "default": "",
       "title": "Output",
+      "type": "string"
+    },
+    "batch_id": {
+      "default": "",
+      "title": "Batch Id",
+      "type": "string"
+    },
+    "scheduler_mode": {
+      "default": "serial",
+      "enum": [
+        "serial",
+        "concurrent"
+      ],
+      "title": "Scheduler Mode",
+      "type": "string"
+    },
+    "queue_ms": {
+      "default": 0,
+      "title": "Queue Ms",
+      "type": "integer"
+    },
+    "queued_at": {
+      "default": "",
+      "title": "Queued At",
+      "type": "string"
+    },
+    "started_at": {
+      "default": "",
+      "title": "Started At",
+      "type": "string"
+    },
+    "finished_at": {
+      "default": "",
+      "title": "Finished At",
       "type": "string"
     },
     "ts": {
@@ -5042,6 +5116,12 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
 | `error_message` | `string` | yes |
 | `elapsed_ms` | `integer` | yes |
 | `attempt` | `integer` | no |
+| `batch_id` | `string` | no |
+| `scheduler_mode` | `string` | no |
+| `queue_ms` | `integer` | no |
+| `queued_at` | `string` | no |
+| `started_at` | `string` | no |
+| `finished_at` | `string` | no |
 | `ts` | `string` | yes |
 
 ```json
@@ -5081,6 +5161,40 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
       "default": 1,
       "title": "Attempt",
       "type": "integer"
+    },
+    "batch_id": {
+      "default": "",
+      "title": "Batch Id",
+      "type": "string"
+    },
+    "scheduler_mode": {
+      "default": "serial",
+      "enum": [
+        "serial",
+        "concurrent"
+      ],
+      "title": "Scheduler Mode",
+      "type": "string"
+    },
+    "queue_ms": {
+      "default": 0,
+      "title": "Queue Ms",
+      "type": "integer"
+    },
+    "queued_at": {
+      "default": "",
+      "title": "Queued At",
+      "type": "string"
+    },
+    "started_at": {
+      "default": "",
+      "title": "Started At",
+      "type": "string"
+    },
+    "finished_at": {
+      "default": "",
+      "title": "Finished At",
+      "type": "string"
     },
     "ts": {
       "title": "Ts",

--- a/src/sztu_code/core/bus/events.py
+++ b/src/sztu_code/core/bus/events.py
@@ -4,6 +4,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Discriminator
 
+ToolSchedulerMode = Literal["serial", "concurrent"]
+
 
 class CoreStartedEvent(BaseModel):
     type: Literal["core.started"] = "core.started"
@@ -51,6 +53,15 @@ class ToolCallStartedEvent(BaseModel):
     tool_use_id: str
     tool_name: str
     params: dict[str, Any]
+    # 同一模型回合的工具批次标识；空值代表未经过批次调度的兼容调用
+    batch_id: str = ""
+    # 供 Trace/TUI 区分调度方式
+    scheduler_mode: ToolSchedulerMode = "serial"
+    # 从批次入队到实际开始调用的等待时长
+    queue_ms: int = 0
+    # 工具进入队列与实际开始执行的 UTC 时间戳
+    queued_at: str = ""
+    started_at: str = ""
     ts: str
 
 
@@ -61,6 +72,12 @@ class ToolCallFinishedEvent(BaseModel):
     tool_name: str
     elapsed_ms: int
     output: str = ""  # tool result content, for TUI display
+    batch_id: str = ""
+    scheduler_mode: ToolSchedulerMode = "serial"
+    queue_ms: int = 0
+    queued_at: str = ""
+    started_at: str = ""
+    finished_at: str = ""
     ts: str
 
 
@@ -74,6 +91,12 @@ class ToolCallFailedEvent(BaseModel):
     error_message: str
     elapsed_ms: int
     attempt: int = 1  # 1=first attempt, 2=first retry, 3=second retry
+    batch_id: str = ""
+    scheduler_mode: ToolSchedulerMode = "serial"
+    queue_ms: int = 0
+    queued_at: str = ""
+    started_at: str = ""
+    finished_at: str = ""
     ts: str
 
 

--- a/src/sztu_code/core/config.py
+++ b/src/sztu_code/core/config.py
@@ -21,6 +21,7 @@ _DEFAULT_WRAP_UP_ON_MAX_STEPS = True
 _DEFAULT_GRACE_STEP_ON_MAX_STEPS = True
 _DEFAULT_STUCK_MAX_FAILURES = 3
 _DEFAULT_STUCK_MAX_TOTAL = 0
+_DEFAULT_TOOL_MAX_CONCURRENCY = 4
 _DEFAULT_TRACE_FILE = "~/.sztu/traces/daemon.jsonl"
 
 API_FORMATS = {
@@ -63,6 +64,8 @@ class AgentConfig:
     stuck_max_failures: int = _DEFAULT_STUCK_MAX_FAILURES
     # 累计干预达到该次数硬停；0=永不硬停
     stuck_max_total: int = _DEFAULT_STUCK_MAX_TOTAL
+    # 同轮全只读工具批次的最大并发数；1 保持完全串行
+    tool_max_concurrency: int = _DEFAULT_TOOL_MAX_CONCURRENCY
 
 
 @dataclass
@@ -389,7 +392,7 @@ def _apply_toml(config: SztuConfig, data: dict[str, Any]) -> None:
             raise SystemExit("Config error: [agent] must be a table")
         unknown_agent: set[str] = set(agent.keys()) - {
             "max_steps", "wrap_up_on_max_steps", "grace_step_on_max_steps",
-            "stuck_max_failures", "stuck_max_total",
+            "stuck_max_failures", "stuck_max_total", "tool_max_concurrency",
         }
         if unknown_agent:
             raise SystemExit(f"Unknown [agent] keys: {', '.join(sorted(unknown_agent))}")
@@ -417,6 +420,13 @@ def _apply_toml(config: SztuConfig, data: dict[str, Any]) -> None:
                 if not isinstance(val, int) or val < 0:
                     raise SystemExit(f"Config error: agent.{_key} must be a non-negative integer")
                 setattr(config.agent, _key, val)
+        if "tool_max_concurrency" in agent:
+            val = agent["tool_max_concurrency"]
+            if not isinstance(val, int) or isinstance(val, bool) or val < 1:
+                raise SystemExit(
+                    "Config error: agent.tool_max_concurrency must be an integer >= 1"
+                )
+            config.agent.tool_max_concurrency = val
 
     if "budget" in data:
         budget = data["budget"]
@@ -784,6 +794,22 @@ def _apply_env(config: SztuConfig) -> None:
                 raise SystemExit(
                     f"Config error: {_env} must be an integer, got: {_str!r}"
                 )
+
+    tool_concurrency_str = os.environ.get("SZTU_TOOL_MAX_CONCURRENCY")
+    if tool_concurrency_str is not None:
+        try:
+            tool_concurrency = int(tool_concurrency_str)
+        except ValueError:
+            raise SystemExit(
+                "Config error: SZTU_TOOL_MAX_CONCURRENCY must be an integer, "
+                f"got: {tool_concurrency_str!r}"
+            )
+        if tool_concurrency < 1:
+            raise SystemExit(
+                "Config error: SZTU_TOOL_MAX_CONCURRENCY must be >= 1, "
+                f"got: {tool_concurrency_str!r}"
+            )
+        config.agent.tool_max_concurrency = tool_concurrency
 
     # --- 多智能体工作流环境变量 ---
     for _env, _attr, _minimum in (

--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -80,7 +80,10 @@ def _can_run_read_only_batch_concurrently(
                 decision = permission_manager.evaluate(tool_call.name, runtime_params)
             except Exception:
                 return None
-            if decision != PermissionDecision.ALLOW:
+            if (
+                not isinstance(decision, PermissionDecision)
+                or decision is not PermissionDecision.ALLOW
+            ):
                 return None
         permissions.append(permission)
     return permissions

--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -10,12 +10,20 @@ from sztu_code.core.bus.events import (
     StepFinishedEvent,
     StepStartedEvent,
     StuckLoopEvent,
+    ToolSchedulerMode,
 )
 from sztu_code.core.compact.budget import truncate_tool_results
 from sztu_code.core.context import ContinueReason, ExecutionContext, TerminationReason
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.base import LLMProvider
+from sztu_code.core.llm.types import ToolCallBlock
+from sztu_code.core.permissions.policy import PermissionDecision
 from sztu_code.core.stuck_tracker import stuck_signature
+from sztu_code.core.tools.base import (
+    _PERMISSION_GRANT_KEY,
+    ToolPermission,
+    ToolResult,
+)
 from sztu_code.core.tools.invocation import invoke_tool
 from sztu_code.core.tools.registry import ToolRegistry
 
@@ -42,6 +50,74 @@ _DEFAULT_SYSTEM_PROMPT = (
 
 def _now() -> str:
     return datetime.now(UTC).isoformat()
+
+
+# 检查一批调用是否均为无需审批的显式只读工具，未知或分类异常一律保守降级
+def _can_run_read_only_batch_concurrently(
+    registry: ToolRegistry,
+    tool_calls: list[ToolCallBlock],
+    permission_manager: PermissionManager | None,
+) -> list[ToolPermission] | None:
+    permissions: list[ToolPermission] = []
+    for tool_call in tool_calls:
+        tool = registry.get(tool_call.name)
+        if tool is None:
+            return None
+        runtime_params = dict(tool_call.input)
+        runtime_params.pop("description", None)
+        runtime_params.pop(_PERMISSION_GRANT_KEY, None)
+        try:
+            permission = tool.classify_permission(runtime_params)
+        except Exception:
+            return None
+        if permission != ToolPermission.READ_ONLY:
+            return None
+        if permission_manager is not None:
+            try:
+                decision = permission_manager.evaluate(tool_call.name, runtime_params)
+            except Exception:
+                return None
+            if decision != PermissionDecision.ALLOW:
+                return None
+        permissions.append(permission)
+    return permissions
+
+
+# 在有界信号量内执行单个工具调用并附加统一调度 Trace 元数据
+async def _invoke_scheduled_tool(
+    registry: ToolRegistry,
+    tool_call: ToolCallBlock,
+    bus: EventBus,
+    run_id: str,
+    permission_manager: PermissionManager | None,
+    session_id: str,
+    semaphore: asyncio.Semaphore,
+    batch_id: str,
+    scheduler_mode: ToolSchedulerMode,
+    queued_at: str,
+    queued_monotonic: float,
+    classified_permission: ToolPermission | None = None,
+) -> ToolResult:
+    try:
+        async with semaphore:
+            return await invoke_tool(
+                registry,
+                tool_call,
+                bus,
+                run_id,
+                permission_manager=permission_manager,
+                session_id=session_id,
+                batch_id=batch_id,
+                scheduler_mode=scheduler_mode,
+                queued_at=queued_at,
+                queued_monotonic=queued_monotonic,
+                classified_permission=classified_permission,
+            )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        # Isolate an unexpected call-level failure from the rest of the batch.
+        return ToolResult(content=str(exc), is_error=True, error_type="runtime_error")
 
 
 class AgentLoop:
@@ -71,7 +147,10 @@ class AgentLoop:
         sliding_window_size: int = 5,
         compact_cooldown_steps: int = 3,
         circuit_breaker_max_failures: int = 3,
+        tool_max_concurrency: int = 4,
     ) -> None:
+        if tool_max_concurrency < 1:
+            raise ValueError("tool_max_concurrency must be at least 1")
         self._provider = provider
         self._registry = registry
         self._bus = bus
@@ -93,6 +172,7 @@ class AgentLoop:
         self._sliding_window_size = sliding_window_size
         self._compact_cooldown_steps = compact_cooldown_steps
         self._circuit_breaker_max_failures = circuit_breaker_max_failures
+        self._tool_max_concurrency = tool_max_concurrency
         # 压缩冷却期：两次压缩之间至少间隔 N 步；冷启动即可触发
         self._last_compact_step: int = -15
         # 熔断器日志去重：避免每步都刷屏
@@ -237,13 +317,74 @@ class AgentLoop:
                         tool_names=[tc.name for tc in response.tool_calls],
                         status="running",
                     )
-                for tc in response.tool_calls:
-                    canvas_tool_names.append(tc.name)
-                    result = await invoke_tool(
-                        self._registry, tc, self._bus, context.run_id,
-                        permission_manager=self._permission_manager,
-                        session_id=self._session_id,
+                batch_id = f"{context.run_id}:{context.step}"
+                queued_at = _now()
+                queued_monotonic = time.monotonic()
+                batch_permissions: list[ToolPermission] | None = None
+                if self._tool_max_concurrency > 1 and len(response.tool_calls) > 1:
+                    batch_permissions = _can_run_read_only_batch_concurrently(
+                        self._registry,
+                        response.tool_calls,
+                        self._permission_manager,
                     )
+                use_concurrent_scheduler = (
+                    self._tool_max_concurrency > 1
+                    and len(response.tool_calls) > 1
+                    and batch_permissions is not None
+                )
+                if use_concurrent_scheduler:
+                    assert batch_permissions is not None
+                    semaphore = asyncio.Semaphore(self._tool_max_concurrency)
+                    concurrent_results = await asyncio.gather(
+                        *(
+                            _invoke_scheduled_tool(
+                                self._registry,
+                                tool_call,
+                                self._bus,
+                                context.run_id,
+                                self._permission_manager,
+                                self._session_id,
+                                semaphore,
+                                batch_id,
+                                "concurrent",
+                                queued_at,
+                                queued_monotonic,
+                                batch_permissions[index],
+                            )
+                            for index, tool_call in enumerate(response.tool_calls)
+                        ),
+                        return_exceptions=True,
+                    )
+                else:
+                    concurrent_results = None
+
+                for index, tc in enumerate(response.tool_calls):
+                    if concurrent_results is None:
+                        result = await invoke_tool(
+                            self._registry,
+                            tc,
+                            self._bus,
+                            context.run_id,
+                            permission_manager=self._permission_manager,
+                            session_id=self._session_id,
+                            batch_id=batch_id,
+                            scheduler_mode="serial",
+                            queued_at=queued_at,
+                            queued_monotonic=queued_monotonic,
+                        )
+                    else:
+                        scheduled_result = concurrent_results[index]
+                        if isinstance(scheduled_result, asyncio.CancelledError):
+                            raise scheduled_result
+                        if not isinstance(scheduled_result, ToolResult):
+                            result = ToolResult(
+                                content=str(scheduled_result),
+                                is_error=True,
+                                error_type="runtime_error",
+                            )
+                        else:
+                            result = scheduled_result
+                    canvas_tool_names.append(tc.name)
                     if result.is_error:
                         has_errors = True
                         # Claude Code 风格错误累积：非权限类错误 ≥3 次触发熔断

--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -70,7 +70,10 @@ def _can_run_read_only_batch_concurrently(
             permission = tool.classify_permission(runtime_params)
         except Exception:
             return None
-        if permission != ToolPermission.READ_ONLY:
+        if (
+            not isinstance(permission, ToolPermission)
+            or permission is not ToolPermission.READ_ONLY
+        ):
             return None
         if permission_manager is not None:
             try:

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -162,6 +162,7 @@ class AgentRunner:
                 grace_step_on_max_steps=self._config.agent.grace_step_on_max_steps,
                 stuck_max_failures=self._config.agent.stuck_max_failures,
                 stuck_max_total=self._config.agent.stuck_max_total,
+                tool_max_concurrency=self._config.agent.tool_max_concurrency,
                 max_depth=self._config.workflow.max_depth,
             )
             if _ok("spawn_agent"):
@@ -325,6 +326,7 @@ class AgentRunner:
                     sliding_window_size=self._config.compaction.sliding_window_size,
                     compact_cooldown_steps=self._config.compaction.compact_cooldown_steps,
                     circuit_breaker_max_failures=self._config.compaction.circuit_breaker_max_failures,
+                    tool_max_concurrency=self._config.agent.tool_max_concurrency,
                 )
                 await loop.run(context)
             except asyncio.CancelledError:

--- a/src/sztu_code/core/subagent/tool.py
+++ b/src/sztu_code/core/subagent/tool.py
@@ -125,6 +125,7 @@ class SpawnAgentTool(BaseTool):
         grace_step_on_max_steps: bool = True,
         stuck_max_failures: int = 3,
         stuck_max_total: int = 0,
+        tool_max_concurrency: int = 4,
         max_depth: int = 2,
     ) -> None:
         self._provider = provider
@@ -145,6 +146,7 @@ class SpawnAgentTool(BaseTool):
         self._grace_step_on_max_steps = grace_step_on_max_steps
         self._stuck_max_failures = stuck_max_failures
         self._stuck_max_total = stuck_max_total
+        self._tool_max_concurrency = tool_max_concurrency
         self._max_depth = max_depth
 
     # 派生子 agent，前台时阻塞直到完成并返回结果，后台时立即返回 run_id
@@ -261,6 +263,7 @@ class SpawnAgentTool(BaseTool):
                 max_failures=self._stuck_max_failures,
                 max_total=self._stuck_max_total,
             ),
+            tool_max_concurrency=self._tool_max_concurrency,
         )
 
         await self._parent_bus.publish(
@@ -422,6 +425,7 @@ class SpawnAgentTool(BaseTool):
                 grace_step_on_max_steps=self._grace_step_on_max_steps,
                 stuck_max_failures=self._stuck_max_failures,
                 stuck_max_total=self._stuck_max_total,
+                tool_max_concurrency=self._tool_max_concurrency,
                 max_depth=self._max_depth,
             )
             if _allowed("spawn_agent"):

--- a/src/sztu_code/core/tools/invocation.py
+++ b/src/sztu_code/core/tools/invocation.py
@@ -15,6 +15,7 @@ from sztu_code.core.bus.events import (
     ToolCallFailedEvent,
     ToolCallFinishedEvent,
     ToolCallStartedEvent,
+    ToolSchedulerMode,
 )
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import ToolCallBlock
@@ -90,7 +91,13 @@ async def _fail(
     elapsed_ms: int,
     *,
     attempt: int = 1,
+    batch_id: str = "",
+    scheduler_mode: ToolSchedulerMode = "serial",
+    queue_ms: int = 0,
+    queued_at: str = "",
+    started_at: str = "",
 ) -> ToolResult:
+    finished_at = _now()
     await bus.publish(
         ToolCallFailedEvent(
             run_id=run_id,
@@ -100,7 +107,13 @@ async def _fail(
             error_message=error_message,
             elapsed_ms=elapsed_ms,
             attempt=attempt,
-            ts=_now(),
+            batch_id=batch_id,
+            scheduler_mode=scheduler_mode,
+            queue_ms=queue_ms,
+            queued_at=queued_at,
+            started_at=started_at,
+            finished_at=finished_at,
+            ts=finished_at,
         )
     )
     await _publish_test_result(bus, run_id, tool_call, "failed", error_message)
@@ -117,31 +130,57 @@ async def invoke_tool(
     *,
     permission_manager: PermissionManager | None = None,
     session_id: str = "",
+    batch_id: str = "",
+    scheduler_mode: ToolSchedulerMode = "serial",
+    queued_at: str = "",
+    queued_monotonic: float | None = None,
+    classified_permission: ToolPermission | None = None,
 ) -> ToolResult:
     t0 = time.monotonic()
+    started_at = _now()
+    queue_ms = (
+        max(0, int((t0 - queued_monotonic) * 1000))
+        if queued_monotonic is not None
+        else 0
+    )
     tool_call.input = registry.enrich_tool_input(tool_call.name, tool_call.input)
     runtime_params = dict(tool_call.input)
     runtime_params.pop("description", None)
     runtime_params.pop(_PERMISSION_GRANT_KEY, None)
 
-    await bus.publish(
-        ToolCallStartedEvent(
-            run_id=run_id,
-            tool_use_id=tool_call.id,
-            tool_name=tool_call.name,
-            params=dict(tool_call.input),
-            ts=_now(),
-        )
-    )
-
     def elapsed() -> int:
         return int((time.monotonic() - t0) * 1000)
+
+    try:
+        await bus.publish(
+            ToolCallStartedEvent(
+                run_id=run_id,
+                tool_use_id=tool_call.id,
+                tool_name=tool_call.name,
+                params=dict(tool_call.input),
+                batch_id=batch_id,
+                scheduler_mode=scheduler_mode,
+                queue_ms=queue_ms,
+                queued_at=queued_at,
+                started_at=started_at,
+                ts=started_at,
+            )
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return ToolResult(content=str(exc), is_error=True, error_type="runtime_error")
 
     tool = registry.get(tool_call.name)
     if tool is None:
         return await _fail(
             bus, run_id, tool_call,
             "runtime_error", f"unknown tool: {tool_call.name}", elapsed(),
+            batch_id=batch_id,
+            scheduler_mode=scheduler_mode,
+            queue_ms=queue_ms,
+            queued_at=queued_at,
+            started_at=started_at,
         )
 
     if tool.params_model is not None:
@@ -151,23 +190,43 @@ async def invoke_tool(
             return await _fail(
                 bus, run_id, tool_call,
                 "schema_error", str(exc), elapsed(),
+                batch_id=batch_id,
+                scheduler_mode=scheduler_mode,
+                queue_ms=queue_ms,
+                queued_at=queued_at,
+                started_at=started_at,
             )
 
     if permission_manager is not None:
         async def _emit_permission(raw: dict[str, Any]) -> None:
             await bus.publish(PermissionRequestedEvent(**raw, run_id=run_id))
 
-        # 获取工具的动态权限级别（bash 根据命令内容分级）
-        tool_permission = tool.classify_permission(runtime_params)
+        try:
+            # 并发预检已确认的权限直接复用，避免同一调用被动态分类两次
+            tool_permission = classified_permission
+            if tool_permission is None:
+                tool_permission = tool.classify_permission(runtime_params)
 
-        allowed, decision = await permission_manager.check_and_wait(
-            tool_use_id=tool_call.id,
-            tool_name=tool_call.name,
-            params=dict(tool_call.input),
-            session_id=session_id,
-            event_emitter=_emit_permission,
-            tool_permission=tool_permission,
-        )
+            allowed, decision = await permission_manager.check_and_wait(
+                tool_use_id=tool_call.id,
+                tool_name=tool_call.name,
+                params=dict(tool_call.input),
+                session_id=session_id,
+                event_emitter=_emit_permission,
+                tool_permission=tool_permission,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return await _fail(
+                bus, run_id, tool_call,
+                "runtime_error", str(exc), elapsed(),
+                batch_id=batch_id,
+                scheduler_mode=scheduler_mode,
+                queue_ms=queue_ms,
+                queued_at=queued_at,
+                started_at=started_at,
+            )
         if allowed:
             if tool_permission == ToolPermission.DANGER_FULL_ACCESS:
                 # 不可序列化的身份令牌只在权限系统放行后注入，防止模型伪造越权
@@ -197,6 +256,11 @@ async def invoke_tool(
                 "Permission denied by user. You may not execute this command. "
                 "Try an alternative approach or ask the user what to do.",
                 elapsed(),
+                batch_id=batch_id,
+                scheduler_mode=scheduler_mode,
+                queue_ms=queue_ms,
+                queued_at=queued_at,
+                started_at=started_at,
             )
 
     for attempt in range(1, _MAX_RETRIES + 2):
@@ -213,6 +277,7 @@ async def invoke_tool(
                 error_class = result.error_type or "runtime_error"
                 error_message = result.content
             else:
+                finished_at = _now()
                 await bus.publish(
                     ToolCallFinishedEvent(
                         run_id=run_id,
@@ -220,7 +285,13 @@ async def invoke_tool(
                         tool_name=tool_call.name,
                         elapsed_ms=ms,
                         output=result.content,
-                        ts=_now(),
+                        batch_id=batch_id,
+                        scheduler_mode=scheduler_mode,
+                        queue_ms=queue_ms,
+                        queued_at=queued_at,
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        ts=finished_at,
                     )
                 )
                 await _publish_test_result(bus, run_id, tool_call, "passed", result.content)
@@ -243,6 +314,7 @@ async def invoke_tool(
         ms = elapsed()
 
         if error_class in _RETRYABLE and attempt <= _MAX_RETRIES:
+            failed_at = _now()
             await bus.publish(
                 ToolCallFailedEvent(
                     run_id=run_id,
@@ -252,7 +324,13 @@ async def invoke_tool(
                     error_message=error_message,
                     elapsed_ms=ms,
                     attempt=attempt,
-                    ts=_now(),
+                    batch_id=batch_id,
+                    scheduler_mode=scheduler_mode,
+                    queue_ms=queue_ms,
+                    queued_at=queued_at,
+                    started_at=started_at,
+                    finished_at=failed_at,
+                    ts=failed_at,
                 )
             )
             await asyncio.sleep(_RETRY_BASE_S * (2 ** (attempt - 1)))
@@ -262,6 +340,11 @@ async def invoke_tool(
             bus, run_id, tool_call,
             error_class, error_message, ms,
             attempt=attempt,
+            batch_id=batch_id,
+            scheduler_mode=scheduler_mode,
+            queue_ms=queue_ms,
+            queued_at=queued_at,
+            started_at=started_at,
         )
 
     # unreachable, but keeps mypy happy

--- a/tests/unit/test_config_env.py
+++ b/tests/unit/test_config_env.py
@@ -162,6 +162,39 @@ def test_agent_budget_keys_toml_parsed(tmp_path: Path, monkeypatch: pytest.Monke
     assert cfg.agent.stuck_max_total == 2
 
 
+# 功能：验证 Agent 工具并发上限支持 TOML 与环境变量配置并由环境变量覆盖
+# 设计：先加载 agent.tool_max_concurrency，再设置同名 SZTU 环境变量，覆盖配置传播的两条入口
+def test_agent_tool_concurrency_config_parsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    toml_path = tmp_path / "sztu.toml"
+    toml_path.write_bytes(b"[agent]\ntool_max_concurrency = 3\n")
+    monkeypatch.setenv("SZTU_CONFIG", str(toml_path))
+    cfg = get_config()
+    assert cfg.agent.tool_max_concurrency == 3
+
+    monkeypatch.setenv("SZTU_TOOL_MAX_CONCURRENCY", "5")
+    cfg = get_config()
+    assert cfg.agent.tool_max_concurrency == 5
+
+
+# 功能：验证 Agent 工具并发上限拒绝零值和非整数
+# 设计：分别覆盖 TOML 与环境变量的无效边界，防止配置为零导致调度器永远无法取得执行槽
+@pytest.mark.parametrize("source", ["toml", "env"])
+def test_agent_tool_concurrency_rejects_invalid_values(
+    source: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if source == "toml":
+        toml_path = tmp_path / "sztu.toml"
+        toml_path.write_bytes(b"[agent]\ntool_max_concurrency = 0\n")
+        monkeypatch.setenv("SZTU_CONFIG", str(toml_path))
+    else:
+        monkeypatch.setenv("SZTU_TOOL_MAX_CONCURRENCY", "not-an-int")
+
+    with pytest.raises(SystemExit):
+        get_config()
+
+
 # 功能：验证 SZTU_GRACE_STEP_ON_MAX_STEPS 环境变量可关闭结语宽限步
 # 设计：设 env=false，断言 get_config 读到 False；未设置时保持默认 True
 def test_grace_step_env_var_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -179,6 +179,13 @@ class _UnknownPermissionTool(_TimedTool):
         return cast(ToolPermission, "unknown")
 
 
+class _StringReadOnlyPermissionTool(_TimedTool):
+    """Simulates a malformed third-party permission classifier result."""
+
+    def classify_permission(self, params: dict[str, object]) -> ToolPermission:
+        return cast(ToolPermission, "read_only")
+
+
 class _RaisingReadTool(_TimedTool):
     # 模拟工具层异常，验证并发调度会隔离单项异常并继续收集其他结果
     async def invoke(self, params: dict[str, object]) -> ToolResult:
@@ -410,24 +417,39 @@ async def test_read_only_batch_with_limit_one_is_serial() -> None:
 
 # 功能：验证未知工具和未知权限能力都不会让批次被错误并发
 # 设计：分别混入未注册工具及返回未知权限值的第三方工具，用只读邻居的峰值并发度证明保守降级
-@pytest.mark.parametrize("unknown_kind", ["tool", "permission"])
+@pytest.mark.parametrize("unknown_kind", ["tool", "permission", "string_permission"])
 async def test_unknown_tool_or_permission_keeps_batch_serial(unknown_kind: str) -> None:
     probe = _ConcurrencyProbe()
     read_tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
     unknown_tool = _UnknownPermissionTool(
         "unknown_permission", ToolPermission.READ_ONLY, probe
     )
-    middle_name = "missing" if unknown_kind == "tool" else "unknown_permission"
+    string_permission_tool = _StringReadOnlyPermissionTool(
+        "string_read_only_permission", ToolPermission.READ_ONLY, probe
+    )
+    middle_name = {
+        "tool": "missing",
+        "permission": "unknown_permission",
+        "string_permission": "string_read_only_permission",
+    }[unknown_kind]
     calls = [
         _tc("timed_read", {"label": "first", "delay": 0.01}, uid="unknown-1"),
         _tc(middle_name, {"label": "middle", "delay": 0.01}, uid="unknown-2"),
         _tc("timed_read", {"label": "last", "delay": 0.01}, uid="unknown-3"),
     ]
 
-    await _run_tool_batch(calls, [read_tool, unknown_tool], max_concurrency=3)
+    await _run_tool_batch(
+        calls,
+        [read_tool, unknown_tool, string_permission_tool],
+        max_concurrency=3,
+    )
 
     assert probe.max_active == 1
-    assert probe.started == ["first", *( ["middle"] if unknown_kind == "permission" else []), "last"]
+    assert probe.started == [
+        "first",
+        *([] if unknown_kind == "tool" else ["middle"]),
+        "last",
+    ]
 
 
 # 功能：验证可能进入审批的只读批次按原顺序串行执行

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 import pytest
 from pydantic import BaseModel
@@ -13,8 +15,10 @@ from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import LlmResponse, ToolCallBlock, UsageStats
 from sztu_code.core.loop import AgentLoop
 from sztu_code.core.permissions.denial_tracker import DenialTracker
+from sztu_code.core.permissions.manager import PermissionManager
+from sztu_code.core.permissions.policy import PermissionDecision, ToolPolicy
 from sztu_code.core.subagent.registry import BackgroundTaskRegistry
-from sztu_code.core.tools.base import BaseTool, ToolResult
+from sztu_code.core.tools.base import BaseTool, ToolPermission, ToolResult
 from sztu_code.core.tools.registry import ToolRegistry
 
 # --- stubs -------------------------------------------------------------------
@@ -118,6 +122,72 @@ class _FailTool(BaseTool):
         raise RuntimeError("tool error")
 
 
+@dataclass
+class _ConcurrencyProbe:
+    active: int = 0
+    max_active: int = 0
+    started: list[str] = field(default_factory=list)
+    finished: list[str] = field(default_factory=list)
+
+
+class _TimedTool(BaseTool):
+    description = "Waits for a configured delay"
+    input_schema: dict[str, object] = {
+        "type": "object",
+        "properties": {
+            "label": {"type": "string"},
+            "delay": {"type": "number"},
+            "fail": {"type": "boolean"},
+        },
+        "required": ["label", "delay"],
+    }
+
+    # 初始化可声明权限并记录并发行为的测试工具
+    def __init__(
+        self,
+        name: str,
+        permission: ToolPermission,
+        probe: _ConcurrencyProbe,
+    ) -> None:
+        self.name = name
+        self.required_permission = permission
+        self._probe = probe
+
+    # 等待指定时长并返回标签，可按参数产生不可重试失败
+    async def invoke(self, params: dict[str, object]) -> ToolResult:
+        label = str(params["label"])
+        self._probe.active += 1
+        self._probe.max_active = max(self._probe.max_active, self._probe.active)
+        self._probe.started.append(label)
+        try:
+            await asyncio.sleep(float(params["delay"]))
+            self._probe.finished.append(label)
+            if bool(params.get("fail", False)):
+                return ToolResult(
+                    content=f"failed:{label}",
+                    is_error=True,
+                    error_type="schema_error",
+                )
+            return ToolResult(content=f"done:{label}")
+        finally:
+            self._probe.active -= 1
+
+
+class _UnknownPermissionTool(_TimedTool):
+    # 模拟第三方工具返回框架无法识别的权限能力值
+    def classify_permission(self, params: dict[str, object]) -> ToolPermission:
+        return cast(ToolPermission, "unknown")
+
+
+class _RaisingReadTool(_TimedTool):
+    # 模拟工具层异常，验证并发调度会隔离单项异常并继续收集其他结果
+    async def invoke(self, params: dict[str, object]) -> ToolResult:
+        label = str(params["label"])
+        self._probe.started.append(label)
+        await asyncio.sleep(float(params.get("delay", 0)))
+        raise RuntimeError(f"raised:{label}")
+
+
 # --- helpers -----------------------------------------------------------------
 
 
@@ -164,7 +234,295 @@ async def _events(bus: EventBus) -> list[BaseModel]:
     return collected
 
 
+# 用一轮工具调用和结束响应构造并执行调度测试场景
+async def _run_tool_batch(
+    calls: list[ToolCallBlock],
+    tools: list[BaseTool],
+    *,
+    max_concurrency: int,
+    permission_manager: PermissionManager | None = None,
+) -> tuple[ExecutionContext, list[BaseModel], float]:
+    provider = _MockProvider(
+        [
+            LlmResponse(stop_reason="tool_use", tool_calls=calls),
+            LlmResponse(stop_reason="end_turn", text="done"),
+        ]
+    )
+    registry = ToolRegistry()
+    for tool in tools:
+        registry.register(tool)
+    bus = EventBus()
+    events = await _events(bus)
+    loop = AgentLoop(
+        provider,
+        registry,
+        bus,
+        permission_manager=permission_manager,
+        tool_max_concurrency=max_concurrency,
+    )
+    context = _ctx()
+    started = time.monotonic()
+    await loop.run(context)
+    return context, events, time.monotonic() - started
+
+
 # --- tests -------------------------------------------------------------------
+
+
+# 功能：验证三个只读工具在并发上限不小于三时于 220ms 内完成
+# 设计：每个工具独立等待 100ms，并同时断言探针峰值并发度，避免仅靠宽松耗时阈值产生假阳性
+async def test_read_only_batch_runs_concurrently_under_bounded_limit() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": label, "delay": 0.1}, uid=f"read-{label}")
+        for label in ("a", "b", "c")
+    ]
+
+    _context, _events_seen, elapsed = await _run_tool_batch(
+        calls, [tool], max_concurrency=3
+    )
+
+    assert elapsed < 0.22
+    assert probe.max_active == 3
+
+
+# 功能：验证并发上限会限制同批只读工具的实际活跃数
+# 设计：三个等长调用配置为两个执行槽，断言探针峰值而非仅检查总耗时
+async def test_read_only_batch_respects_intermediate_concurrency_limit() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": label, "delay": 0.03}, uid=f"limit-{label}")
+        for label in ("a", "b", "c")
+    ]
+
+    await _run_tool_batch(calls, [tool], max_concurrency=2)
+
+    assert probe.max_active == 2
+
+
+# 功能：验证包含写工具的混合批次保持串行且执行顺序与请求顺序一致
+# 设计：交替使用只读和写权限元数据并记录开始顺序，锁定整批降级规则而非只隔离单个写调用
+async def test_mixed_read_write_batch_stays_serial_in_request_order() -> None:
+    probe = _ConcurrencyProbe()
+    read_tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    write_tool = _TimedTool("timed_write", ToolPermission.WORKSPACE_WRITE, probe)
+    calls = [
+        _tc("timed_read", {"label": "read-a", "delay": 0.02}, uid="mixed-1"),
+        _tc("timed_write", {"label": "write", "delay": 0.02}, uid="mixed-2"),
+        _tc("timed_read", {"label": "read-b", "delay": 0.02}, uid="mixed-3"),
+    ]
+
+    await _run_tool_batch(calls, [read_tool, write_tool], max_concurrency=3)
+
+    assert probe.max_active == 1
+    assert probe.started == ["read-a", "write", "read-b"]
+
+
+# 功能：验证只读批次中间调用失败时其他调用仍完成且结果按请求顺序写回上下文
+# 设计：让第二项最快失败、第三项次快、第一项最慢，故意打乱完成顺序后检查三项完整性及 tool_use_id 顺序
+async def test_read_only_failure_is_isolated_and_context_order_is_stable() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": "first", "delay": 0.06}, uid="ordered-1"),
+        _tc(
+            "timed_read",
+            {"label": "second", "delay": 0.01, "fail": True},
+            uid="ordered-2",
+        ),
+        _tc("timed_read", {"label": "third", "delay": 0.03}, uid="ordered-3"),
+    ]
+
+    context, events, _elapsed = await _run_tool_batch(
+        calls, [tool], max_concurrency=3
+    )
+
+    assert probe.max_active == 3
+    assert set(probe.finished) == {"first", "second", "third"}
+    assert probe.finished != ["first", "second", "third"]
+    result_blocks = context.messages[2]["content"]
+    assert [block["tool_use_id"] for block in result_blocks] == [
+        "ordered-1",
+        "ordered-2",
+        "ordered-3",
+    ]
+    assert [block["content"] for block in result_blocks] == [
+        "done:first",
+        "failed:second",
+        "done:third",
+    ]
+    terminal_ids = [
+        event.tool_use_id  # type: ignore[attr-defined]
+        for event in events
+        if event.type in {"tool.call_finished", "tool.call_failed"}  # type: ignore[attr-defined]
+    ]
+    assert set(terminal_ids) == {"ordered-1", "ordered-2", "ordered-3"}
+
+
+# 功能：验证只读工具抛出未捕获异常时不会取消同批其他调用
+# 设计：中间工具直接抛异常，前后工具仍应完成，并按请求顺序生成完整 tool_result
+async def test_read_only_raised_exception_is_isolated() -> None:
+    probe = _ConcurrencyProbe()
+    read_tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    raising_tool = _RaisingReadTool("raising_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": "first", "delay": 0.02}, uid="raise-1"),
+        _tc("raising_read", {"label": "middle", "delay": 0.01}, uid="raise-2"),
+        _tc("timed_read", {"label": "last", "delay": 0.02}, uid="raise-3"),
+    ]
+
+    context, events, _elapsed = await _run_tool_batch(
+        calls, [read_tool, raising_tool], max_concurrency=3
+    )
+
+    result_blocks = context.messages[2]["content"]
+    assert [block["tool_use_id"] for block in result_blocks] == [
+        "raise-1", "raise-2", "raise-3"
+    ]
+    assert result_blocks[0].get("is_error") is None
+    assert result_blocks[1].get("is_error") is True
+    assert result_blocks[2].get("is_error") is None
+    failed_ids = {
+        event.tool_use_id
+        for event in events
+        if event.type == "tool.call_failed"  # type: ignore[attr-defined]
+    }
+    assert "raise-2" in failed_ids
+
+
+# 功能：验证最大并发数为一时全只读批次保持现有串行行为
+# 设计：三个声明只读的工具仍只允许一个活跃调用，并核对开始顺序以覆盖兼容性边界
+async def test_read_only_batch_with_limit_one_is_serial() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": label, "delay": 0.01}, uid=f"serial-{label}")
+        for label in ("a", "b", "c")
+    ]
+
+    await _run_tool_batch(calls, [tool], max_concurrency=1)
+
+    assert probe.max_active == 1
+    assert probe.started == ["a", "b", "c"]
+
+
+# 功能：验证未知工具和未知权限能力都不会让批次被错误并发
+# 设计：分别混入未注册工具及返回未知权限值的第三方工具，用只读邻居的峰值并发度证明保守降级
+@pytest.mark.parametrize("unknown_kind", ["tool", "permission"])
+async def test_unknown_tool_or_permission_keeps_batch_serial(unknown_kind: str) -> None:
+    probe = _ConcurrencyProbe()
+    read_tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    unknown_tool = _UnknownPermissionTool(
+        "unknown_permission", ToolPermission.READ_ONLY, probe
+    )
+    middle_name = "missing" if unknown_kind == "tool" else "unknown_permission"
+    calls = [
+        _tc("timed_read", {"label": "first", "delay": 0.01}, uid="unknown-1"),
+        _tc(middle_name, {"label": "middle", "delay": 0.01}, uid="unknown-2"),
+        _tc("timed_read", {"label": "last", "delay": 0.01}, uid="unknown-3"),
+    ]
+
+    await _run_tool_batch(calls, [read_tool, unknown_tool], max_concurrency=3)
+
+    assert probe.max_active == 1
+    assert probe.started == ["first", *( ["middle"] if unknown_kind == "permission" else []), "last"]
+
+
+# 功能：验证可能进入审批的只读批次按原顺序串行执行
+# 设计：为只读工具配置 ASK 策略并在请求事件中逐一批准，断言不会同时出现多个待审批调用
+async def test_read_only_batch_requiring_approval_stays_serial() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("approval_read", ToolPermission.READ_ONLY, probe)
+    manager = PermissionManager(
+        {"approval_read": ToolPolicy(default=PermissionDecision.ASK)},
+        timeout_s=1,
+    )
+    pending = 0
+    max_pending = 0
+    bus = EventBus()
+
+    # 收到权限请求后在下一事件循环拍批准，测量同时待批的调用数
+    async def approve(event: BaseModel) -> None:
+        nonlocal pending, max_pending
+        if event.type != "permission.requested":  # type: ignore[attr-defined]
+            return
+        pending += 1
+        max_pending = max(max_pending, pending)
+        await asyncio.sleep(0)
+        manager.respond(event.tool_use_id, "allow_once")  # type: ignore[attr-defined]
+        pending -= 1
+
+    bus.subscribe(approve)
+    provider = _MockProvider(
+        [
+            LlmResponse(
+                stop_reason="tool_use",
+                tool_calls=[
+                    _tc(
+                        "approval_read",
+                        {"label": label, "delay": 0.01},
+                        uid=f"approval-{label}",
+                    )
+                    for label in ("a", "b")
+                ],
+            ),
+            LlmResponse(stop_reason="end_turn", text="done"),
+        ]
+    )
+    registry = ToolRegistry()
+    registry.register(tool)
+    loop = AgentLoop(
+        provider,
+        registry,
+        bus,
+        permission_manager=manager,
+        tool_max_concurrency=2,
+    )
+
+    await loop.run(_ctx())
+
+    assert max_pending == 1
+    assert probe.max_active == 1
+
+
+# 功能：验证工具事件携带批次标识、排队与起止时间及调度模式并保持正确 tool_use_id
+# 设计：收集统一 EventBus 事件并按 tool_use_id 配对，直接覆盖 Trace 订阅者会持久化的最小事件元数据
+async def test_tool_events_include_batch_scheduling_trace_metadata() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": label, "delay": 0.01}, uid=f"trace-{label}")
+        for label in ("a", "b")
+    ]
+
+    _context, events, _elapsed = await _run_tool_batch(
+        calls, [tool], max_concurrency=2
+    )
+
+    started = {
+        event.tool_use_id: event  # type: ignore[attr-defined]
+        for event in events
+        if event.type == "tool.call_started"  # type: ignore[attr-defined]
+    }
+    terminal = {
+        event.tool_use_id: event  # type: ignore[attr-defined]
+        for event in events
+        if event.type in {"tool.call_finished", "tool.call_failed"}  # type: ignore[attr-defined]
+    }
+    assert set(started) == {"trace-a", "trace-b"}
+    assert set(terminal) == set(started)
+    assert len({event.batch_id for event in started.values()}) == 1  # type: ignore[attr-defined]
+    for tool_use_id, start_event in started.items():
+        finish_event = terminal[tool_use_id]
+        assert start_event.scheduler_mode == "concurrent"  # type: ignore[attr-defined]
+        assert start_event.queued_at <= start_event.started_at  # type: ignore[attr-defined]
+        assert start_event.queue_ms >= 0  # type: ignore[attr-defined]
+        assert finish_event.batch_id == start_event.batch_id  # type: ignore[attr-defined]
+        assert finish_event.scheduler_mode == "concurrent"  # type: ignore[attr-defined]
+        assert finish_event.started_at == start_event.started_at  # type: ignore[attr-defined]
+        assert finish_event.finished_at >= finish_event.started_at  # type: ignore[attr-defined]
 
 
 # 功能：验证 LLM 返回 end_turn 时 loop 将 context 标记为 success

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -186,6 +186,13 @@ class _StringReadOnlyPermissionTool(_TimedTool):
         return cast(ToolPermission, "read_only")
 
 
+class _StringAllowPermissionManager(PermissionManager):
+    """Simulates a malformed third-party policy decision result."""
+
+    def evaluate(self, tool_name: str, params: dict[str, object]) -> PermissionDecision:
+        return cast(PermissionDecision, "allow")
+
+
 class _RaisingReadTool(_TimedTool):
     # 模拟工具层异常，验证并发调度会隔离单项异常并继续收集其他结果
     async def invoke(self, params: dict[str, object]) -> ToolResult:
@@ -450,6 +457,29 @@ async def test_unknown_tool_or_permission_keeps_batch_serial(unknown_kind: str) 
         *([] if unknown_kind == "tool" else ["middle"]),
         "last",
     ]
+
+
+# 功能：验证裸字符串 allow 不会被视为明确的权限允许，从而错误开启并发
+# 设计：模拟不符合 PermissionDecision 合约的权限管理器，断言只读邻居仍被保守串行调度
+async def test_non_enum_permission_allow_keeps_batch_serial() -> None:
+    probe = _ConcurrencyProbe()
+    tool = _TimedTool("timed_read", ToolPermission.READ_ONLY, probe)
+    calls = [
+        _tc("timed_read", {"label": label, "delay": 0.01}, uid=f"allow-{label}")
+        for label in ("first", "second", "last")
+    ]
+
+    await _run_tool_batch(
+        calls,
+        [tool],
+        max_concurrency=3,
+        permission_manager=_StringAllowPermissionManager(
+            {"timed_read": ToolPolicy(default=PermissionDecision.ALLOW)}
+        ),
+    )
+
+    assert probe.max_active == 1
+    assert probe.started == ["first", "second", "last"]
 
 
 # 功能：验证可能进入审批的只读批次按原顺序串行执行

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from typing import Any
 
+import pytest
 from pydantic import BaseModel
 
 from sztu_code.core.config import SztuConfig
@@ -245,6 +247,26 @@ async def test_config_max_steps_passed_to_loop(tmp_path: Path) -> None:
     provider = _LoopingProvider()
     await _run(provider=provider, config=_config(max_steps=3), tmp_path=tmp_path)
     assert provider._call == 3
+
+
+# 功能：验证配置中的工具并发上限会传递给 AgentLoop
+# 设计：替换 loop.run 捕获已构造实例，直接断言 runner 不会丢失 agent 配置值
+async def test_config_tool_concurrency_passed_to_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[int] = []
+
+    async def fake_run(self: Any, context: Any) -> None:
+        captured.append(self._tool_max_concurrency)
+        context.mark_success()
+
+    monkeypatch.setattr("sztu_code.core.runner.AgentLoop.run", fake_run)
+    config = _config()
+    config.agent.tool_max_concurrency = 2
+
+    await _run(config=config, tmp_path=tmp_path)
+
+    assert captured == [2]
 
 
 # 功能：验证 run.started 和 run.finished 事件使用相同且非空的 run_id

--- a/tests/unit/test_spawn_agent_tool.py
+++ b/tests/unit/test_spawn_agent_tool.py
@@ -417,6 +417,26 @@ async def test_budget_fields_propagate_to_child(tmp_path: Path, monkeypatch: pyt
     assert captured[0].max_wall_clock_s == 30
 
 
+# 功能：验证父代理的工具并发上限会继承给子 AgentLoop
+# 设计：替换 child loop 的 run 捕获实例私有配置，覆盖多代理传播链而不依赖实际工具执行
+async def test_tool_concurrency_propagates_to_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[int] = []
+
+    async def fake_run(self: Any, context: ExecutionContext) -> None:
+        captured.append(self._tool_max_concurrency)
+        context.mark_success()
+
+    monkeypatch.setattr("sztu_code.core.subagent.tool.AgentLoop.run", fake_run)
+    tool, _, _ = _make_tool(tmp_path)
+    tool._tool_max_concurrency = 2
+
+    await tool.invoke({"description": "任务", "prompt": "干活"})
+
+    assert captured == [2]
+
+
 # 功能：嵌套 spawn 继承解析后的 child_max_steps，而非父传入的固定值
 # 设计：profile max_steps=2、父 max_steps=5，spy SpawnAgentTool.__init__ 断言嵌套传 2
 async def test_nested_spawn_inherits_resolved_max_steps(


### PR DESCRIPTION
## Summary

实现 Issue #70：为 Agent Loop 增加同轮明确只读工具调用的有界并发，同时保持副作用工具确定性和结果顺序。

Fixes #70

## Behavior

- 依据工具能力元数据判定只读，不使用工具名称白名单。
- 混入写工具、Shell、审批或未知权限时整批串行。
- 并发上限支持 TOML 和环境变量配置。
- ExecutionContext、canvas、offload、错误和追踪后处理保持原始请求顺序。
- Trace 事件记录批次、调度模式、排队时间及起止时间。

## Validation

- `tests/unit/test_loop.py`：43 passed
- 配置、调用、重试定向测试：41 passed
- Runner/子 Agent 透传测试：2 passed
- Ruff：通过
- Mypy：通过
- `scripts/gen_protocol_doc.py --check`：通过
- 完整 unit tests 受 Windows 临时目录权限和执行时限影响，未完整结束。

## Risk

并发仅作用于明确只读工具；写入、Shell、审批和未知能力继续串行。并发结果在后处理中按模型请求顺序写回。

## UI evidence

N/A

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。
- [x] 用户文档、配置示例和迁移说明已同步。
- [x] 提交包含 `Signed-off-by`（DCO）。