### PR TITLE
feat: 自动识别项目框架并生成验证策略（#13）

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "tauri": "tauri",
-    "test:unit": "tsx --test tests/playwright-chromium.test.ts tests/platform.test.ts tests/timeline-stream.test.ts",
+    "test:unit": "tsx --test tests/playwright-chromium.test.ts tests/platform.test.ts tests/project-profile.test.ts tests/timeline-stream.test.ts",
     "test:visual": "playwright test"
   },
   "dependencies": {

--- a/desktop/src/components/Inspector/ProjectInspector.vue
+++ b/desktop/src/components/Inspector/ProjectInspector.vue
@@ -8,11 +8,13 @@ import {
 } from "@lucide/vue";
 import {
   changeDiff, listChanges, readFile,
-  type ChangeSummary,
+  getWorkspaceProfile,
+  type ChangeSummary, type DetectionEvidence, type ProjectComponent, type TechnologyFinding, type ValidationCategory,
 } from "../../services/sztu-runtime";
 import BrowserWebview from "./BrowserWebview.vue";
 import CodePreview from "./CodePreview.vue";
 import FileTree from "./FileTree.vue";
+import { createProjectProfileController, type ProjectProfileState } from "./project-profile";
 import { fileTypeIconUrl } from "../../utils/fileIcon";
 import type { TimelineStep } from "../timeline/types";
 
@@ -32,7 +34,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{ close: [] }>();
 
-type SectionKey = "todo" | "artifacts" | "references";
+type SectionKey = "profile" | "todo" | "artifacts" | "references";
 type BrowserTab = {
   id: number;
   label: string;
@@ -51,8 +53,8 @@ const activeTab = ref<ActiveTab>("files");
 const browserSequence = ref(0);
 const sandboxSequence = ref(0);
 const browserTabs = ref<BrowserTab[]>([]);
-const workspaceTabs = ref<WorkspaceTab[]>([{ key: "files", kind: "files" }]);
-const openSections = ref<Set<SectionKey>>(new Set(["todo", "artifacts", "references"]));
+const workspaceTabs = ref<WorkspaceTab[]>([{ key: "summary", kind: "summary" }, { key: "files", kind: "files" }]);
+const openSections = ref<Set<SectionKey>>(new Set(["profile", "todo", "artifacts", "references"]));
 const changes = ref<ChangeSummary[]>([]);
 const loadingArtifacts = ref(false);
 const notice = ref("");
@@ -75,6 +77,17 @@ function closePreviewOnOutside(event: PointerEvent) {
 const expandedPanel = ref(false);
 const toolMenuOpen = ref(false);
 const toolMenuRoot = ref<HTMLElement | null>(null);
+const projectProfileController = createProjectProfileController(getWorkspaceProfile);
+const profileState = ref<ProjectProfileState>(projectProfileController.state);
+const stopProjectProfileSubscription = projectProfileController.subscribe((next) => { profileState.value = next; });
+
+const validationCategories: Array<{ key: ValidationCategory; label: string }> = [
+  { key: "format", label: "格式化" },
+  { key: "static_check", label: "静态检查" },
+  { key: "unit_test", label: "单元测试" },
+  { key: "integration_test", label: "集成测试" },
+  { key: "build", label: "构建" },
+];
 
 const plan = computed(() => [...(props.steps ?? [])].reverse().find((step) => step.plan?.length)?.plan ?? []);
 const completed = computed(() => plan.value.filter((item) => item.status === "completed").length);
@@ -134,6 +147,39 @@ function toggleSection(section: SectionKey) {
   if (next.has(section)) next.delete(section);
   else next.add(section);
   openSections.value = next;
+}
+
+function openSummary() {
+  if (!workspaceTabs.value.some((tab) => tab.kind === "summary")) workspaceTabs.value.unshift({ key: "summary", kind: "summary" });
+  activeTab.value = "summary";
+  selectedPath.value = "";
+  toolMenuOpen.value = false;
+}
+
+function projectTechnologies(project: ProjectComponent): Array<{ label: string; findings: TechnologyFinding[] }> {
+  return [
+    { label: "语言", findings: project.languages },
+    { label: "框架", findings: project.frameworks },
+    { label: "包管理器", findings: project.package_managers },
+    { label: "构建工具", findings: project.build_tools },
+  ];
+}
+
+function commandsFor(project: ProjectComponent, category: ValidationCategory) {
+  return project.validation_plan.filter((command) => command.category === category);
+}
+
+function evidenceLabel(evidence: DetectionEvidence): string {
+  const detail = evidence.detail ? `：${evidence.detail}` : "";
+  return `${evidence.path} · ${evidence.rule}${detail}`;
+}
+
+function confidenceLabel(confidence: TechnologyFinding["confidence"]): string {
+  return confidence === "confirmed" ? "已确认" : "可能";
+}
+
+async function refreshProjectProfile() {
+  await projectProfileController.refresh();
 }
 
 function activateBrowser(id: number) {
@@ -327,9 +373,13 @@ watch(() => [props.workspaceId, props.runId], () => {
   browserSequence.value = 0;
   sandboxSequence.value = 0;
   browserTabs.value = [];
-  workspaceTabs.value = [{ key: "files", kind: "files" }];
+  workspaceTabs.value = [{ key: "summary", kind: "summary" }, { key: "files", kind: "files" }];
   selectedPath.value = "";
   void refreshArtifacts();
+}, { immediate: true });
+
+watch(() => props.workspaceId, (workspaceId) => {
+  void projectProfileController.setWorkspace(workspaceId || null);
 }, { immediate: true });
 
 // 「查看项目文件」信号：seq 变化时切换到文件标签页（在 workspaceId/runId 重置之后执行）。
@@ -344,6 +394,7 @@ onMounted(() => {
   document.addEventListener("keydown", closeToolMenuOnEscape);
 });
 onBeforeUnmount(() => {
+  stopProjectProfileSubscription();
   document.removeEventListener("pointerdown", closeToolMenu);
   document.removeEventListener("pointerdown", closePreviewOnOutside);
   document.removeEventListener("keydown", closeToolMenuOnEscape);
@@ -356,6 +407,7 @@ onBeforeUnmount(() => {
       <div ref="toolMenuRoot" class="workspace-tool-menu-root">
         <button type="button" class="workspace-tool-menu-trigger" :class="{ active: toolMenuOpen }" aria-label="打开功能" aria-haspopup="menu" :aria-expanded="toolMenuOpen" @click="toolMenuOpen = !toolMenuOpen"><Plus :size="16" /></button>
         <nav v-if="toolMenuOpen" class="workspace-tool-menu" aria-label="选择功能" role="menu">
+          <button type="button" role="menuitem" :class="{ active: activeTab === 'summary' }" @click="openSummary"><ListChecks :size="15" /><span>任务摘要</span></button>
           <button type="button" role="menuitem" :class="{ active: currentBrowser }" @click="openBrowser"><Globe2 :size="15" /><span>浏览器</span></button>
           <button type="button" role="menuitem" :class="{ active: activeTab.startsWith('sandbox-') }" @click="openTerminal"><SquareTerminal :size="15" /><span>终端</span></button>
           <button type="button" role="menuitem" :class="{ active: activeTab === 'files' }" @click="openFiles"><FolderOpen :size="15" /><span>文件</span></button>
@@ -382,6 +434,63 @@ onBeforeUnmount(() => {
     </header>
 
     <main v-if="activeTab === 'summary'" class="task-summary-view">
+      <section class="summary-section project-profile-section" :class="{ collapsed: !openSections.has('profile') }">
+        <button type="button" class="summary-section-trigger" :aria-expanded="openSections.has('profile')" @click="toggleSection('profile')">
+          <b>项目画像</b><ChevronDown :size="13" /><small v-if="profileState.profile">{{ profileState.profile.monorepo ? `Monorepo · ${profileState.profile.projects.length} 个项目` : `${profileState.profile.projects.length} 个项目` }}</small>
+        </button>
+        <div v-if="openSections.has('profile')" class="summary-section-body project-profile-body">
+          <div class="project-profile-toolbar">
+            <p><b>基于工作区结构生成</b><small>仅建议，未执行；实际运行仍需经过工具权限与审批。</small></p>
+            <button type="button" class="summary-refresh" :disabled="profileState.loading" @click="refreshProjectProfile"><RefreshCw :size="13" :class="{ spin: profileState.loading }" />{{ profileState.refreshing ? '正在刷新' : '刷新项目画像' }}</button>
+          </div>
+          <div v-if="profileState.loading && !profileState.profile" class="project-profile-loading"><LoaderCircle :size="16" class="spin" /><span>正在识别项目结构</span></div>
+          <p v-if="profileState.error" class="project-profile-error" role="alert">{{ profileState.profile ? `刷新失败，仍显示上次检测结果：${profileState.error}` : `项目画像加载失败：${profileState.error}` }}</p>
+          <template v-if="profileState.profile">
+            <div class="project-profile-meta">
+              <span><b>根目录</b><code :title="profileState.profile.root_path">{{ profileState.profile.root_path }}</code></span>
+              <span v-if="profileState.profile.monorepo" class="project-profile-badge">Monorepo</span>
+              <span v-if="profileState.profile.scan_limited" class="project-profile-warning">扫描范围受限，结果可能不完整</span>
+            </div>
+            <article v-for="project in profileState.profile.projects" :key="project.path" class="project-profile-component">
+              <header>
+                <div><b>{{ project.path === '.' ? '工作区根项目' : project.path }}</b><small>路径归属：{{ project.path }}</small></div>
+                <span>仅建议，未执行</span>
+              </header>
+              <div class="project-technology-grid">
+                <section v-for="group in projectTechnologies(project)" :key="group.label">
+                  <b>{{ group.label }}</b>
+                  <div v-if="group.findings.length" class="project-technology-list">
+                    <span v-for="finding in group.findings" :key="finding.name" :title="finding.evidence.map(evidenceLabel).join('\n')"><em>{{ finding.name }}</em><small>{{ confidenceLabel(finding.confidence) }}</small></span>
+                  </div>
+                  <small v-else>未识别</small>
+                </section>
+              </div>
+              <div class="project-validation-plan">
+                <section v-for="category in validationCategories" :key="category.key" class="project-validation-group">
+                  <header><b>{{ category.label }}</b><small>{{ commandsFor(project, category.key).length }} 条建议</small></header>
+                  <p v-if="!commandsFor(project, category.key).length" class="project-validation-empty">暂无推荐命令</p>
+                  <article v-for="command in commandsFor(project, category.key)" :key="`${command.working_directory}:${command.command}`" class="project-validation-command">
+                    <div><code>{{ command.command }}</code><span>目录：{{ command.working_directory || '.' }}</span></div>
+                    <p>{{ command.reason }}</p>
+                    <small v-if="command.evidence.length">依据：{{ command.evidence.map(evidenceLabel).join('；') }}</small>
+                    <em>仅建议，未执行</em>
+                  </article>
+                </section>
+              </div>
+              <details v-if="project.evidence.length" class="project-evidence">
+                <summary>识别证据（{{ project.evidence.length }}）</summary>
+                <ul><li v-for="evidence in project.evidence" :key="`${evidence.path}:${evidence.rule}`"><code>{{ evidence.path }}</code><span>{{ evidence.rule }}</span><small v-if="evidence.detail">{{ evidence.detail }}</small></li></ul>
+              </details>
+            </article>
+          </template>
+          <div v-else-if="!profileState.loading && !profileState.error" class="summary-empty project-profile-empty">
+            <span class="summary-empty-icon"><ListChecks :size="15" /></span>
+            <b>暂无项目画像</b>
+            <p>可点击“刷新项目画像”重新检测当前工作区。</p>
+          </div>
+        </div>
+      </section>
+
       <section class="summary-section" :class="{ collapsed: !openSections.has('todo') }">
         <button type="button" class="summary-section-trigger" :aria-expanded="openSections.has('todo')" @click="toggleSection('todo')">
           <b>待办</b><ChevronDown :size="13" /><small v-if="plan.length">{{ completed }}/{{ plan.length }}</small>

--- a/desktop/src/components/Inspector/project-profile.ts
+++ b/desktop/src/components/Inspector/project-profile.ts
@@ -1,0 +1,81 @@
+import { getWorkspaceProfile, type ProjectProfile } from "../../services/sztu-runtime";
+
+export type ProjectProfileState = {
+  workspaceId: string | null;
+  profile: ProjectProfile | null;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+};
+
+export type WorkspaceProfileLoader = (workspaceId: string, refresh?: boolean) => Promise<ProjectProfile>;
+type StateListener = (state: ProjectProfileState) => void;
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function snapshot(state: ProjectProfileState): ProjectProfileState {
+  return { ...state };
+}
+
+export function createProjectProfileController(loadProfile: WorkspaceProfileLoader = getWorkspaceProfile) {
+  let generation = 0;
+  let state: ProjectProfileState = {
+    workspaceId: null,
+    profile: null,
+    loading: false,
+    refreshing: false,
+    error: null,
+  };
+  const listeners = new Set<StateListener>();
+
+  function publish(next: ProjectProfileState): void {
+    state = next;
+    const current = snapshot(state);
+    for (const listener of listeners) listener(current);
+  }
+
+  async function request(workspaceId: string, refresh: boolean): Promise<void> {
+    const requestGeneration = ++generation;
+    const keepExisting = state.workspaceId === workspaceId;
+    publish({
+      workspaceId,
+      profile: keepExisting ? state.profile : null,
+      loading: true,
+      refreshing: refresh,
+      error: null,
+    });
+    try {
+      const profile = await loadProfile(workspaceId, refresh);
+      if (requestGeneration !== generation || state.workspaceId !== workspaceId) return;
+      publish({ workspaceId, profile, loading: false, refreshing: false, error: null });
+    } catch (error) {
+      if (requestGeneration !== generation || state.workspaceId !== workspaceId) return;
+      publish({ ...state, loading: false, refreshing: false, error: errorMessage(error) });
+    }
+  }
+
+  return {
+    get state(): ProjectProfileState {
+      return snapshot(state);
+    },
+    subscribe(listener: StateListener): () => void {
+      listeners.add(listener);
+      listener(snapshot(state));
+      return () => listeners.delete(listener);
+    },
+    async setWorkspace(workspaceId: string | null): Promise<void> {
+      if (!workspaceId) {
+        generation += 1;
+        publish({ workspaceId: null, profile: null, loading: false, refreshing: false, error: null });
+        return;
+      }
+      await request(workspaceId, false);
+    },
+    async refresh(): Promise<void> {
+      if (!state.workspaceId || state.loading) return;
+      await request(state.workspaceId, true);
+    },
+  };
+}

--- a/desktop/src/file-rail.css
+++ b/desktop/src/file-rail.css
@@ -101,6 +101,56 @@
 .summary-empty b { color: #292d2a; font-size: 11px; font-weight: 500; }
 .summary-empty p { max-width: 280px; margin: 0; color: #a1a5a2; font-size: 10px; line-height: 1.6; }
 
+.project-profile-body { display: grid; gap: 14px; }
+.project-profile-toolbar { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+.project-profile-toolbar p { display: grid; gap: 3px; margin: 0; }
+.project-profile-toolbar p b { color: #313632; font-size: 10px; font-weight: 600; }
+.project-profile-toolbar p small { color: #858c87; font-size: 9px; line-height: 1.5; }
+.project-profile-toolbar .summary-refresh { flex: 0 0 auto; margin: 0; }
+.project-profile-loading { display: flex; min-height: 72px; align-items: center; justify-content: center; gap: 7px; color: #87908a; font-size: 10px; }
+.project-profile-error { margin: 0; padding: 7px 8px; color: #8b4b3c; background: #fff4f1; border: 1px solid #f0dad4; border-radius: 5px; font-size: 9px; line-height: 1.5; overflow-wrap: anywhere; }
+.project-profile-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 9px; padding: 8px; color: #68706b; background: #f6f8f6; border: 1px solid #e6e9e6; border-radius: 6px; font-size: 9px; }
+.project-profile-meta > span:first-child { display: flex; min-width: 0; align-items: center; gap: 5px; }
+.project-profile-meta b { flex: 0 0 auto; color: #626964; font-weight: 500; }
+.project-profile-meta code { min-width: 0; overflow: hidden; color: #444b46; font: 9px Consolas, "Cascadia Mono", monospace; text-overflow: ellipsis; white-space: nowrap; }
+.project-profile-badge, .project-profile-warning { padding: 2px 5px; border-radius: 4px; white-space: nowrap; }
+.project-profile-badge { color: #246457; background: #e9f4ef; }
+.project-profile-warning { color: #98623a; background: #fff5e9; }
+.project-profile-component { display: grid; gap: 11px; padding: 10px; background: #fff; border: 1px solid #e5e8e5; border-radius: 7px; }
+.project-profile-component > header { display: flex; align-items: start; justify-content: space-between; gap: 9px; }
+.project-profile-component > header > div { display: grid; min-width: 0; gap: 2px; }
+.project-profile-component > header b { overflow: hidden; color: #303631; font-size: 10px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.project-profile-component > header small { overflow: hidden; color: #8b918d; font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.project-profile-component > header > span, .project-validation-command > em { flex: 0 0 auto; padding: 2px 4px; color: #63706a; background: #f0f4f1; border-radius: 3px; font-size: 8px; font-style: normal; white-space: nowrap; }
+.project-technology-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; }
+.project-technology-grid > section { display: grid; min-width: 0; gap: 4px; padding: 6px; background: #fafbfa; border: 1px solid #eff1ef; border-radius: 5px; }
+.project-technology-grid > section > b { color: #737a75; font-size: 8px; font-weight: 500; }
+.project-technology-grid > section > small { color: #a2a7a3; font-size: 8px; }
+.project-technology-list { display: flex; flex-wrap: wrap; gap: 4px; }
+.project-technology-list > span { display: inline-flex; min-width: 0; align-items: center; gap: 3px; padding: 2px 4px; color: #45504a; background: #f0f4f1; border-radius: 3px; }
+.project-technology-list em { overflow: hidden; font-size: 8px; font-style: normal; text-overflow: ellipsis; white-space: nowrap; }
+.project-technology-list small { color: #87908a; font-size: 7px; }
+.project-validation-plan { display: grid; gap: 7px; }
+.project-validation-group { display: grid; gap: 5px; padding-top: 8px; border-top: 1px solid #edf0ed; }
+.project-validation-group > header { display: flex; align-items: center; gap: 5px; }
+.project-validation-group > header b { color: #5b645e; font-size: 9px; font-weight: 500; }
+.project-validation-group > header small { color: #a0a6a2; font-size: 8px; }
+.project-validation-empty { margin: 0; color: #a2a7a3; font-size: 8px; }
+.project-validation-command { display: grid; gap: 4px; padding: 7px; background: #fafbfa; border: 1px solid #edf0ed; border-radius: 5px; }
+.project-validation-command > div { display: grid; min-width: 0; gap: 4px; }
+.project-validation-command code { display: block; overflow-x: auto; color: #303b34; font: 9px/1.45 Consolas, "Cascadia Mono", monospace; white-space: pre; }
+.project-validation-command > div > span, .project-validation-command > small { color: #858c88; font-size: 8px; line-height: 1.45; overflow-wrap: anywhere; }
+.project-validation-command p { margin: 0; color: #5d665f; font-size: 8px; line-height: 1.45; }
+.project-validation-command > em { justify-self: start; }
+.project-evidence { color: #7a827d; font-size: 8px; }
+.project-evidence summary { cursor: pointer; color: #68716b; }
+.project-evidence ul { display: grid; gap: 4px; margin: 7px 0 0; padding: 0; list-style: none; }
+.project-evidence li { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 3px 6px; padding: 5px 6px; background: #fafbfa; border-radius: 4px; }
+.project-evidence code { overflow: hidden; color: #4c554f; font: 8px Consolas, "Cascadia Mono", monospace; text-overflow: ellipsis; white-space: nowrap; }
+.project-evidence li > span { min-width: 0; color: #737b75; overflow-wrap: anywhere; }
+.project-evidence li > small { grid-column: 1 / -1; color: #969d98; line-height: 1.4; overflow-wrap: anywhere; }
+.project-profile-empty { min-height: 96px; }
+
 .artifact-list { display: grid; gap: 3px; padding-top: 4px; }
 .artifact-list > button { display: grid; width: 100%; min-height: 43px; grid-template-columns: 28px minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 4px 6px; color: #4c534f; background: transparent; border-radius: 6px; text-align: left; }
 .artifact-list > button:hover { background: #f3f5f3; }

--- a/desktop/src/services/sztu-runtime.ts
+++ b/desktop/src/services/sztu-runtime.ts
@@ -5,6 +5,41 @@ export type Workspace = { workspace_id: string; name: string; path: string; arch
 export type NativeSettings = { autostart: boolean; stay_awake: boolean; supported: boolean };
 export type WorkspaceNode = { path: string; name: string; kind: "directory" | "file"; children?: WorkspaceNode[] };
 export type FileSearchMatch = { path: string; line: number; preview: string };
+export type DetectionEvidence = {
+  path: string;
+  rule: string;
+  detail?: string | null;
+  strength: "confirmed" | "supporting" | "weak";
+};
+export type TechnologyFinding = {
+  name: string;
+  confidence: "confirmed" | "likely";
+  evidence: DetectionEvidence[];
+};
+export type ValidationCategory = "format" | "static_check" | "unit_test" | "integration_test" | "build";
+export type ValidationCommand = {
+  category: ValidationCategory;
+  command: string;
+  working_directory: string;
+  reason: string;
+  evidence: DetectionEvidence[];
+  recommendation_only: boolean;
+};
+export type ProjectComponent = {
+  path: string;
+  languages: TechnologyFinding[];
+  frameworks: TechnologyFinding[];
+  package_managers: TechnologyFinding[];
+  build_tools: TechnologyFinding[];
+  evidence: DetectionEvidence[];
+  validation_plan: ValidationCommand[];
+};
+export type ProjectProfile = {
+  root_path: string;
+  monorepo: boolean;
+  projects: ProjectComponent[];
+  scan_limited: boolean;
+};
 export type FileReadResult = {
   content: string; encoding: string; binary: boolean; truncated: boolean;
   media_base64?: string | null; mime_type?: string | null;
@@ -230,6 +265,11 @@ export async function workspaceStatus(workspaceId: string): Promise<WorkspaceSta
     is_git_repository: Boolean(result.is_git_repository),
     changed_file_count: Number(result.changed_file_count ?? 0),
   };
+}
+
+export async function getWorkspaceProfile(workspaceId: string, refresh = false): Promise<ProjectProfile> {
+  const result = await client.request("workspace.profile", { workspace_id: workspaceId, refresh });
+  return result.profile as ProjectProfile;
 }
 
 export async function workspaceTree(workspaceId: string, path = "", maxDepth = 1): Promise<WorkspaceNode[]> {

--- a/desktop/src/services/sztu-runtime.ts
+++ b/desktop/src/services/sztu-runtime.ts
@@ -23,7 +23,7 @@ export type ValidationCommand = {
   working_directory: string;
   reason: string;
   evidence: DetectionEvidence[];
-  recommendation_only: boolean;
+  recommendation_only: true;
 };
 export type ProjectComponent = {
   path: string;

--- a/desktop/tests/project-profile.test.ts
+++ b/desktop/tests/project-profile.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createProjectProfileController } from "../src/components/Inspector/project-profile";
+import type { ProjectProfile } from "../src/services/sztu-runtime";
+
+function profile(rootPath: string): ProjectProfile {
+  return {
+    root_path: rootPath,
+    monorepo: false,
+    projects: [{
+      path: ".",
+      languages: [{ name: "Python", confidence: "confirmed", evidence: [] }],
+      frameworks: [],
+      package_managers: [],
+      build_tools: [],
+      evidence: [],
+      validation_plan: [],
+    }],
+    scan_limited: false,
+  };
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => { resolve = nextResolve; });
+  return { promise, resolve };
+}
+
+test("loads a workspace profile on first selection", async () => {
+  const calls: Array<{ workspaceId: string; refresh: boolean }> = [];
+  const controller = createProjectProfileController(async (workspaceId, refresh) => {
+    calls.push({ workspaceId, refresh });
+    return profile("C:/projects/alpha");
+  });
+
+  const loading = controller.setWorkspace("workspace-alpha");
+  assert.equal(controller.state.loading, true);
+  assert.equal(controller.state.profile, null);
+  await loading;
+
+  assert.deepEqual(calls, [{ workspaceId: "workspace-alpha", refresh: false }]);
+  assert.equal(controller.state.profile?.root_path, "C:/projects/alpha");
+  assert.equal(controller.state.error, null);
+});
+
+test("refreshes the current workspace profile with a new result", async () => {
+  const results = [profile("C:/projects/alpha"), profile("C:/projects/alpha-updated")];
+  const calls: Array<{ workspaceId: string; refresh: boolean }> = [];
+  const controller = createProjectProfileController(async (workspaceId, refresh) => {
+    calls.push({ workspaceId, refresh });
+    return results.shift()!;
+  });
+
+  await controller.setWorkspace("workspace-alpha");
+  await controller.refresh();
+
+  assert.deepEqual(calls, [
+    { workspaceId: "workspace-alpha", refresh: false },
+    { workspaceId: "workspace-alpha", refresh: true },
+  ]);
+  assert.equal(controller.state.profile?.root_path, "C:/projects/alpha-updated");
+});
+
+test("keeps the previous profile when an explicit refresh fails", async () => {
+  const previous = profile("C:/projects/alpha");
+  let request = 0;
+  const controller = createProjectProfileController(async () => {
+    request += 1;
+    if (request === 1) return previous;
+    throw new Error("profile service unavailable");
+  });
+
+  await controller.setWorkspace("workspace-alpha");
+  await controller.refresh();
+
+  assert.equal(controller.state.profile, previous);
+  assert.equal(controller.state.loading, false);
+  assert.equal(controller.state.error, "profile service unavailable");
+});
+
+test("ignores stale responses after switching workspaces", async () => {
+  const first = deferred<ProjectProfile>();
+  const second = deferred<ProjectProfile>();
+  const controller = createProjectProfileController((workspaceId) => workspaceId === "workspace-alpha" ? first.promise : second.promise);
+
+  const alpha = controller.setWorkspace("workspace-alpha");
+  const beta = controller.setWorkspace("workspace-beta");
+  second.resolve(profile("C:/projects/beta"));
+  await beta;
+  first.resolve(profile("C:/projects/alpha"));
+  await alpha;
+
+  assert.equal(controller.state.workspaceId, "workspace-beta");
+  assert.equal(controller.state.profile?.root_path, "C:/projects/beta");
+  assert.equal(controller.state.error, null);
+});

--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -188,6 +188,275 @@ All commands are sent as JSON-RPC 2.0 requests. The `type` field inside `params`
 }
 ```
 
+### WorkspaceProfileCommand
+
+| Field | Type | Required |
+|---|---|---|
+| `type` | `string` | no |
+| `workspace_id` | `string` | yes |
+| `refresh` | `boolean` | no |
+
+```json
+{
+  "properties": {
+    "type": {
+      "const": "workspace.profile",
+      "default": "workspace.profile",
+      "title": "Type",
+      "type": "string"
+    },
+    "workspace_id": {
+      "title": "Workspace Id",
+      "type": "string"
+    },
+    "refresh": {
+      "default": false,
+      "title": "Refresh",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "workspace_id"
+  ],
+  "title": "WorkspaceProfileCommand",
+  "type": "object"
+}
+```
+
+### WorkspaceProfileResult
+
+| Field | Type | Required |
+|---|---|---|
+| `profile` | `object` | yes |
+
+```json
+{
+  "$defs": {
+    "DetectionEvidence": {
+      "description": "\u63cf\u8ff0\u4e00\u9879\u68c0\u6d4b\u7ed3\u8bba\u7684\u672c\u5730\u8bc1\u636e\u3002",
+      "properties": {
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "rule": {
+          "title": "Rule",
+          "type": "string"
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Detail"
+        },
+        "strength": {
+          "$ref": "#/$defs/EvidenceStrength",
+          "default": "supporting"
+        }
+      },
+      "required": [
+        "path",
+        "rule"
+      ],
+      "title": "DetectionEvidence",
+      "type": "object"
+    },
+    "EvidenceStrength": {
+      "enum": [
+        "confirmed",
+        "supporting",
+        "weak"
+      ],
+      "title": "EvidenceStrength",
+      "type": "string"
+    },
+    "ProjectComponent": {
+      "description": "\u63cf\u8ff0\u5de5\u4f5c\u533a\u5185\u4e00\u4e2a\u72ec\u7acb\u9879\u76ee\u8fb9\u754c\u7684\u6280\u672f\u753b\u50cf\u3002",
+      "properties": {
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "languages": {
+          "items": {
+            "$ref": "#/$defs/TechnologyFinding"
+          },
+          "title": "Languages",
+          "type": "array"
+        },
+        "frameworks": {
+          "items": {
+            "$ref": "#/$defs/TechnologyFinding"
+          },
+          "title": "Frameworks",
+          "type": "array"
+        },
+        "package_managers": {
+          "items": {
+            "$ref": "#/$defs/TechnologyFinding"
+          },
+          "title": "Package Managers",
+          "type": "array"
+        },
+        "build_tools": {
+          "items": {
+            "$ref": "#/$defs/TechnologyFinding"
+          },
+          "title": "Build Tools",
+          "type": "array"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/DetectionEvidence"
+          },
+          "title": "Evidence",
+          "type": "array"
+        },
+        "validation_plan": {
+          "items": {
+            "$ref": "#/$defs/ValidationCommand"
+          },
+          "title": "Validation Plan",
+          "type": "array"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "ProjectComponent",
+      "type": "object"
+    },
+    "ProjectProfile": {
+      "description": "\u63cf\u8ff0\u6574\u4e2a\u5de5\u4f5c\u533a\u7684\u9879\u76ee\u753b\u50cf\uff0c\u8def\u5f84\u5747\u76f8\u5bf9\u5de5\u4f5c\u533a\u6839\u76ee\u5f55\u3002",
+      "properties": {
+        "root_path": {
+          "default": ".",
+          "title": "Root Path",
+          "type": "string"
+        },
+        "monorepo": {
+          "default": false,
+          "title": "Monorepo",
+          "type": "boolean"
+        },
+        "projects": {
+          "items": {
+            "$ref": "#/$defs/ProjectComponent"
+          },
+          "title": "Projects",
+          "type": "array"
+        },
+        "scan_limited": {
+          "default": false,
+          "title": "Scan Limited",
+          "type": "boolean"
+        }
+      },
+      "title": "ProjectProfile",
+      "type": "object"
+    },
+    "TechnologyFinding": {
+      "description": "\u63cf\u8ff0\u8bed\u8a00\u3001\u6846\u67b6\u3001\u5305\u7ba1\u7406\u5668\u6216\u6784\u5efa\u5de5\u5177\u7ed3\u8bba\u3002",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "confidence": {
+          "default": "confirmed",
+          "enum": [
+            "confirmed",
+            "likely"
+          ],
+          "title": "Confidence",
+          "type": "string"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/DetectionEvidence"
+          },
+          "title": "Evidence",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "TechnologyFinding",
+      "type": "object"
+    },
+    "ValidationCategory": {
+      "enum": [
+        "format",
+        "static_check",
+        "unit_test",
+        "integration_test",
+        "build"
+      ],
+      "title": "ValidationCategory",
+      "type": "string"
+    },
+    "ValidationCommand": {
+      "description": "\u63cf\u8ff0\u4e00\u6761\u4ec5\u4f9b\u53c2\u8003\u7684\u9a8c\u8bc1\u547d\u4ee4\u3002",
+      "properties": {
+        "category": {
+          "$ref": "#/$defs/ValidationCategory"
+        },
+        "command": {
+          "title": "Command",
+          "type": "string"
+        },
+        "working_directory": {
+          "title": "Working Directory",
+          "type": "string"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "evidence": {
+          "items": {
+            "$ref": "#/$defs/DetectionEvidence"
+          },
+          "title": "Evidence",
+          "type": "array"
+        },
+        "recommendation_only": {
+          "const": true,
+          "default": true,
+          "title": "Recommendation Only",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "category",
+        "command",
+        "working_directory",
+        "reason"
+      ],
+      "title": "ValidationCommand",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "profile": {
+      "$ref": "#/$defs/ProjectProfile"
+    }
+  },
+  "required": [
+    "profile"
+  ],
+  "title": "WorkspaceProfileResult",
+  "type": "object"
+}
+```
+
 ### ChangeListCommand
 
 | Field | Type | Required |

--- a/scripts/gen_protocol_doc.py
+++ b/scripts/gen_protocol_doc.py
@@ -70,6 +70,8 @@ from sztu_code.core.bus.commands import (
     SkillListResult,
     SkillSetEnabledCommand,
     SkillSetEnabledResult,
+    WorkspaceProfileCommand,
+    WorkspaceProfileResult,
 )
 from sztu_code.core.bus.envelope import EventPushEnvelope
 from sztu_code.core.bus.events import (
@@ -223,6 +225,10 @@ def generate() -> str:
         _model_section("AgentRunCommand", AgentRunCommand, agent_run_req_example),
         "\n",
         _model_section("AgentRunResult", AgentRunResult, agent_run_resp_example),
+        "\n",
+        _model_section("WorkspaceProfileCommand", WorkspaceProfileCommand),
+        "\n",
+        _model_section("WorkspaceProfileResult", WorkspaceProfileResult),
         "\n",
         _model_section("ChangeListCommand", ChangeListCommand),
         "\n",

--- a/src/sztu_code/core/app.py
+++ b/src/sztu_code/core/app.py
@@ -134,6 +134,8 @@ from sztu_code.core.bus.commands import (
     WorkspaceListResult,
     WorkspaceOpenCommand,
     WorkspaceOpenResult,
+    WorkspaceProfileCommand,
+    WorkspaceProfileResult,
     WorkspaceResumeCommand,
     WorkspaceResumeResult,
     WorkspaceStatusCommand,
@@ -461,6 +463,16 @@ class CoreApp:
             is_git_repository=bool(status["is_git_repository"]),
             changed_file_count=changed_file_count,
         )
+
+    # 返回工作区离线检测出的结构化项目画像，refresh 仅重新读取磁盘而不执行建议命令
+    async def _workspace_profile_handler(self, params: dict[str, Any]) -> WorkspaceProfileResult:
+        assert self._workspaces is not None
+        cmd = WorkspaceProfileCommand.model_validate(params)
+        try:
+            profile = self._workspaces.profile(cmd.workspace_id, refresh=cmd.refresh)
+        except ValueError as error:
+            raise HandlerError(-32602, str(error)) from error
+        return WorkspaceProfileResult(profile=profile)
 
     # 返回指定工作区子路径的受限目录树
     async def _workspace_tree_handler(self, params: dict[str, Any]) -> WorkspaceTreeResult:
@@ -1705,6 +1717,7 @@ class CoreApp:
         server.register("workspace.resume", self._workspace_resume_handler)
         server.register("workspace.delete", self._workspace_delete_handler)
         server.register("workspace.status", self._workspace_status_handler)
+        server.register("workspace.profile", self._workspace_profile_handler)
         server.register("workspace.tree", self._workspace_tree_handler)
         server.register("file.read", self._file_read_handler)
         server.register("file.search", self._file_search_handler)

--- a/src/sztu_code/core/bus/commands.py
+++ b/src/sztu_code/core/bus/commands.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Discriminator, Field
 
 from sztu_code.core.session.model import SessionMode, SessionStatus
+from sztu_code.core.workspace.project_profile import ProjectProfile
 
 ApiFormat = Literal[
     "openai_chat_completions",
@@ -139,6 +140,16 @@ class WorkspaceStatusResult(BaseModel):
     branch: str | None = None
     is_git_repository: bool
     changed_file_count: int
+
+
+class WorkspaceProfileCommand(BaseModel):
+    type: Literal["workspace.profile"] = "workspace.profile"
+    workspace_id: str
+    refresh: bool = False
+
+
+class WorkspaceProfileResult(BaseModel):
+    profile: ProjectProfile
 
 
 class WorkspaceTreeCommand(BaseModel):
@@ -782,6 +793,7 @@ Command = Annotated[
     | WorkspaceResumeCommand
     | WorkspaceDeleteCommand
     | WorkspaceStatusCommand
+    | WorkspaceProfileCommand
     | WorkspaceTreeCommand
     | FileReadCommand
     | FileSearchCommand

--- a/src/sztu_code/core/context.py
+++ b/src/sztu_code/core/context.py
@@ -36,6 +36,7 @@ class ExecutionContext:
     session_notes: str = ""
     global_context: str = ""
     project_context: str = ""
+    project_profile_context: str = ""
     base_system_prompt: str = ""  # 分层基础提示词（runner 构建），空则回退默认
     messages: list[dict[str, Any]] = field(default_factory=list)
     step: int = 0
@@ -83,6 +84,8 @@ class ExecutionContext:
             parts.append("\n\n## Global Context\n" + self.global_context.strip())
         if self.project_context.strip():
             parts.append("\n\n## Project Context\n" + self.project_context.strip())
+        if self.project_profile_context.strip():
+            parts.append("\n\n## Project Profile\n" + self.project_profile_context.strip())
         if self.session_notes.strip():
             parts.append(
                 "\n\n## Session Notes\n"

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -47,6 +47,10 @@ from sztu_code.core.tools.registry import ToolRegistry
 from sztu_code.core.trace.provider import TracingProvider
 from sztu_code.core.trace.writer import TraceWriter
 from sztu_code.core.workflow.tool import WorkflowRunTool
+from sztu_code.core.workspace.project_profile import (
+    detect_project_profile,
+    render_project_profile_context,
+)
 
 
 def _now() -> str:
@@ -206,8 +210,19 @@ class AgentRunner:
             notes = ""
         run_path.mkdir(parents=True, exist_ok=True)
 
+        project_root = workspace_root or Path.cwd()
+        project_profile_context = ""
+        try:
+            project_root = project_root.resolve()
+            profile = detect_project_profile(project_root)
+            project_profile_context = render_project_profile_context(profile)
+        except (OSError, ValueError) as error:
+            logging.getLogger(__name__).warning(
+                "project profile detection failed root=%s: %s", project_root, error
+            )
+
         global_ctx = load_context_file(Path("~/.sztu/context.md").expanduser())
-        project_ctx = load_context_file((workspace_root or Path.cwd()) / ".sztu/context.md")
+        project_ctx = load_context_file(project_root / ".sztu/context.md")
         memory_catalog = MemoryCatalog(
             [
                 MemoryDocument("global", global_ctx, "~/.sztu/context.md"),
@@ -242,6 +257,7 @@ class AgentRunner:
             session_notes=memory_catalog.prompt_content("session"),
             global_context=memory_catalog.prompt_content("global"),
             project_context=memory_catalog.prompt_content("project"),
+            project_profile_context=project_profile_context,
             base_system_prompt=base_prompt,
             system_prompt_override=system_prompt_override,
             max_tokens=self._config.budget.max_tokens,

--- a/src/sztu_code/core/subagent/tool.py
+++ b/src/sztu_code/core/subagent/tool.py
@@ -208,6 +208,11 @@ class SpawnAgentTool(BaseTool):
             run_id=child_run_id,
             goal=p.prompt,
             max_steps=child_max_steps,
+            project_profile_context=(
+                self._parent_context.project_profile_context
+                if self._parent_context is not None
+                else ""
+            ),
             system_prompt_override=system_prompt_override,
             max_tokens=(
                 p.max_tokens

--- a/src/sztu_code/core/workspace/manager.py
+++ b/src/sztu_code/core/workspace/manager.py
@@ -10,6 +10,8 @@ from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE
 from dataclasses import dataclass, replace
 from pathlib import Path
 
+from sztu_code.core.workspace.project_profile import ProjectProfile, detect_project_profile
+
 
 @dataclass(frozen=True)
 class Workspace:
@@ -65,6 +67,7 @@ class WorkspaceManager:
     def __init__(self, recent_file: Path) -> None:
         self._recent_file = recent_file.expanduser()
         self._workspaces: dict[str, Workspace] = {}
+        self._profiles: dict[str, ProjectProfile] = {}
         self._load_recent()
 
     # 打开本地目录并将其加入最近工作区列表
@@ -74,6 +77,7 @@ class WorkspaceManager:
             raise ValueError("workspace path must be an existing directory")
         workspace = self._make_workspace(resolved, archived=False)
         self._workspaces[workspace.id] = workspace
+        self._profiles.pop(workspace.id, None)
         self._save_recent()
         return workspace
 
@@ -105,6 +109,7 @@ class WorkspaceManager:
     def delete(self, workspace_id: str) -> None:
         self.get(workspace_id)  # 不存在时抛错
         del self._workspaces[workspace_id]
+        self._profiles.pop(workspace_id, None)
         self._save_recent()
 
     # 返回工作区的 Git 分支和未提交文件摘要
@@ -124,6 +129,15 @@ class WorkspaceManager:
             "is_git_repository": bool(branch or self._is_git_repository(root)),
             "changed_file_count": len(changed_files),
         }
+
+    # 返回工作区的离线项目画像；默认复用缓存，显式刷新时重新扫描磁盘。
+    def profile(self, workspace_id: str, *, refresh: bool = False) -> ProjectProfile:
+        if not refresh and (cached := self._profiles.get(workspace_id)) is not None:
+            return cached
+        workspace = self.get(workspace_id)
+        profile = detect_project_profile(Path(workspace.path))
+        self._profiles[workspace_id] = profile
+        return profile
 
     # 构建受深度和条目数限制的目录树，供客户端文件面板展示
     def tree(

--- a/src/sztu_code/core/workspace/project_profile.py
+++ b/src/sztu_code/core/workspace/project_profile.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import tomllib
 from dataclasses import dataclass, field
 from enum import StrEnum
+from itertools import islice
 from pathlib import Path
 from typing import Any, Literal
 
@@ -18,6 +20,7 @@ _MAX_CONTEXT_COMMANDS = 8
 _MAX_CONTEXT_CHARS = 4_000
 _IGNORED_DIRECTORY_NAMES = {
     ".git",
+    ".gradle",
     ".hg",
     ".idea",
     ".mypy_cache",
@@ -200,6 +203,11 @@ def detect_project_profile(root: Path) -> ProjectProfile:
     )
 
 
+# 将路径和命令中的控制字符清理为单行文本，避免工程文件名破坏上下文格式。
+def _context_value(value: str) -> str:
+    return "".join("'" if char == "`" else char if char.isprintable() else " " for char in value)
+
+
 # 把结构化画像压缩成适合 Agent system prompt 的说明，不复制原始清单内容。
 def render_project_profile_context(profile: ProjectProfile) -> str:
     if not profile.projects:
@@ -212,25 +220,26 @@ def render_project_profile_context(profile: ProjectProfile) -> str:
         f"Workspace layout: {'monorepo' if profile.monorepo else 'single project'}.",
     ]
     for project in profile.projects[:_MAX_CONTEXT_PROJECTS]:
-        languages = _finding_names(project.languages) or "unknown"
-        frameworks = _finding_names(project.frameworks)
-        package_managers = _finding_names(project.package_managers)
-        build_tools = _finding_names(project.build_tools)
-        summary = f"- {project.path}: languages={languages}"
+        languages = _context_value(_finding_names(project.languages) or "unknown")
+        frameworks = _context_value(_finding_names(project.frameworks))
+        package_managers = _context_value(_finding_names(project.package_managers))
+        build_tools = _context_value(_finding_names(project.build_tools))
+        project_path = _context_value(project.path)
+        summary = f"- {project_path}: languages={languages}"
         if frameworks:
             summary += f"; frameworks={frameworks}"
         if package_managers:
             summary += f"; package managers={package_managers}"
         if build_tools:
             summary += f"; build tools={build_tools}"
-        evidence_paths = ", ".join(item.path for item in project.evidence[:4])
+        evidence_paths = ", ".join(_context_value(item.path) for item in project.evidence[:4])
         if evidence_paths:
             summary += f"; evidence={evidence_paths}"
         lines.append(summary)
         for command in project.validation_plan[:_MAX_CONTEXT_COMMANDS]:
             lines.append(
-                f"  - {command.category.value}: `{command.command}` "
-                f"(run from `{command.working_directory}`; advisory)"
+                f"  - {command.category.value}: `{_context_value(command.command)}` "
+                f"(run from `{_context_value(command.working_directory)}`; advisory)"
             )
     remaining = len(profile.projects) - _MAX_CONTEXT_PROJECTS
     if remaining > 0:
@@ -249,15 +258,18 @@ def _scan_workspace(root: Path) -> _WorkspaceScan:
     scan_limited = False
     while pending:
         current, depth = pending.pop()
+        remaining_entries = _MAX_SCAN_ENTRIES - entry_count
         try:
-            entries = sorted(current.iterdir(), key=lambda item: item.name.lower())
+            with os.scandir(current) as iterator:
+                entries = list(islice(iterator, remaining_entries + 1))
         except OSError:
             continue
-        for entry in entries:
-            if entry_count >= _MAX_SCAN_ENTRIES:
-                scan_limited = True
-                pending.clear()
-                break
+        if len(entries) > remaining_entries:
+            entries.pop()
+            scan_limited = True
+            pending.clear()
+        for scanned_entry in sorted(entries, key=lambda item: item.name.lower()):
+            entry = Path(scanned_entry.path)
             entry_count += 1
             if entry.is_symlink():
                 continue
@@ -952,16 +964,46 @@ def _declared_node_package_manager(package_data: dict[str, Any]) -> str | None:
     )
 
 
-# 读取目录直属普通文件，为 Monorepo 根的锁文件和 package.json 提供受限信号。
+# 仅探测已知 Node.js 清单和锁文件，避免为继承工作区信号遍历大型父目录。
 def _directory_direct_files(directory: Path) -> dict[str, Path]:
-    try:
-        return {
-            entry.name.lower(): entry
-            for entry in directory.iterdir()
-            if entry.is_file() and not entry.is_symlink()
-        }
-    except OSError:
-        return {}
+    names = {
+        "package.json",
+        *_NODE_WORKSPACE_MARKERS,
+        *(filename for _, filename, _ in _NODE_PACKAGE_MANAGER_CANDIDATES),
+    }
+    direct_files: dict[str, Path] = {}
+    for name in names:
+        candidate = directory / name
+        try:
+            if not candidate.is_symlink() and candidate.is_file():
+                direct_files[name.lower()] = candidate
+        except OSError:
+            continue
+    return direct_files
+
+
+# 查找组件自身或祖先项目中的 Maven/Gradle wrapper，并生成相对组件目录可执行的路径。
+def _java_wrapper_executable(
+    workspace_root: Path,
+    component_root: Path,
+    wrapper_names: tuple[str, ...],
+    fallback: str,
+) -> tuple[str, Path | None]:
+    current = component_root
+    while _is_within(current, workspace_root):
+        for wrapper_name in wrapper_names:
+            candidate = current / wrapper_name
+            try:
+                if not candidate.is_symlink() and candidate.is_file():
+                    relative = os.path.relpath(candidate, component_root).replace(os.sep, "/")
+                    executable = relative if relative.startswith(".") else f"./{relative}"
+                    return executable, candidate
+            except OSError:
+                continue
+        if current == workspace_root:
+            break
+        current = current.parent
+    return fallback, None
 
 
 # 查找最近的显式 Node.js 工作区根，避免把任意父项目的包管理器错误继承给子项目。
@@ -1219,7 +1261,6 @@ def _detect_java(
                 )
             )
     _add_finding(signals.languages, "Java", evidence)
-    signals.evidence.extend(evidence)
     framework_evidence = evidence[:1]
     for marker, name in (
         ("spring-boot", "Spring Boot"),
@@ -1231,13 +1272,52 @@ def _detect_java(
     if has_maven:
         _add_finding(signals.package_managers, "Maven", evidence)
         _add_finding(signals.build_tools, "Maven", evidence)
-        executable = "./mvnw" if "mvnw" in direct_files else "mvn"
+        executable, wrapper = _java_wrapper_executable(
+            workspace_root,
+            component_root,
+            ("mvnw.cmd", "mvnw") if os.name == "nt" else ("mvnw", "mvnw.cmd"),
+            "mvn",
+        )
+        if wrapper is not None:
+            wrapper_rule = (
+                "Maven wrapper"
+                if wrapper.parent == component_root
+                else "Inherited Maven wrapper"
+            )
+            evidence.append(
+                _evidence(
+                    workspace_root,
+                    wrapper,
+                    wrapper_rule,
+                    strength=EvidenceStrength.SUPPORTING,
+                )
+            )
         _add_java_commands(executable, "maven", combined_text, relative_path, signals, evidence)
     if has_gradle:
         _add_finding(signals.package_managers, "Gradle", evidence)
         _add_finding(signals.build_tools, "Gradle", evidence)
-        executable = "./gradlew" if "gradlew" in direct_files else "gradle"
+        executable, wrapper = _java_wrapper_executable(
+            workspace_root,
+            component_root,
+            ("gradlew.bat", "gradlew") if os.name == "nt" else ("gradlew", "gradlew.bat"),
+            "gradle",
+        )
+        if wrapper is not None:
+            wrapper_rule = (
+                "Gradle wrapper"
+                if wrapper.parent == component_root
+                else "Inherited Gradle wrapper"
+            )
+            evidence.append(
+                _evidence(
+                    workspace_root,
+                    wrapper,
+                    wrapper_rule,
+                    strength=EvidenceStrength.SUPPORTING,
+                )
+            )
         _add_java_commands(executable, "gradle", combined_text, relative_path, signals, evidence)
+    signals.evidence.extend(evidence)
 
 
 # 按 Maven 或 Gradle 的已声明插件与目录生成 Java 验证建议。

--- a/src/sztu_code/core/workspace/project_profile.py
+++ b/src/sztu_code/core/workspace/project_profile.py
@@ -1,0 +1,1603 @@
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_MAX_SCAN_DEPTH = 6
+_MAX_SCAN_ENTRIES = 8_000
+_MAX_MANIFEST_CHARS = 128_000
+_MAX_CONTEXT_PROJECTS = 8
+_MAX_CONTEXT_COMMANDS = 8
+_MAX_CONTEXT_CHARS = 4_000
+_IGNORED_DIRECTORY_NAMES = {
+    ".git",
+    ".hg",
+    ".idea",
+    ".mypy_cache",
+    ".nox",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pycache__",
+    "build",
+    "cmakefiles",
+    "coverage",
+    "dist",
+    "node_modules",
+    "out",
+    "target",
+    "venv",
+}
+_COMPONENT_MARKER_NAMES = {
+    "build.gradle",
+    "build.gradle.kts",
+    "cmakelists.txt",
+    "compile_commands.json",
+    "conanfile.py",
+    "conanfile.txt",
+    "configure.ac",
+    "makefile",
+    "meson.build",
+    "package.json",
+    "pipfile",
+    "pipfile.lock",
+    "pdm.lock",
+    "pnpm-workspace.yaml",
+    "poetry.lock",
+    "pom.xml",
+    "pyproject.toml",
+    "setup.cfg",
+    "setup.py",
+    "settings.gradle",
+    "settings.gradle.kts",
+    "uv.lock",
+    "vcpkg.json",
+}
+_CPP_SUFFIXES = {".cc", ".cpp", ".cxx", ".c++", ".hpp", ".hh", ".hxx", ".h++"}
+_PYTHON_PACKAGING_TOOL_TABLES = {
+    "flit",
+    "hatch",
+    "pdm",
+    "poetry",
+    "setuptools",
+    "uv",
+}
+_PYTHON_CHECK_TOOL_TABLES = {
+    "black",
+    "mypy",
+    "pytest",
+    "ruff",
+}
+_NODE_PACKAGE_MANAGER_CANDIDATES = (
+    ("pnpm", "pnpm-lock.yaml", "pnpm lockfile"),
+    ("yarn", "yarn.lock", "Yarn lockfile"),
+    ("bun", "bun.lockb", "Bun lockfile"),
+    ("bun", "bun.lock", "Bun lockfile"),
+    ("npm", "package-lock.json", "npm lockfile"),
+)
+_NODE_WORKSPACE_MARKERS = ("pnpm-workspace.yaml", "lerna.json", "nx.json", "turbo.json")
+
+
+class EvidenceStrength(StrEnum):
+    CONFIRMED = "confirmed"
+    SUPPORTING = "supporting"
+    WEAK = "weak"
+
+
+class ValidationCategory(StrEnum):
+    FORMAT = "format"
+    STATIC_CHECK = "static_check"
+    UNIT_TEST = "unit_test"
+    INTEGRATION_TEST = "integration_test"
+    BUILD = "build"
+
+
+class DetectionEvidence(BaseModel):
+    """描述一项检测结论的本地证据。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    rule: str
+    detail: str | None = None
+    strength: EvidenceStrength = EvidenceStrength.SUPPORTING
+
+
+class TechnologyFinding(BaseModel):
+    """描述语言、框架、包管理器或构建工具结论。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    confidence: Literal["confirmed", "likely"] = "confirmed"
+    evidence: list[DetectionEvidence] = Field(default_factory=list)
+
+
+class ValidationCommand(BaseModel):
+    """描述一条仅供参考的验证命令。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    category: ValidationCategory
+    command: str
+    working_directory: str
+    reason: str
+    evidence: list[DetectionEvidence] = Field(default_factory=list)
+    recommendation_only: Literal[True] = True
+
+
+class ProjectComponent(BaseModel):
+    """描述工作区内一个独立项目边界的技术画像。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    languages: list[TechnologyFinding] = Field(default_factory=list)
+    frameworks: list[TechnologyFinding] = Field(default_factory=list)
+    package_managers: list[TechnologyFinding] = Field(default_factory=list)
+    build_tools: list[TechnologyFinding] = Field(default_factory=list)
+    evidence: list[DetectionEvidence] = Field(default_factory=list)
+    validation_plan: list[ValidationCommand] = Field(default_factory=list)
+
+
+class ProjectProfile(BaseModel):
+    """描述整个工作区的项目画像，路径均相对工作区根目录。"""
+
+    model_config = ConfigDict(frozen=True)
+
+    root_path: str = "."
+    monorepo: bool = False
+    projects: list[ProjectComponent] = Field(default_factory=list)
+    scan_limited: bool = False
+
+
+@dataclass(frozen=True)
+class _WorkspaceScan:
+    candidate_roots: tuple[Path, ...]
+    files: tuple[Path, ...]
+    scan_limited: bool
+
+
+@dataclass
+class _ComponentSignals:
+    languages: list[TechnologyFinding] = field(default_factory=list)
+    frameworks: list[TechnologyFinding] = field(default_factory=list)
+    package_managers: list[TechnologyFinding] = field(default_factory=list)
+    build_tools: list[TechnologyFinding] = field(default_factory=list)
+    evidence: list[DetectionEvidence] = field(default_factory=list)
+    validation_plan: list[ValidationCommand] = field(default_factory=list)
+
+
+# 读取工作区并返回稳定排序的候选项目与普通文件清单。
+def detect_project_profile(root: Path) -> ProjectProfile:
+    workspace_root = root.expanduser().resolve()
+    if not workspace_root.is_dir():
+        raise ValueError("project profile root must be an existing directory")
+    scan = _scan_workspace(workspace_root)
+    projects: list[ProjectComponent] = []
+    for component_root in scan.candidate_roots:
+        component = _detect_component(
+            workspace_root,
+            component_root,
+            scan.files,
+            scan.candidate_roots,
+        )
+        if component is not None:
+            projects.append(component)
+    return ProjectProfile(
+        monorepo=_is_monorepo(workspace_root, projects),
+        projects=projects,
+        scan_limited=scan.scan_limited,
+    )
+
+
+# 把结构化画像压缩成适合 Agent system prompt 的说明，不复制原始清单内容。
+def render_project_profile_context(profile: ProjectProfile) -> str:
+    if not profile.projects:
+        return ""
+    lines = [
+        "## Detected Project Profile",
+        "Generated locally from project structure. Recommended verification commands are advisory "
+        "only and are not executed automatically; any execution still requires the normal tool "
+        "permission and approval flow.",
+        f"Workspace layout: {'monorepo' if profile.monorepo else 'single project'}.",
+    ]
+    for project in profile.projects[:_MAX_CONTEXT_PROJECTS]:
+        languages = _finding_names(project.languages) or "unknown"
+        frameworks = _finding_names(project.frameworks)
+        package_managers = _finding_names(project.package_managers)
+        build_tools = _finding_names(project.build_tools)
+        summary = f"- {project.path}: languages={languages}"
+        if frameworks:
+            summary += f"; frameworks={frameworks}"
+        if package_managers:
+            summary += f"; package managers={package_managers}"
+        if build_tools:
+            summary += f"; build tools={build_tools}"
+        evidence_paths = ", ".join(item.path for item in project.evidence[:4])
+        if evidence_paths:
+            summary += f"; evidence={evidence_paths}"
+        lines.append(summary)
+        for command in project.validation_plan[:_MAX_CONTEXT_COMMANDS]:
+            lines.append(
+                f"  - {command.category.value}: `{command.command}` "
+                f"(run from `{command.working_directory}`; advisory)"
+            )
+    remaining = len(profile.projects) - _MAX_CONTEXT_PROJECTS
+    if remaining > 0:
+        lines.append(
+            f"- {remaining} additional detected project(s) are available in the workspace UI."
+        )
+    return "\n".join(lines)[:_MAX_CONTEXT_CHARS].rstrip()
+
+
+# 受深度和数量上限约束地遍历目录，避免扫描依赖、缓存和构建产物。
+def _scan_workspace(root: Path) -> _WorkspaceScan:
+    pending: list[tuple[Path, int]] = [(root, 0)]
+    candidate_roots: set[Path] = set()
+    files: list[Path] = []
+    entry_count = 0
+    scan_limited = False
+    while pending:
+        current, depth = pending.pop()
+        try:
+            entries = sorted(current.iterdir(), key=lambda item: item.name.lower())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry_count >= _MAX_SCAN_ENTRIES:
+                scan_limited = True
+                pending.clear()
+                break
+            entry_count += 1
+            if entry.is_symlink():
+                continue
+            try:
+                if entry.is_dir():
+                    if entry.name.lower() in _IGNORED_DIRECTORY_NAMES:
+                        continue
+                    if depth < _MAX_SCAN_DEPTH:
+                        pending.append((entry, depth + 1))
+                    else:
+                        scan_limited = True
+                    continue
+                if not entry.is_file():
+                    continue
+            except OSError:
+                continue
+            files.append(entry)
+            if _is_component_marker(entry.name):
+                candidate_roots.add(current)
+    ordered_roots = tuple(sorted(candidate_roots, key=lambda path: _component_sort_key(root, path)))
+    return _WorkspaceScan(ordered_roots, tuple(files), scan_limited)
+
+
+# 判断文件名是否能作为明确的项目边界候选信号。
+def _is_component_marker(name: str) -> bool:
+    lowered = name.lower()
+    return lowered in _COMPONENT_MARKER_NAMES or (
+        lowered.startswith("requirements") and lowered.endswith(".txt")
+    )
+
+
+# 为候选项目路径提供根目录优先、深度优先的稳定排序键。
+def _component_sort_key(root: Path, component_root: Path) -> tuple[int, str]:
+    relative = component_root.relative_to(root)
+    return (len(relative.parts), relative.as_posix().lower())
+
+
+# 在工作区文件清单中识别某一组件范围内的非嵌套文件。
+def _component_files(
+    component_root: Path,
+    files: tuple[Path, ...],
+    candidate_roots: tuple[Path, ...],
+) -> list[Path]:
+    nested_roots = [
+        candidate
+        for candidate in candidate_roots
+        if candidate != component_root and _is_within(candidate, component_root)
+    ]
+    result: list[Path] = []
+    for path in files:
+        if not _is_within(path, component_root):
+            continue
+        if any(_is_within(path, nested_root) for nested_root in nested_roots):
+            continue
+        result.append(path)
+    return result
+
+
+# 判断路径是否在给定父目录内，避免字符串前缀造成路径边界误判。
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+# 检测候选目录中的所有支持语言，并组合为一个项目组件。
+def _detect_component(
+    workspace_root: Path,
+    component_root: Path,
+    files: tuple[Path, ...],
+    candidate_roots: tuple[Path, ...],
+) -> ProjectComponent | None:
+    component_files = _component_files(component_root, files, candidate_roots)
+    direct_files = _direct_files(component_root, component_files)
+    relative_path = _relative_path(workspace_root, component_root)
+    signals = _ComponentSignals()
+    _detect_python(
+        workspace_root, component_root, relative_path, direct_files, component_files, signals
+    )
+    _detect_node(workspace_root, component_root, relative_path, direct_files, signals)
+    _detect_java(
+        workspace_root,
+        component_root,
+        relative_path,
+        direct_files,
+        component_files,
+        signals,
+    )
+    _detect_c_family(
+        workspace_root, component_root, relative_path, direct_files, component_files, signals
+    )
+    if not signals.languages:
+        return None
+    return ProjectComponent(
+        path=relative_path,
+        languages=signals.languages,
+        frameworks=signals.frameworks,
+        package_managers=signals.package_managers,
+        build_tools=signals.build_tools,
+        evidence=_unique_evidence(signals.evidence),
+        validation_plan=signals.validation_plan,
+    )
+
+
+# 获取组件根目录下直接存在的文件，键统一为小写以兼容不同文件系统。
+def _direct_files(component_root: Path, files: list[Path]) -> dict[str, Path]:
+    result: dict[str, Path] = {}
+    for path in files:
+        if path.parent == component_root:
+            result.setdefault(path.name.lower(), path)
+    return result
+
+
+# 将绝对路径转换为工作区内相对路径，根目录固定以 . 表示。
+def _relative_path(root: Path, path: Path) -> str:
+    relative = path.relative_to(root)
+    return relative.as_posix() if relative.parts else "."
+
+
+# 安全读取有限长度的 UTF-8 工程清单，读取失败时作为无信号处理。
+def _read_text(path: Path) -> str:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as stream:
+            return stream.read(_MAX_MANIFEST_CHARS)
+    except OSError:
+        return ""
+
+
+# 安全解析 pyproject.toml，只有结构化 Python 字段才会作为语言识别信号。
+def _read_toml(path: Path) -> dict[str, Any]:
+    try:
+        parsed = tomllib.loads(_read_text(path))
+    except tomllib.TOMLDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+# 安全解析 package.json，只接受对象根节点以避免弱信号误报。
+def _read_package_json(path: Path) -> dict[str, Any]:
+    try:
+        parsed = json.loads(_read_text(path))
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+# 构造相对于工作区的可解释证据对象。
+def _evidence(
+    workspace_root: Path,
+    path: Path,
+    rule: str,
+    *,
+    detail: str | None = None,
+    strength: EvidenceStrength = EvidenceStrength.SUPPORTING,
+) -> DetectionEvidence:
+    return DetectionEvidence(
+        path=_relative_path(workspace_root, path),
+        rule=rule,
+        detail=detail,
+        strength=strength,
+    )
+
+
+# 向技术结论列表追加名称唯一的结论，保留首次出现的最直接证据。
+def _add_finding(
+    target: list[TechnologyFinding],
+    name: str,
+    evidence: list[DetectionEvidence],
+    *,
+    confidence: Literal["confirmed", "likely"] = "confirmed",
+) -> None:
+    if any(item.name == name for item in target):
+        return
+    target.append(
+        TechnologyFinding(name=name, confidence=confidence, evidence=_unique_evidence(evidence))
+    )
+
+
+# 向验证计划追加去重后的建议命令，所有命令显式标记为仅建议。
+def _add_command(
+    target: list[ValidationCommand],
+    category: ValidationCategory,
+    command: str,
+    working_directory: str,
+    reason: str,
+    evidence: list[DetectionEvidence],
+) -> None:
+    if any(item.category == category and item.command == command for item in target):
+        return
+    target.append(
+        ValidationCommand(
+            category=category,
+            command=command,
+            working_directory=working_directory,
+            reason=reason,
+            evidence=_unique_evidence(evidence),
+        )
+    )
+
+
+# 去重证据以保持 IPC 结果与上下文渲染稳定、紧凑。
+def _unique_evidence(items: list[DetectionEvidence]) -> list[DetectionEvidence]:
+    result: list[DetectionEvidence] = []
+    seen: set[tuple[str, str, str | None, EvidenceStrength]] = set()
+    for item in items:
+        key = (item.path, item.rule, item.detail, item.strength)
+        if key not in seen:
+            seen.add(key)
+            result.append(item)
+    return result
+
+
+# 汇总技术结论的名称，用于紧凑上下文而不暴露完整配置。
+def _finding_names(items: list[TechnologyFinding]) -> str:
+    return ", ".join(item.name for item in items)
+
+
+# 判断组件范围内是否存在指定后缀的源码文件，源码仅作为清单之外的辅助信号。
+def _has_source_suffix(files: list[Path], suffixes: set[str]) -> bool:
+    return any(path.suffix.lower() in suffixes for path in files)
+
+
+# 返回组件范围内第一个指定后缀的源码文件，作为工程清单之外的辅助证据。
+def _first_source_with_suffix(files: list[Path], suffixes: set[str]) -> Path | None:
+    sources = sorted(
+        (path for path in files if path.suffix.lower() in suffixes),
+        key=lambda path: path.as_posix().lower(),
+    )
+    return sources[0] if sources else None
+
+
+# 返回组件范围内第一个稳定排序的 C/C++ 源码路径，供建议命令提供具体输入。
+def _first_c_family_source(component_root: Path, files: list[Path]) -> str | None:
+    sources = sorted(
+        (
+            path
+            for path in files
+            if path.suffix.lower() == ".c" or path.suffix.lower() in _CPP_SUFFIXES
+        ),
+        key=lambda path: path.as_posix().lower(),
+    )
+    if not sources:
+        return None
+    return sources[0].relative_to(component_root).as_posix()
+
+
+# 从 Python 清单和源码目录综合识别项目、依赖框架、包管理器与验证建议。
+def _detect_python(
+    workspace_root: Path,
+    component_root: Path,
+    relative_path: str,
+    direct_files: dict[str, Path],
+    component_files: list[Path],
+    signals: _ComponentSignals,
+) -> None:
+    pyproject = direct_files.get("pyproject.toml")
+    setup_py = direct_files.get("setup.py")
+    setup_cfg = direct_files.get("setup.cfg")
+    requirements = [
+        path
+        for name, path in direct_files.items()
+        if name.startswith("requirements") and name.endswith(".txt")
+    ]
+    pyproject_data = _read_toml(pyproject) if pyproject is not None else {}
+    pyproject_text = _read_text(pyproject).lower() if pyproject is not None else ""
+    setup_py_text = _read_text(setup_py).lower() if setup_py is not None else ""
+    setup_cfg_text = _read_text(setup_cfg).lower() if setup_cfg is not None else ""
+    setup_text = "\n".join((setup_py_text, setup_cfg_text))
+    requirements_text = "\n".join(_read_text(path).lower() for path in requirements)
+    pyproject_project = pyproject_data.get("project")
+    pyproject_build_system = pyproject_data.get("build-system")
+    pyproject_tools = pyproject_data.get("tool")
+    has_pyproject_metadata = isinstance(pyproject_project, dict) or isinstance(
+        pyproject_build_system, dict
+    )
+    tool_names = set(pyproject_tools) if isinstance(pyproject_tools, dict) else set()
+    has_python_packaging_tool_config = bool(tool_names & _PYTHON_PACKAGING_TOOL_TABLES)
+    has_python_check_tool_config = bool(tool_names & _PYTHON_CHECK_TOOL_TABLES)
+    has_setup_py_metadata = setup_py is not None and (
+        "setuptools" in setup_py_text
+        or "distutils" in setup_py_text
+        or bool(re.search(r"\bsetup\s*\(", setup_py_text))
+    )
+    has_setup_cfg_metadata = setup_cfg is not None and (
+        "[metadata]" in setup_cfg_text or "[options]" in setup_cfg_text
+    )
+    python_source = _first_source_with_suffix(component_files, {".py"})
+    has_python_lock = any(
+        name in direct_files
+        for name in ("uv.lock", "poetry.lock", "pdm.lock", "pipfile.lock", "pipfile")
+    )
+    has_requirements_project = bool(requirements) and python_source is not None
+    has_python_tool_project = has_python_packaging_tool_config or (
+        has_python_check_tool_config
+        and (python_source is not None or bool(requirements) or has_python_lock)
+    )
+    has_lock_project = has_python_lock and (
+        python_source is not None
+        or bool(requirements)
+        or has_pyproject_metadata
+        or has_python_tool_project
+    )
+    has_python_manifest = (
+        has_pyproject_metadata
+        or has_python_tool_project
+        or has_setup_py_metadata
+        or has_setup_cfg_metadata
+    )
+    if not has_python_manifest and not has_requirements_project and not has_lock_project:
+        return
+    evidence: list[DetectionEvidence] = []
+    if pyproject is not None and (has_pyproject_metadata or has_python_tool_project):
+        evidence.append(
+            _evidence(
+                workspace_root,
+                pyproject,
+                "Structured Python project metadata or tool configuration in pyproject.toml",
+                strength=(
+                    EvidenceStrength.CONFIRMED
+                    if has_pyproject_metadata
+                    else EvidenceStrength.SUPPORTING
+                ),
+            )
+        )
+    if setup_py is not None and has_setup_py_metadata:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                setup_py,
+                "Python setuptools entry point",
+                strength=EvidenceStrength.CONFIRMED,
+            )
+        )
+    if setup_cfg is not None and has_setup_cfg_metadata:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                setup_cfg,
+                "Python setup configuration",
+                strength=EvidenceStrength.CONFIRMED,
+            )
+        )
+    for requirement in requirements:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                requirement,
+                "Python dependency requirements",
+                strength=EvidenceStrength.SUPPORTING,
+            )
+        )
+    if python_source is not None:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                python_source,
+                "Python source file accompanies project metadata or dependencies",
+                strength=EvidenceStrength.SUPPORTING,
+            )
+        )
+    _add_finding(
+        signals.languages,
+        "Python",
+        evidence,
+        confidence=(
+            "confirmed"
+            if has_pyproject_metadata
+            or has_python_packaging_tool_config
+            or has_setup_py_metadata
+            or has_setup_cfg_metadata
+            else "likely"
+        ),
+    )
+    signals.evidence.extend(evidence)
+    combined_text = "\n".join((pyproject_text, setup_text, requirements_text))
+    framework_source = pyproject or (requirements[0] if requirements else setup_py or setup_cfg)
+    if framework_source is not None:
+        _add_python_frameworks(
+            workspace_root,
+            framework_source,
+            combined_text,
+            signals,
+            evidence,
+        )
+    package_managers = _add_python_package_managers(
+        workspace_root,
+        direct_files,
+        pyproject_text,
+        signals,
+        evidence,
+    )
+    _add_python_build_tools(
+        workspace_root,
+        pyproject,
+        setup_py,
+        setup_cfg,
+        pyproject_text,
+        signals,
+        evidence,
+    )
+    runner = _python_runner(package_managers)
+    tool_evidence = evidence[:1]
+    if "ruff" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.FORMAT,
+            f"{runner} ruff format --check .",
+            relative_path,
+            "Ruff is declared by the Python project",
+            tool_evidence,
+        )
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.STATIC_CHECK,
+            f"{runner} ruff check .",
+            relative_path,
+            "Ruff is declared by the Python project",
+            tool_evidence,
+        )
+    if "black" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.FORMAT,
+            f"{runner} black --check .",
+            relative_path,
+            "Black is declared by the Python project",
+            tool_evidence,
+        )
+    if "mypy" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.STATIC_CHECK,
+            f"{runner} mypy .",
+            relative_path,
+            "mypy is declared by the Python project",
+            tool_evidence,
+        )
+    has_tests = "pytest" in combined_text or (component_root / "tests").is_dir()
+    if has_tests:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.UNIT_TEST,
+            f"{runner} pytest",
+            relative_path,
+            "pytest configuration or tests directory detected",
+            tool_evidence,
+        )
+    if (component_root / "tests" / "integration").is_dir() or "integration" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.INTEGRATION_TEST,
+            f"{runner} pytest tests/integration",
+            relative_path,
+            "Python integration-test directory or marker detected",
+            tool_evidence,
+        )
+    if (
+        has_pyproject_metadata
+        or has_python_packaging_tool_config
+        or has_setup_py_metadata
+        or has_setup_cfg_metadata
+    ):
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.BUILD,
+            _python_build_command(package_managers),
+            relative_path,
+            "Python package metadata detected",
+            tool_evidence,
+        )
+
+
+# 从依赖文本中记录常见 Python Web 框架，避免根据单个源码扩展名猜测。
+def _add_python_frameworks(
+    workspace_root: Path,
+    evidence_path: Path,
+    combined_text: str,
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    framework_evidence = [
+        _evidence(
+            workspace_root,
+            evidence_path,
+            "Python dependency or tool configuration names the framework",
+            strength=EvidenceStrength.SUPPORTING,
+        )
+    ]
+    for marker, name in (("fastapi", "FastAPI"), ("django", "Django"), ("flask", "Flask")):
+        if marker in combined_text:
+            _add_finding(signals.frameworks, name, framework_evidence)
+            signals.evidence.extend(framework_evidence)
+    del evidence
+
+
+# 根据锁文件和工具配置选择 Python 包管理器，并返回名称供命令前缀使用。
+def _add_python_package_managers(
+    workspace_root: Path,
+    direct_files: dict[str, Path],
+    pyproject_text: str,
+    signals: _ComponentSignals,
+    fallback_evidence: list[DetectionEvidence],
+) -> list[str]:
+    result: list[str] = []
+    candidates = (
+        ("uv.lock", "uv", "uv lockfile"),
+        ("poetry.lock", "Poetry", "Poetry lockfile"),
+        ("pdm.lock", "PDM", "PDM lockfile"),
+        ("pipfile.lock", "Pipenv", "Pipenv lockfile"),
+        ("pipfile", "Pipenv", "Pipenv manifest"),
+    )
+    for filename, name, rule in candidates:
+        path = direct_files.get(filename)
+        if path is None:
+            continue
+        item_evidence = [_evidence(workspace_root, path, rule, strength=EvidenceStrength.CONFIRMED)]
+        _add_finding(signals.package_managers, name, item_evidence)
+        signals.evidence.extend(item_evidence)
+        result.append(name)
+    if "[tool.uv" in pyproject_text and "uv" not in result:
+        _add_finding(signals.package_managers, "uv", fallback_evidence, confidence="likely")
+        result.append("uv")
+    if "[tool.poetry" in pyproject_text and "Poetry" not in result:
+        _add_finding(signals.package_managers, "Poetry", fallback_evidence, confidence="likely")
+        result.append("Poetry")
+    if "[tool.pdm" in pyproject_text and "PDM" not in result:
+        _add_finding(signals.package_managers, "PDM", fallback_evidence, confidence="likely")
+        result.append("PDM")
+    if not result:
+        _add_finding(signals.package_managers, "pip", fallback_evidence, confidence="likely")
+        result.append("pip")
+    return result
+
+
+# 根据 build backend 与工具配置记录 Python 构建工具结论。
+def _add_python_build_tools(
+    workspace_root: Path,
+    pyproject: Path | None,
+    setup_py: Path | None,
+    setup_cfg: Path | None,
+    pyproject_text: str,
+    signals: _ComponentSignals,
+    fallback_evidence: list[DetectionEvidence],
+) -> None:
+    if pyproject is None:
+        setuptools_path = setup_py or setup_cfg
+        if setuptools_path is not None:
+            setuptools_evidence = [
+                _evidence(
+                    workspace_root,
+                    setuptools_path,
+                    "Python setuptools entry point or configuration",
+                    strength=EvidenceStrength.CONFIRMED,
+                )
+            ]
+            _add_finding(signals.build_tools, "Setuptools", setuptools_evidence)
+            signals.evidence.extend(setuptools_evidence)
+        return
+    build_evidence = [
+        _evidence(
+            workspace_root,
+            pyproject,
+            "Python build backend declared in pyproject.toml",
+            strength=EvidenceStrength.SUPPORTING,
+        )
+    ]
+    tool_names = (
+        ("hatchling", "Hatchling"),
+        ("setuptools", "Setuptools"),
+        ("poetry-core", "Poetry"),
+        ("flit", "Flit"),
+        ("pdm.backend", "PDM"),
+    )
+    for marker, name in tool_names:
+        if marker in pyproject_text:
+            _add_finding(signals.build_tools, name, build_evidence)
+            signals.evidence.extend(build_evidence)
+    if not signals.build_tools:
+        _add_finding(signals.build_tools, "PEP 517", fallback_evidence, confidence="likely")
+
+
+# 选择 Python 验证命令的安全运行器前缀，不执行或安装任何依赖。
+def _python_runner(package_managers: list[str]) -> str:
+    if "uv" in package_managers:
+        return "uv run"
+    if "Poetry" in package_managers:
+        return "poetry run"
+    if "PDM" in package_managers:
+        return "pdm run"
+    if "Pipenv" in package_managers:
+        return "pipenv run"
+    return "python -m"
+
+
+# 根据已识别的 Python 包管理器生成构建建议，而非直接尝试构建。
+def _python_build_command(package_managers: list[str]) -> str:
+    if "uv" in package_managers:
+        return "uv build"
+    if "Poetry" in package_managers:
+        return "poetry build"
+    if "PDM" in package_managers:
+        return "pdm build"
+    return "python -m build"
+
+
+# 从 package.json、锁文件和 scripts 识别 Node.js 项目及其建议命令。
+def _detect_node(
+    workspace_root: Path,
+    component_root: Path,
+    relative_path: str,
+    direct_files: dict[str, Path],
+    signals: _ComponentSignals,
+) -> None:
+    package_json = direct_files.get("package.json")
+    if package_json is None:
+        return
+    package_data = _read_package_json(package_json)
+    scripts = _string_mapping(package_data.get("scripts"))
+    dependencies = _dependency_names(package_data)
+    has_node_manifest = bool(
+        package_data.get("name")
+        or scripts
+        or dependencies
+        or package_data.get("workspaces")
+        or package_data.get("packageManager")
+        or package_data.get("private")
+    )
+    if not has_node_manifest:
+        return
+    manifest_evidence = [
+        _evidence(
+            workspace_root,
+            package_json,
+            "Node.js package manifest with metadata, dependencies, or scripts",
+            strength=EvidenceStrength.CONFIRMED,
+        )
+    ]
+    _add_finding(signals.languages, "Node.js", manifest_evidence)
+    signals.evidence.extend(manifest_evidence)
+    manager = _add_node_package_manager(
+        workspace_root,
+        component_root,
+        package_json,
+        package_data,
+        direct_files,
+        signals,
+        manifest_evidence,
+    )
+    _add_node_frameworks_and_build_tools(dependencies, signals, manifest_evidence)
+    _add_node_validation_commands(scripts, manager, relative_path, signals, manifest_evidence)
+
+
+# 从 JSON 映射提取字符串键值，忽略非字符串脚本和异常配置。
+def _string_mapping(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): item for key, item in value.items() if isinstance(item, str)}
+
+
+# 从 package.json 的依赖区块汇总规范化包名。
+def _dependency_names(package_data: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for field_name in (
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ):
+        value = package_data.get(field_name)
+        if isinstance(value, dict):
+            names.update(str(name).lower() for name in value)
+    return names
+
+
+# 返回直接目录中优先级最高的 Node.js 锁文件包管理器信号。
+def _node_lockfile_manager(direct_files: dict[str, Path]) -> tuple[str, Path, str] | None:
+    for name, filename, rule in _NODE_PACKAGE_MANAGER_CANDIDATES:
+        path = direct_files.get(filename)
+        if path is not None:
+            return name, path, rule
+    return None
+
+
+# 规范化 packageManager 字段中声明的 Node.js 包管理器名称。
+def _declared_node_package_manager(package_data: dict[str, Any]) -> str | None:
+    package_manager_field = str(package_data.get("packageManager", "")).lower()
+    return next(
+        (name for name in ("pnpm", "yarn", "bun", "npm") if package_manager_field.startswith(name)),
+        None,
+    )
+
+
+# 读取目录直属普通文件，为 Monorepo 根的锁文件和 package.json 提供受限信号。
+def _directory_direct_files(directory: Path) -> dict[str, Path]:
+    try:
+        return {
+            entry.name.lower(): entry
+            for entry in directory.iterdir()
+            if entry.is_file() and not entry.is_symlink()
+        }
+    except OSError:
+        return {}
+
+
+# 查找最近的显式 Node.js 工作区根，避免把任意父项目的包管理器错误继承给子项目。
+def _node_workspace_source(
+    workspace_root: Path,
+    component_root: Path,
+) -> tuple[dict[str, Any], dict[str, Path]] | None:
+    if component_root == workspace_root:
+        return None
+    current = component_root.parent
+    while _is_within(current, workspace_root):
+        direct_files = _directory_direct_files(current)
+        package_json = direct_files.get("package.json")
+        package_data = _read_package_json(package_json) if package_json is not None else {}
+        has_workspaces = isinstance(package_data.get("workspaces"), (list, dict))
+        if has_workspaces or any(name in direct_files for name in _NODE_WORKSPACE_MARKERS):
+            return package_data, direct_files
+        if current == workspace_root:
+            break
+        current = current.parent
+    return None
+
+
+# 使用本地或工作区级 packageManager 字段和锁文件确定 Node.js 包管理器，默认 npm 仅作为保守回退。
+def _add_node_package_manager(
+    workspace_root: Path,
+    component_root: Path,
+    package_json: Path,
+    package_data: dict[str, Any],
+    direct_files: dict[str, Path],
+    signals: _ComponentSignals,
+    fallback_evidence: list[DetectionEvidence],
+) -> str:
+    lockfile = _node_lockfile_manager(direct_files)
+    if lockfile is not None:
+        name, path, rule = lockfile
+        item_evidence = [_evidence(workspace_root, path, rule, strength=EvidenceStrength.CONFIRMED)]
+        _add_finding(signals.package_managers, name, item_evidence)
+        signals.evidence.extend(item_evidence)
+        return name
+    if (name := _declared_node_package_manager(package_data)) is not None:
+        item_evidence = [
+            _evidence(
+                workspace_root,
+                package_json,
+                f"packageManager field declares {name}",
+                strength=EvidenceStrength.SUPPORTING,
+            )
+        ]
+        _add_finding(signals.package_managers, name, item_evidence, confidence="likely")
+        signals.evidence.extend(item_evidence)
+        return name
+    workspace_source = _node_workspace_source(workspace_root, component_root)
+    if workspace_source is not None:
+        workspace_data, workspace_files = workspace_source
+        workspace_lockfile = _node_lockfile_manager(workspace_files)
+        if workspace_lockfile is not None:
+            name, path, rule = workspace_lockfile
+            item_evidence = [
+                _evidence(
+                    workspace_root,
+                    path,
+                    f"{rule} inherited from the workspace root",
+                    strength=EvidenceStrength.CONFIRMED,
+                )
+            ]
+            _add_finding(signals.package_managers, name, item_evidence)
+            signals.evidence.extend(item_evidence)
+            return name
+        if (name := _declared_node_package_manager(workspace_data)) is not None:
+            workspace_package_json = workspace_files.get("package.json")
+            if workspace_package_json is not None:
+                item_evidence = [
+                    _evidence(
+                        workspace_root,
+                        workspace_package_json,
+                        f"workspace packageManager field declares {name}",
+                        strength=EvidenceStrength.SUPPORTING,
+                    )
+                ]
+                _add_finding(signals.package_managers, name, item_evidence, confidence="likely")
+                signals.evidence.extend(item_evidence)
+                return name
+    _add_finding(signals.package_managers, "npm", fallback_evidence, confidence="likely")
+    return "npm"
+
+
+# 从依赖名称提取常见前端、后端框架和构建工具结论。
+def _add_node_frameworks_and_build_tools(
+    dependencies: set[str],
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    for package_name, display_name in (
+        ("react", "React"),
+        ("next", "Next.js"),
+        ("vue", "Vue"),
+        ("nuxt", "Nuxt"),
+        ("@angular/core", "Angular"),
+        ("svelte", "Svelte"),
+        ("express", "Express"),
+        ("@nestjs/core", "NestJS"),
+    ):
+        if package_name in dependencies:
+            _add_finding(signals.frameworks, display_name, evidence)
+    for package_name, display_name in (
+        ("vite", "Vite"),
+        ("webpack", "Webpack"),
+        ("turbo", "Turborepo"),
+        ("nx", "Nx"),
+        ("tsup", "tsup"),
+    ):
+        if package_name in dependencies:
+            _add_finding(signals.build_tools, display_name, evidence)
+
+
+# 按 package scripts 的名称分类 Node.js 验证建议，绝不拼接或执行脚本正文。
+def _add_node_validation_commands(
+    scripts: dict[str, str],
+    package_manager: str,
+    relative_path: str,
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    for category, names, reason in (
+        (
+            ValidationCategory.FORMAT,
+            ("format", "format:check", "prettier:check"),
+            "format script declared",
+        ),
+        (
+            ValidationCategory.STATIC_CHECK,
+            ("lint", "typecheck", "check"),
+            "static-check script declared",
+        ),
+        (ValidationCategory.UNIT_TEST, ("test:unit", "unit", "test"), "unit-test script declared"),
+        (
+            ValidationCategory.INTEGRATION_TEST,
+            ("test:integration", "integration", "test:e2e", "e2e"),
+            "integration-test script declared",
+        ),
+        (ValidationCategory.BUILD, ("build", "compile", "bundle"), "build script declared"),
+    ):
+        script = _first_matching_script(scripts, names)
+        if script is not None:
+            _add_command(
+                signals.validation_plan,
+                category,
+                f"{package_manager} run {script}",
+                relative_path,
+                reason,
+                evidence,
+            )
+
+
+# 按优先级返回第一个声明的脚本名，保持建议的确定性。
+def _first_matching_script(scripts: dict[str, str], names: tuple[str, ...]) -> str | None:
+    for name in names:
+        if name in scripts:
+            return name
+    return None
+
+
+# 从 Maven 或 Gradle 清单及源码目录识别 Java 项目和验证工具。
+def _detect_java(
+    workspace_root: Path,
+    component_root: Path,
+    relative_path: str,
+    direct_files: dict[str, Path],
+    component_files: list[Path],
+    signals: _ComponentSignals,
+) -> None:
+    pom = direct_files.get("pom.xml")
+    gradle = direct_files.get("build.gradle") or direct_files.get("build.gradle.kts")
+    pom_text = _read_text(pom).lower() if pom is not None else ""
+    gradle_text = _read_text(gradle).lower() if gradle is not None else ""
+    has_maven = pom is not None and "<project" in pom_text
+    has_gradle = gradle is not None and bool(gradle_text.strip())
+    if not has_maven and not has_gradle:
+        return
+    combined_text = "\n".join((pom_text, gradle_text))
+    java_source = _first_source_with_suffix(component_files, {".java"})
+    has_java_build_signal = any(
+        marker in combined_text
+        for marker in (
+            "maven-compiler-plugin",
+            "maven.compiler.",
+            "spring-boot",
+            "quarkus",
+            "micronaut",
+            "id 'java'",
+            'id("java")',
+            "java-library",
+            "sourcecompatibility",
+            "targetcompatibility",
+        )
+    )
+    if java_source is None and not has_java_build_signal:
+        return
+    evidence: list[DetectionEvidence] = []
+    if has_maven and pom is not None:
+        evidence.append(
+            _evidence(
+                workspace_root, pom, "Maven project descriptor", strength=EvidenceStrength.CONFIRMED
+            )
+        )
+    if has_gradle and gradle is not None:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                gradle,
+                "Gradle build descriptor",
+                strength=EvidenceStrength.CONFIRMED,
+            )
+        )
+    if java_source is not None:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                java_source,
+                "Java source file accompanies build descriptor",
+                strength=EvidenceStrength.SUPPORTING,
+            )
+        )
+    source_dir = component_root / "src" / "main" / "java"
+    if source_dir.is_dir():
+        evidence.append(
+            DetectionEvidence(
+                path=_relative_path(workspace_root, source_dir),
+                rule="Java conventional source directory",
+                strength=EvidenceStrength.SUPPORTING,
+            )
+        )
+    if has_java_build_signal:
+        descriptor = pom if has_maven else gradle
+        if descriptor is not None:
+            evidence.append(
+                _evidence(
+                    workspace_root,
+                    descriptor,
+                    "Java compiler, plugin, or framework configuration",
+                    strength=EvidenceStrength.SUPPORTING,
+                )
+            )
+    _add_finding(signals.languages, "Java", evidence)
+    signals.evidence.extend(evidence)
+    framework_evidence = evidence[:1]
+    for marker, name in (
+        ("spring-boot", "Spring Boot"),
+        ("quarkus", "Quarkus"),
+        ("micronaut", "Micronaut"),
+    ):
+        if marker in combined_text:
+            _add_finding(signals.frameworks, name, framework_evidence)
+    if has_maven:
+        _add_finding(signals.package_managers, "Maven", evidence)
+        _add_finding(signals.build_tools, "Maven", evidence)
+        executable = "./mvnw" if "mvnw" in direct_files else "mvn"
+        _add_java_commands(executable, "maven", combined_text, relative_path, signals, evidence)
+    if has_gradle:
+        _add_finding(signals.package_managers, "Gradle", evidence)
+        _add_finding(signals.build_tools, "Gradle", evidence)
+        executable = "./gradlew" if "gradlew" in direct_files else "gradle"
+        _add_java_commands(executable, "gradle", combined_text, relative_path, signals, evidence)
+
+
+# 按 Maven 或 Gradle 的已声明插件与目录生成 Java 验证建议。
+def _add_java_commands(
+    executable: str,
+    build_system: Literal["maven", "gradle"],
+    combined_text: str,
+    relative_path: str,
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    if build_system == "maven":
+        if "spotless" in combined_text:
+            _add_command(
+                signals.validation_plan,
+                ValidationCategory.FORMAT,
+                f"{executable} spotless:check",
+                relative_path,
+                "Spotless Maven plugin detected",
+                evidence,
+            )
+        if "checkstyle" in combined_text:
+            _add_command(
+                signals.validation_plan,
+                ValidationCategory.STATIC_CHECK,
+                f"{executable} checkstyle:check",
+                relative_path,
+                "Checkstyle Maven plugin detected",
+                evidence,
+            )
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.UNIT_TEST,
+            f"{executable} test",
+            relative_path,
+            "Maven project descriptor detected",
+            evidence,
+        )
+        if "failsafe" in combined_text or "integration" in combined_text:
+            _add_command(
+                signals.validation_plan,
+                ValidationCategory.INTEGRATION_TEST,
+                f"{executable} verify",
+                relative_path,
+                "Maven integration-test configuration detected",
+                evidence,
+            )
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.BUILD,
+            f"{executable} package",
+            relative_path,
+            "Maven project descriptor detected",
+            evidence,
+        )
+        return
+    if "spotless" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.FORMAT,
+            f"{executable} spotlessCheck",
+            relative_path,
+            "Spotless Gradle plugin detected",
+            evidence,
+        )
+    if "checkstyle" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.STATIC_CHECK,
+            f"{executable} checkstyleMain",
+            relative_path,
+            "Checkstyle Gradle plugin detected",
+            evidence,
+        )
+    _add_command(
+        signals.validation_plan,
+        ValidationCategory.UNIT_TEST,
+        f"{executable} test",
+        relative_path,
+        "Gradle build descriptor detected",
+        evidence,
+    )
+    if "integrationtest" in combined_text or "integration" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.INTEGRATION_TEST,
+            f"{executable} integrationTest",
+            relative_path,
+            "Gradle integration-test configuration detected",
+            evidence,
+        )
+    _add_command(
+        signals.validation_plan,
+        ValidationCategory.BUILD,
+        f"{executable} build",
+        relative_path,
+        "Gradle build descriptor detected",
+        evidence,
+    )
+
+
+# 从 CMake、Meson 或 Make 清单和源码信号识别 C/C++ 项目。
+def _detect_c_family(
+    workspace_root: Path,
+    component_root: Path,
+    relative_path: str,
+    direct_files: dict[str, Path],
+    component_files: list[Path],
+    signals: _ComponentSignals,
+) -> None:
+    cmake = direct_files.get("cmakelists.txt")
+    meson = direct_files.get("meson.build")
+    makefile = direct_files.get("makefile")
+    cmake_text = _read_text(cmake).lower() if cmake is not None else ""
+    meson_text = _read_text(meson).lower() if meson is not None else ""
+    make_text = _read_text(makefile).lower() if makefile is not None else ""
+    has_sources = _has_source_suffix(component_files, {".c", *_CPP_SUFFIXES})
+    cmake_declares_c = bool(re.search(r"\blanguages\b[^)]*\bc\b", cmake_text))
+    cmake_declares_cpp = "cxx" in cmake_text or bool(re.search(r"\b(?:cpp|c\+\+)\b", cmake_text))
+    meson_declares_c = bool(re.search(r"project\s*\([^)]*['\"]c['\"]", meson_text))
+    meson_declares_cpp = bool(re.search(r"project\s*\([^)]*['\"](?:cpp|c\+\+)['\"]", meson_text))
+    cmake_mentions_c_source = bool(re.search(r"\.c\b", cmake_text))
+    cmake_mentions_cpp_source = bool(re.search(r"\.(?:cc|cpp|cxx|c\+\+)\b", cmake_text))
+    meson_mentions_c_source = bool(re.search(r"\.c\b", meson_text))
+    meson_mentions_cpp_source = bool(re.search(r"\.(?:cc|cpp|cxx|c\+\+)\b", meson_text))
+    has_cmake = cmake is not None and (
+        has_sources
+        or cmake_declares_c
+        or cmake_declares_cpp
+        or cmake_mentions_c_source
+        or cmake_mentions_cpp_source
+    )
+    has_meson = meson is not None and (
+        has_sources
+        or meson_declares_c
+        or meson_declares_cpp
+        or meson_mentions_c_source
+        or meson_mentions_cpp_source
+    )
+    has_make = makefile is not None and has_sources and bool(make_text.strip())
+    if not has_cmake and not has_meson and not has_make:
+        return
+    evidence: list[DetectionEvidence] = []
+    if has_cmake and cmake is not None:
+        evidence.append(
+            _evidence(
+                workspace_root, cmake, "CMake build descriptor", strength=EvidenceStrength.CONFIRMED
+            )
+        )
+    if has_meson and meson is not None:
+        evidence.append(
+            _evidence(
+                workspace_root, meson, "Meson build descriptor", strength=EvidenceStrength.CONFIRMED
+            )
+        )
+    if has_make and makefile is not None:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                makefile,
+                "Make build descriptor with C/C++ sources",
+                strength=EvidenceStrength.CONFIRMED,
+            )
+        )
+    c_or_cpp_source = _first_source_with_suffix(component_files, {".c", *_CPP_SUFFIXES})
+    if c_or_cpp_source is not None:
+        evidence.append(
+            _evidence(
+                workspace_root,
+                c_or_cpp_source,
+                "C/C++ source file accompanies build descriptor",
+                strength=EvidenceStrength.SUPPORTING,
+            )
+        )
+    has_c = _has_source_suffix(component_files, {".c"}) or (
+        cmake_declares_c or meson_declares_c or cmake_mentions_c_source or meson_mentions_c_source
+    )
+    has_cpp = _has_source_suffix(component_files, _CPP_SUFFIXES) or (
+        cmake_declares_cpp
+        or meson_declares_cpp
+        or cmake_mentions_cpp_source
+        or meson_mentions_cpp_source
+    )
+    if has_c:
+        _add_finding(signals.languages, "C", evidence)
+    if has_cpp:
+        _add_finding(signals.languages, "C++", evidence)
+    signals.evidence.extend(evidence)
+    combined_text = "\n".join((cmake_text, meson_text, make_text))
+    for marker, name in (("gtest", "GoogleTest"), ("catch2", "Catch2"), ("find_package(qt", "Qt")):
+        if marker in combined_text:
+            _add_finding(signals.frameworks, name, evidence)
+    _add_c_family_package_managers(workspace_root, direct_files, signals, evidence)
+    if has_cmake:
+        _add_finding(signals.build_tools, "CMake", evidence)
+        _add_cmake_commands(
+            component_root,
+            relative_path,
+            direct_files,
+            component_files,
+            combined_text,
+            signals,
+            evidence,
+        )
+    if has_meson:
+        _add_finding(signals.build_tools, "Meson", evidence)
+        _add_meson_commands(relative_path, combined_text, signals, evidence)
+    if has_make:
+        _add_finding(signals.build_tools, "Make", evidence)
+        _add_make_commands(relative_path, make_text, signals, evidence)
+
+
+# 记录 C/C++ 项目使用的 Conan 或 vcpkg 包管理器。
+def _add_c_family_package_managers(
+    workspace_root: Path,
+    direct_files: dict[str, Path],
+    signals: _ComponentSignals,
+    fallback_evidence: list[DetectionEvidence],
+) -> None:
+    for filename, name, rule in (
+        ("conanfile.py", "Conan", "Conan dependency manifest"),
+        ("conanfile.txt", "Conan", "Conan dependency manifest"),
+        ("vcpkg.json", "vcpkg", "vcpkg dependency manifest"),
+    ):
+        path = direct_files.get(filename)
+        if path is not None:
+            item_evidence = [
+                _evidence(workspace_root, path, rule, strength=EvidenceStrength.CONFIRMED)
+            ]
+            _add_finding(signals.package_managers, name, item_evidence)
+            signals.evidence.extend(item_evidence)
+    del fallback_evidence
+
+
+# 基于 CMake 的测试、clang 配置和源码信号生成 C/C++ 验证建议。
+def _add_cmake_commands(
+    component_root: Path,
+    relative_path: str,
+    direct_files: dict[str, Path],
+    component_files: list[Path],
+    combined_text: str,
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    source = _first_c_family_source(component_root, component_files)
+    if source is not None and (".clang-format" in direct_files or "clang-format" in combined_text):
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.FORMAT,
+            f"clang-format --dry-run --Werror {source}",
+            relative_path,
+            "clang-format configuration detected",
+            evidence,
+        )
+    if source is not None and (".clang-tidy" in direct_files or "clang-tidy" in combined_text):
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.STATIC_CHECK,
+            f"clang-tidy {source}",
+            relative_path,
+            "clang-tidy configuration detected",
+            evidence,
+        )
+    has_tests = any(
+        marker in combined_text for marker in ("enable_testing", "add_test", "gtest", "catch2")
+    )
+    if has_tests:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.UNIT_TEST,
+            "ctest --test-dir build --output-on-failure",
+            relative_path,
+            "CTest or C/C++ test framework configuration detected",
+            evidence,
+        )
+    if "integration" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.INTEGRATION_TEST,
+            "ctest --test-dir build --output-on-failure -L integration",
+            relative_path,
+            "CMake integration-test signal detected",
+            evidence,
+        )
+    _add_command(
+        signals.validation_plan,
+        ValidationCategory.BUILD,
+        "cmake -S . -B build && cmake --build build",
+        relative_path,
+        "CMake build descriptor detected",
+        evidence,
+    )
+
+
+# 为 Meson 项目生成保持在建议层的构建和测试命令。
+def _add_meson_commands(
+    relative_path: str,
+    combined_text: str,
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    if "test(" in combined_text:
+        _add_command(
+            signals.validation_plan,
+            ValidationCategory.UNIT_TEST,
+            "meson test -C build",
+            relative_path,
+            "Meson test declaration detected",
+            evidence,
+        )
+    _add_command(
+        signals.validation_plan,
+        ValidationCategory.BUILD,
+        "meson setup build && meson compile -C build",
+        relative_path,
+        "Meson build descriptor detected",
+        evidence,
+    )
+
+
+# 为 Makefile 中明确声明的目标生成 C/C++ 验证建议。
+def _add_make_commands(
+    relative_path: str,
+    make_text: str,
+    signals: _ComponentSignals,
+    evidence: list[DetectionEvidence],
+) -> None:
+    for category, target, reason in (
+        (ValidationCategory.FORMAT, "format", "Makefile format target detected"),
+        (ValidationCategory.STATIC_CHECK, "lint", "Makefile lint target detected"),
+        (ValidationCategory.UNIT_TEST, "test", "Makefile test target detected"),
+        (
+            ValidationCategory.INTEGRATION_TEST,
+            "integration-test",
+            "Makefile integration target detected",
+        ),
+    ):
+        if _make_target_exists(make_text, target):
+            _add_command(
+                signals.validation_plan,
+                category,
+                f"make {target}",
+                relative_path,
+                reason,
+                evidence,
+            )
+    build_command = "make build" if _make_target_exists(make_text, "build") else "make"
+    _add_command(
+        signals.validation_plan,
+        ValidationCategory.BUILD,
+        build_command,
+        relative_path,
+        "Make build descriptor detected",
+        evidence,
+    )
+
+
+# 用行首 target 语法识别 Makefile 目标，避免把普通文本误作为可运行命令。
+def _make_target_exists(make_text: str, target: str) -> bool:
+    return re.search(rf"^{re.escape(target)}\s*:", make_text, flags=re.MULTILINE) is not None
+
+
+# 根据显式 workspace 配置或多个项目边界判断是否为 Monorepo。
+def _is_monorepo(root: Path, projects: list[ProjectComponent]) -> bool:
+    if len(projects) > 1:
+        return True
+    package_json = root / "package.json"
+    if package_json.is_file() and isinstance(
+        _read_package_json(package_json).get("workspaces"), (list, dict)
+    ):
+        return True
+    return any(
+        (root / name).is_file()
+        for name in (*_NODE_WORKSPACE_MARKERS, "settings.gradle", "settings.gradle.kts")
+    )

--- a/src/sztu_code/core/workspace/project_profile.py
+++ b/src/sztu_code/core/workspace/project_profile.py
@@ -1002,18 +1002,24 @@ def _add_node_package_manager(
         _add_finding(signals.package_managers, name, item_evidence)
         signals.evidence.extend(item_evidence)
         return name
-    if (name := _declared_node_package_manager(package_data)) is not None:
+    declared_manager = _declared_node_package_manager(package_data)
+    if declared_manager is not None:
         item_evidence = [
             _evidence(
                 workspace_root,
                 package_json,
-                f"packageManager field declares {name}",
+                f"packageManager field declares {declared_manager}",
                 strength=EvidenceStrength.SUPPORTING,
             )
         ]
-        _add_finding(signals.package_managers, name, item_evidence, confidence="likely")
+        _add_finding(
+            signals.package_managers,
+            declared_manager,
+            item_evidence,
+            confidence="likely",
+        )
         signals.evidence.extend(item_evidence)
-        return name
+        return declared_manager
     workspace_source = _node_workspace_source(workspace_root, component_root)
     if workspace_source is not None:
         workspace_data, workspace_files = workspace_source
@@ -1031,20 +1037,26 @@ def _add_node_package_manager(
             _add_finding(signals.package_managers, name, item_evidence)
             signals.evidence.extend(item_evidence)
             return name
-        if (name := _declared_node_package_manager(workspace_data)) is not None:
+        workspace_declared_manager = _declared_node_package_manager(workspace_data)
+        if workspace_declared_manager is not None:
             workspace_package_json = workspace_files.get("package.json")
             if workspace_package_json is not None:
                 item_evidence = [
                     _evidence(
                         workspace_root,
                         workspace_package_json,
-                        f"workspace packageManager field declares {name}",
+                        f"workspace packageManager field declares {workspace_declared_manager}",
                         strength=EvidenceStrength.SUPPORTING,
                     )
                 ]
-                _add_finding(signals.package_managers, name, item_evidence, confidence="likely")
+                _add_finding(
+                    signals.package_managers,
+                    workspace_declared_manager,
+                    item_evidence,
+                    confidence="likely",
+                )
                 signals.evidence.extend(item_evidence)
-                return name
+                return workspace_declared_manager
     _add_finding(signals.package_managers, "npm", fallback_evidence, confidence="likely")
     return "npm"
 

--- a/tests/integration/test_s4_session_ipc.py
+++ b/tests/integration/test_s4_session_ipc.py
@@ -116,8 +116,8 @@ async def test_session_create_history_close_over_ipc(
     await writer.wait_closed()
 
 
-# 功能：验证 daemon 通过 IPC 打开工作区后可列出文件树、搜索文本并读取指定文件。
-# 设计：使用测试专属临时目录而非仓库本身，串联 workspace.open/tree、file.search/read 四个端点，并确认结果不依赖 Git 或真实模型。
+# 功能：验证 daemon 通过 IPC 打开工作区后可列出文件、读取内容并返回结构化项目画像。
+# 设计：使用测试专属临时目录而非仓库本身，串联 workspace.open/tree、file.search/read/profile 端点，并确认画像经真实 IPC 传输而不依赖模型。
 async def test_workspace_file_commands_over_ipc(
     running_daemon: subprocess.Popen[bytes],
     free_port: int,
@@ -126,6 +126,7 @@ async def test_workspace_file_commands_over_ipc(
     project = tmp_path / "workspace"
     project.mkdir()
     (project / "hello.py").write_text("def greet():\n    return 'hello'\n", encoding="utf-8")
+    (project / "pyproject.toml").write_text("[project]\nname = 'workspace'\n", encoding="utf-8")
 
     reader, writer = await asyncio.open_connection("127.0.0.1", free_port)
     opened = await _send_recv(
@@ -183,6 +184,18 @@ async def test_workspace_file_commands_over_ipc(
         req_id="read",
     )
     assert "def greet" in read["result"]["content"]
+
+    profile = await _send_recv(
+        reader,
+        writer,
+        "workspace.profile",
+        {"workspace_id": workspace_id, "refresh": True},
+        req_id="profile",
+    )
+    component = profile["result"]["profile"]["projects"][0]
+    assert component["path"] == "."
+    assert component["languages"][0]["name"] == "Python"
+    assert all(command["recommendation_only"] is True for command in component["validation_plan"])
 
     writer.close()
     await writer.wait_closed()

--- a/tests/unit/test_context_system_prompt.py
+++ b/tests/unit/test_context_system_prompt.py
@@ -44,6 +44,21 @@ def test_only_global() -> None:
     assert "## Session Notes" not in prompt
 
 
+# 功能：验证自动检测的项目画像作为独立区段注入 system prompt，并保留项目记忆的顺序。
+# 设计：同时设置人工项目上下文与生成画像，断言画像不会覆盖用户内容且包含明确的建议安全边界。
+def test_project_profile_context_is_injected_after_project_context() -> None:
+    ctx = _make_ctx(
+        project_context="user project context",
+        project_profile_context="Detected Project Profile\nadvisory only",
+    )
+
+    prompt = ctx.system_prompt("BASE")
+
+    assert "## Project Context\nuser project context" in prompt
+    assert "## Project Profile\nDetected Project Profile\nadvisory only" in prompt
+    assert prompt.index("Project Context") < prompt.index("Project Profile")
+
+
 # 功能：验证 session_notes 非空时包含 note_save 提示语
 # 设计：只设置 session_notes，断言 prompt 含 note_save 相关提示
 def test_session_notes_hint() -> None:

--- a/tests/unit/test_context_system_prompt.py
+++ b/tests/unit/test_context_system_prompt.py
@@ -44,19 +44,24 @@ def test_only_global() -> None:
     assert "## Session Notes" not in prompt
 
 
-# 功能：验证自动检测的项目画像作为独立区段注入 system prompt，并保留项目记忆的顺序。
-# 设计：同时设置人工项目上下文与生成画像，断言画像不会覆盖用户内容且包含明确的建议安全边界。
-def test_project_profile_context_is_injected_after_project_context() -> None:
+# 功能：验证项目画像作为独立段落注入 system prompt，且位于项目上下文之后
+# 设计：同时设置人工项目上下文、生成画像与会话笔记，断言安全说明不覆盖用户内容且三个段落顺序稳定
+def test_project_profile_follows_project_context() -> None:
     ctx = _make_ctx(
         project_context="user project context",
         project_profile_context="Detected Project Profile\nadvisory only",
+        session_notes="remember this",
     )
 
     prompt = ctx.system_prompt("BASE")
 
     assert "## Project Context\nuser project context" in prompt
     assert "## Project Profile\nDetected Project Profile\nadvisory only" in prompt
-    assert prompt.index("Project Context") < prompt.index("Project Profile")
+    assert (
+        prompt.index("## Project Context")
+        < prompt.index("## Project Profile")
+        < prompt.index("## Session Notes")
+    )
 
 
 # 功能：验证 session_notes 非空时包含 note_save 提示语

--- a/tests/unit/test_project_profile.py
+++ b/tests/unit/test_project_profile.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from sztu_code.core.workspace.project_profile import (
+    ValidationCategory,
+    detect_project_profile,
+    render_project_profile_context,
+)
+
+
+# 从画像中按相对路径取得唯一子项目，便于断言路径归属。
+def _project_at(profile: object, path: str) -> object:
+    projects = getattr(profile, "projects")
+    return next(project for project in projects if project.path == path)
+
+
+# 将技术结论转换为名称集合，避免测试依赖列表内部排序细节。
+def _names(findings: object) -> set[str]:
+    return {finding.name for finding in findings}
+
+
+# 将验证命令按分类取出，直接验证分层后的建议而不是原始配置文本。
+def _commands(project: object, category: ValidationCategory) -> list[str]:
+    return [item.command for item in project.validation_plan if item.category == category]
+
+
+# 功能：识别带锁文件和工具配置的 Python 项目，并生成完整的分层验证建议。
+# 设计：使用临时目录中的 pyproject、uv 锁文件和集成测试目录，覆盖清单、框架、构建工具与路径证据的组合信号。
+def test_detects_python_profile_and_layered_plan(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[project]
+name = "api"
+dependencies = ["fastapi", "pytest", "ruff", "mypy"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+
+[tool.pytest.ini_options]
+markers = ["integration"]
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+    (tmp_path / "tests" / "integration").mkdir(parents=True)
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, ".")
+
+    assert _names(project.languages) == {"Python"}
+    assert "FastAPI" in _names(project.frameworks)
+    assert "uv" in _names(project.package_managers)
+    assert "Hatchling" in _names(project.build_tools)
+    assert "uv run ruff format --check ." in _commands(project, ValidationCategory.FORMAT)
+    assert "uv run ruff check ." in _commands(project, ValidationCategory.STATIC_CHECK)
+    assert "uv run pytest" in _commands(project, ValidationCategory.UNIT_TEST)
+    assert "uv run pytest tests/integration" in _commands(
+        project, ValidationCategory.INTEGRATION_TEST
+    )
+    assert "uv build" in _commands(project, ValidationCategory.BUILD)
+    assert any(item.path == "pyproject.toml" for item in project.evidence)
+    assert all(command.recommendation_only for command in project.validation_plan)
+
+
+# 功能：识别仅使用 setup.py 的传统 Python 项目，并保留可解释的 Setuptools 构建结论。
+# 设计：不放置 pyproject 或 requirements，覆盖旧式清单路径，防止框架证据来源为空时越界。
+def test_detects_setuptools_project_without_pyproject_or_requirements(tmp_path: Path) -> None:
+    (tmp_path / "setup.py").write_text(
+        "from setuptools import setup\nsetup(name='legacy', install_requires=['flask'])\n",
+        encoding="utf-8",
+    )
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, ".")
+
+    assert _names(project.languages) == {"Python"}
+    assert "Flask" in _names(project.frameworks)
+    assert "pip" in _names(project.package_managers)
+    assert "Setuptools" in _names(project.build_tools)
+    assert "python -m build" in _commands(project, ValidationCategory.BUILD)
+
+
+# 功能：识别 Node.js 的框架、包管理器和 package scripts，并按五类验证层生成建议。
+# 设计：只从 package.json 的声明式字段和 pnpm 锁文件读取信号，断言建议使用脚本名称而不会解析或执行脚本正文。
+def test_detects_node_profile_from_manifest_lockfile_and_scripts(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "web",
+                "packageManager": "pnpm@9.0.0",
+                "scripts": {
+                    "format": "prettier --check .",
+                    "lint": "eslint .",
+                    "test": "vitest run",
+                    "test:integration": "playwright test",
+                    "build": "vite build",
+                },
+                "dependencies": {"react": "^19.0.0"},
+                "devDependencies": {"vite": "^6.0.0"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n", encoding="utf-8")
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, ".")
+
+    assert _names(project.languages) == {"Node.js"}
+    assert "React" in _names(project.frameworks)
+    assert "pnpm" in _names(project.package_managers)
+    assert "Vite" in _names(project.build_tools)
+    assert "pnpm run format" in _commands(project, ValidationCategory.FORMAT)
+    assert "pnpm run lint" in _commands(project, ValidationCategory.STATIC_CHECK)
+    assert "pnpm run test" in _commands(project, ValidationCategory.UNIT_TEST)
+    assert "pnpm run test:integration" in _commands(project, ValidationCategory.INTEGRATION_TEST)
+    assert "pnpm run build" in _commands(project, ValidationCategory.BUILD)
+    assert all("prettier --check" not in command.command for command in project.validation_plan)
+
+
+# 功能：识别 Maven Java 项目中的框架和验证工具，不把构建插件当成自动执行动作。
+# 设计：以 pom、wrapper、源码目录和插件标识组成多重证据，分别断言格式化、静态检查、单测、集成与构建建议。
+def test_detects_java_maven_profile_and_validation_layers(tmp_path: Path) -> None:
+    (tmp_path / "pom.xml").write_text(
+        """
+<project>
+  <dependencies><dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency></dependencies>
+  <build><plugins><plugin>spotless</plugin><plugin>checkstyle</plugin><plugin>maven-failsafe-plugin</plugin></plugins></build>
+</project>
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "mvnw").write_text("#!/bin/sh\n", encoding="utf-8")
+    (tmp_path / "src" / "main" / "java").mkdir(parents=True)
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, ".")
+
+    assert _names(project.languages) == {"Java"}
+    assert "Spring Boot" in _names(project.frameworks)
+    assert "Maven" in _names(project.package_managers)
+    assert "Maven" in _names(project.build_tools)
+    assert "./mvnw spotless:check" in _commands(project, ValidationCategory.FORMAT)
+    assert "./mvnw checkstyle:check" in _commands(project, ValidationCategory.STATIC_CHECK)
+    assert "./mvnw test" in _commands(project, ValidationCategory.UNIT_TEST)
+    assert "./mvnw verify" in _commands(project, ValidationCategory.INTEGRATION_TEST)
+    assert "./mvnw package" in _commands(project, ValidationCategory.BUILD)
+
+
+# 功能：识别 Gradle 多模块项目，并将单个子模块标注为 Monorepo 内的独立 Java 项目。
+# 设计：使用 settings.gradle、Java 插件和真实 .java 源码组成组合信号，断言父聚合配置不会让子模块命令丢失路径归属。
+def test_detects_gradle_multi_module_java_project(tmp_path: Path) -> None:
+    (tmp_path / "settings.gradle").write_text("include 'service'\n", encoding="utf-8")
+    (tmp_path / "service" / "src" / "main" / "java").mkdir(parents=True)
+    (tmp_path / "service" / "build.gradle").write_text(
+        "plugins { id 'java' }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "service" / "src" / "main" / "java" / "App.java").write_text(
+        "class App {}\n",
+        encoding="utf-8",
+    )
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, "service")
+
+    assert profile.monorepo is True
+    assert _names(project.languages) == {"Java"}
+    assert "Gradle" in _names(project.build_tools)
+    assert "gradle test" in _commands(project, ValidationCategory.UNIT_TEST)
+    assert all(command.working_directory == "service" for command in project.validation_plan)
+
+
+# 功能：识别 C 与 C++ 的 CMake 项目、依赖管理器和分层验证策略。
+# 设计：同时放置 C/C++ 源码、CTest、clang 配置和 vcpkg 清单，保证语言结论由构建文件与目录信号共同支撑。
+def test_detects_c_and_cpp_cmake_profile_and_validation_layers(tmp_path: Path) -> None:
+    (tmp_path / "CMakeLists.txt").write_text(
+        """
+cmake_minimum_required(VERSION 3.24)
+project(native LANGUAGES C CXX)
+find_package(GTest REQUIRED)
+enable_testing()
+add_test(NAME integration_native COMMAND native)
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.cpp").write_text("int main() { return 0; }\n", encoding="utf-8")
+    (tmp_path / "src" / "legacy.c").write_text("int legacy(void) { return 0; }\n", encoding="utf-8")
+    (tmp_path / ".clang-format").write_text("BasedOnStyle: LLVM\n", encoding="utf-8")
+    (tmp_path / ".clang-tidy").write_text("Checks: '*'\n", encoding="utf-8")
+    (tmp_path / "vcpkg.json").write_text('{"name": "native"}\n', encoding="utf-8")
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, ".")
+
+    assert _names(project.languages) == {"C", "C++"}
+    assert "GoogleTest" in _names(project.frameworks)
+    assert "vcpkg" in _names(project.package_managers)
+    assert "CMake" in _names(project.build_tools)
+    assert _commands(project, ValidationCategory.FORMAT)
+    assert _commands(project, ValidationCategory.STATIC_CHECK)
+    assert "ctest --test-dir build --output-on-failure" in _commands(
+        project, ValidationCategory.UNIT_TEST
+    )
+    assert "ctest --test-dir build --output-on-failure -L integration" in _commands(
+        project, ValidationCategory.INTEGRATION_TEST
+    )
+    assert "cmake -S . -B build && cmake --build build" in _commands(
+        project, ValidationCategory.BUILD
+    )
+
+
+# 功能：避免把通用构建文件或非 Python 的 pyproject 配置误报为确定语言项目。
+# 设计：分别构造 coverage、Kotlin Gradle 与无语言声明 CMake 信号，验证缺少语言语义或源码时不产生画像组件。
+def test_ignores_ambiguous_manifests_without_language_evidence(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n", encoding="utf-8")
+    (tmp_path / "kotlin").mkdir()
+    (tmp_path / "kotlin" / "build.gradle.kts").write_text(
+        'plugins { kotlin("jvm") version "2.0.0" }\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "generator").mkdir()
+    (tmp_path / "generator" / "CMakeLists.txt").write_text(
+        "cmake_minimum_required(VERSION 3.24)\nproject(generator)\n",
+        encoding="utf-8",
+    )
+
+    profile = detect_project_profile(tmp_path)
+
+    assert profile.projects == []
+
+
+# 功能：在 Monorepo 中分离父工作区和子项目的检测结果与命令归属。
+# 设计：构造带根 pnpm 锁文件的 Node 工作区、Web 子包与 Python 服务，断言子包继承包管理器且每条建议仍携带自身路径。
+def test_detects_monorepo_children_without_mixing_validation_commands(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "root", "private": True, "workspaces": ["apps/*", "services/*"]}),
+        encoding="utf-8",
+    )
+    (tmp_path / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n", encoding="utf-8")
+    (tmp_path / "apps" / "web").mkdir(parents=True)
+    (tmp_path / "apps" / "web" / "package.json").write_text(
+        json.dumps({"name": "web", "scripts": {"lint": "eslint .", "build": "vite build"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "services" / "api").mkdir(parents=True)
+    (tmp_path / "services" / "api" / "pyproject.toml").write_text(
+        """
+[project]
+name = "api"
+dependencies = ["pytest"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+""".strip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "services" / "api" / "tests").mkdir()
+
+    profile = detect_project_profile(tmp_path)
+    web = _project_at(profile, "apps/web")
+    api = _project_at(profile, "services/api")
+
+    assert profile.monorepo is True
+    assert all(command.working_directory == "apps/web" for command in web.validation_plan)
+    assert all(command.working_directory == "services/api" for command in api.validation_plan)
+    assert "pnpm" in _names(web.package_managers)
+    assert "pnpm run build" in _commands(web, ValidationCategory.BUILD)
+    assert "pnpm run build" not in _commands(api, ValidationCategory.BUILD)
+    assert "python -m build" in _commands(api, ValidationCategory.BUILD)
+    assert {project.path for project in profile.projects} >= {"apps/web", "services/api"}
+
+
+# 功能：忽略构建产物和依赖目录中的伪清单，并确保检测不会执行推荐命令。
+# 设计：将 subprocess.run 替换为立即失败的桩，同时放置真实 Node 清单与被忽略目录，检测成功即证明只做离线读取。
+def test_ignores_generated_directories_and_never_executes_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "safe", "scripts": {"build": "echo should-not-run"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "package.json").write_text(
+        json.dumps({"name": "ignored"}), encoding="utf-8"
+    )
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "CMakeLists.txt").write_text("project(ignored)\n", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "pom.xml").write_text("<project/>\n", encoding="utf-8")
+
+    # 调用外部进程即视为失败，验证检测器仅返回建议数据。
+    def fail_if_called(*args: object, **kwargs: object) -> object:
+        raise AssertionError(f"unexpected command execution: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+    profile = detect_project_profile(tmp_path)
+
+    assert [project.path for project in profile.projects] == ["."]
+    assert all(command.recommendation_only for command in profile.projects[0].validation_plan)
+    assert "ignored" not in {finding.name for finding in profile.projects[0].frameworks}
+
+
+# 功能：将画像渲染成紧凑工作上下文，并保留“仅建议、不自动执行”的安全边界。
+# 设计：复用 Monorepo 形状的临时项目，断言上下文包含路径和建议说明而不包含原始 package script 正文。
+def test_renders_compact_advisory_project_context(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"name": "web", "scripts": {"build": "dangerous-command --all"}}),
+        encoding="utf-8",
+    )
+
+    context = render_project_profile_context(detect_project_profile(tmp_path))
+
+    assert "Detected Project Profile" in context
+    assert "advisory only" in context
+    assert "dangerous-command --all" not in context
+    assert len(context) < 4_000

--- a/tests/unit/test_project_profile.py
+++ b/tests/unit/test_project_profile.py
@@ -6,8 +6,14 @@ from pathlib import Path
 
 import pytest
 
+import sztu_code.core.workspace.project_profile as project_profile
 from sztu_code.core.workspace.project_profile import (
+    DetectionEvidence,
+    ProjectComponent,
+    ProjectProfile,
+    TechnologyFinding,
     ValidationCategory,
+    ValidationCommand,
     detect_project_profile,
     render_project_profile_context,
 )
@@ -155,10 +161,11 @@ def test_detects_java_maven_profile_and_validation_layers(tmp_path: Path) -> Non
     assert "./mvnw package" in _commands(project, ValidationCategory.BUILD)
 
 
-# 功能：识别 Gradle 多模块项目，并将单个子模块标注为 Monorepo 内的独立 Java 项目。
-# 设计：使用 settings.gradle、Java 插件和真实 .java 源码组成组合信号，断言父聚合配置不会让子模块命令丢失路径归属。
+# 功能：识别 Gradle 多模块项目，并让子模块安全继承根目录 wrapper。
+# 设计：使用 settings.gradle、根 gradlew、Java 插件和真实 .java 源码组成组合信号，断言命令既保留子项目路径归属又不回退到全局 Gradle。
 def test_detects_gradle_multi_module_java_project(tmp_path: Path) -> None:
     (tmp_path / "settings.gradle").write_text("include 'service'\n", encoding="utf-8")
+    (tmp_path / "gradlew").write_text("#!/bin/sh\n", encoding="utf-8")
     (tmp_path / "service" / "src" / "main" / "java").mkdir(parents=True)
     (tmp_path / "service" / "build.gradle").write_text(
         "plugins { id 'java' }\n",
@@ -175,8 +182,27 @@ def test_detects_gradle_multi_module_java_project(tmp_path: Path) -> None:
     assert profile.monorepo is True
     assert _names(project.languages) == {"Java"}
     assert "Gradle" in _names(project.build_tools)
-    assert "gradle test" in _commands(project, ValidationCategory.UNIT_TEST)
+    assert "../gradlew test" in _commands(project, ValidationCategory.UNIT_TEST)
     assert all(command.working_directory == "service" for command in project.validation_plan)
+    assert any(item.path == "gradlew" for item in project.evidence)
+
+
+# 功能：为 Maven 子项目继承最近父项目 wrapper，同时保留子项目命令归属。
+# 设计：在根目录只放置 wrapper、在模块放置 pom 和 Java 源码，覆盖未复制 wrapper 时的真实 Reactor 项目布局。
+def test_inherits_parent_maven_wrapper_for_java_subproject(tmp_path: Path) -> None:
+    (tmp_path / "mvnw.cmd").write_text("@echo off\n", encoding="utf-8")
+    (tmp_path / "modules" / "api" / "src" / "main" / "java").mkdir(parents=True)
+    (tmp_path / "modules" / "api" / "pom.xml").write_text("<project></project>\n", encoding="utf-8")
+    (tmp_path / "modules" / "api" / "src" / "main" / "java" / "App.java").write_text(
+        "class App {}\n", encoding="utf-8"
+    )
+
+    profile = detect_project_profile(tmp_path)
+    project = _project_at(profile, "modules/api")
+
+    assert "../../mvnw.cmd test" in _commands(project, ValidationCategory.UNIT_TEST)
+    assert all(command.working_directory == "modules/api" for command in project.validation_plan)
+    assert any(item.path == "mvnw.cmd" for item in project.evidence)
 
 
 # 功能：识别 C 与 C++ 的 CMake 项目、依赖管理器和分层验证策略。
@@ -281,6 +307,46 @@ build-backend = "setuptools.build_meta"
     assert {project.path for project in profile.projects} >= {"apps/web", "services/api"}
 
 
+# 功能：在超大目录中于全局扫描额度耗尽后停止读取目录项。
+# 设计：用追踪 scandir 迭代器统计实际拉取次数，并把额度设得很小，直接防止先完整枚举再检查上限的回归。
+def test_bounds_directory_enumeration_before_sorting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for index in range(12):
+        (tmp_path / f"unrelated-{index:02d}.txt").write_text("x\n", encoding="utf-8")
+    original_scandir = project_profile.os.scandir
+    entry_reads = 0
+
+    class TrackingScandir:
+        def __init__(self, path: Path) -> None:
+            self.iterator = original_scandir(path)
+
+        def __enter__(self) -> TrackingScandir:
+            return self
+
+        def __exit__(self, *_: object) -> None:
+            self.iterator.close()
+
+        def __iter__(self) -> TrackingScandir:
+            return self
+
+        def __next__(self) -> object:
+            nonlocal entry_reads
+            entry_reads += 1
+            return next(self.iterator)
+
+    def tracking_scandir(path: Path) -> TrackingScandir:
+        return TrackingScandir(path)
+
+    monkeypatch.setattr(project_profile, "_MAX_SCAN_ENTRIES", 3)
+    monkeypatch.setattr(project_profile.os, "scandir", tracking_scandir)
+
+    profile = detect_project_profile(tmp_path)
+
+    assert profile.scan_limited is True
+    assert entry_reads == 4
+
+
 # 功能：忽略构建产物和依赖目录中的伪清单，并确保检测不会执行推荐命令。
 # 设计：将 subprocess.run 替换为立即失败的桩，同时放置真实 Node 清单与被忽略目录，检测成功即证明只做离线读取。
 def test_ignores_generated_directories_and_never_executes_commands(
@@ -296,6 +362,8 @@ def test_ignores_generated_directories_and_never_executes_commands(
     )
     (tmp_path / "build").mkdir()
     (tmp_path / "build" / "CMakeLists.txt").write_text("project(ignored)\n", encoding="utf-8")
+    (tmp_path / ".gradle").mkdir()
+    (tmp_path / ".gradle" / "pom.xml").write_text("<project/>\n", encoding="utf-8")
     (tmp_path / ".git").mkdir()
     (tmp_path / ".git" / "pom.xml").write_text("<project/>\n", encoding="utf-8")
 
@@ -325,3 +393,31 @@ def test_renders_compact_advisory_project_context(tmp_path: Path) -> None:
     assert "advisory only" in context
     assert "dangerous-command --all" not in context
     assert len(context) < 4_000
+
+
+# 功能：清理工程路径和命令中的换行与反引号，保持画像上下文的单行安全格式。
+# 设计：直接构造带控制字符的结构化画像，断言渲染结果不携带原始分隔符而仍保留可读文本。
+def test_context_sanitizes_untrusted_project_values() -> None:
+    profile = ProjectProfile(
+        projects=[
+            ProjectComponent(
+                path="apps/bad`path\nnext",
+                languages=[TechnologyFinding(name="Node\n.js")],
+                evidence=[DetectionEvidence(path="package`\njson", rule="manifest")],
+                validation_plan=[
+                    ValidationCommand(
+                        category=ValidationCategory.BUILD,
+                        command="npm run build`\n--unsafe",
+                        working_directory="apps/bad\npath",
+                        reason="script",
+                    )
+                ],
+            )
+        ]
+    )
+
+    context = render_project_profile_context(profile)
+
+    assert "bad`path" not in context
+    assert "bad'path next" in context
+    assert "build' --unsafe" in context

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -340,8 +340,73 @@ async def test_session_history_and_notes_injected(tmp_path: Path) -> None:
     assert not (tmp_path / "runs" / "run-new").exists()
 
 
-# 功能：验证有工作区的 Agent run 会获得自动生成的项目画像和仅建议的验证策略。
-# 设计：用捕获型 provider 观察真正传给模型的 system prompt，避免只测试渲染函数而漏掉 Runner 接入。
+# 功能：验证每次 run 都会在工作区根目录检测画像并把渲染结果注入 system prompt
+# 设计：替换检测与渲染函数并用捕获型 provider 观察最终 system，避免依赖真实文件结构或模型调用
+async def test_project_profile_is_injected_into_system_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+    detected_roots: list[Path] = []
+
+    # 记录检测根目录并返回最小画像替身
+    def fake_detect_project_profile(root: Path) -> object:
+        detected_roots.append(root)
+        return object()
+
+    monkeypatch.setattr(
+        "sztu_code.core.runner.detect_project_profile", fake_detect_project_profile
+    )
+    monkeypatch.setattr(
+        "sztu_code.core.runner.render_project_profile_context",
+        lambda profile: "Language: Python\nRecommended unit test: uv run pytest",
+    )
+    provider = _CapturingProvider(LlmResponse(stop_reason="end_turn", text="done"))
+    runner = AgentRunner(_config(), provider=provider, runs_dir=tmp_path / "runs")
+
+    outcome = await runner.run_and_capture("inspect project", workspace_root=workspace_root)
+
+    assert outcome.status == "success"
+    assert detected_roots == [workspace_root.resolve()]
+    assert provider.system is not None
+    assert "## Project Profile" in provider.system
+    assert "Recommended unit test: uv run pytest" in provider.system
+
+
+# 功能：验证项目画像检测遇到文件系统或数据错误时不会阻断 agent run
+# 设计：依次注入 OSError 和 ValueError，确认两种允许捕获的失败均保留正常 run 且不产生画像段
+async def test_project_profile_detection_errors_do_not_block_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    workspace_root.mkdir()
+
+    for error_type in (OSError, ValueError):
+        # 模拟检测阶段抛出可恢复的文件系统或数据异常
+        def raise_detection_error(
+            root: Path, error_type: type[OSError | ValueError] = error_type
+        ) -> object:
+            raise error_type("unreadable project metadata")
+
+        monkeypatch.setattr(
+            "sztu_code.core.runner.detect_project_profile", raise_detection_error
+        )
+        provider = _CapturingProvider(LlmResponse(stop_reason="end_turn", text="done"))
+        runner = AgentRunner(_config(), provider=provider, runs_dir=tmp_path / error_type.__name__)
+
+        outcome = await runner.run_and_capture(
+            "inspect project",
+            run_id=f"profile-error-{error_type.__name__}",
+            workspace_root=workspace_root,
+        )
+
+        assert outcome.status == "success"
+        assert provider.system is not None
+        assert "## Project Profile" not in provider.system
+
+
+# 功能：验证真实工作区画像会进入 Agent prompt，且 package script 正文不会被注入。
+# 设计：用捕获型 provider 观察真实检测和渲染后的 system prompt，锁定推荐命令与不执行脚本正文的边界。
 async def test_workspace_project_profile_is_injected_into_agent_context(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -340,6 +340,28 @@ async def test_session_history_and_notes_injected(tmp_path: Path) -> None:
     assert not (tmp_path / "runs" / "run-new").exists()
 
 
+# 功能：验证有工作区的 Agent run 会获得自动生成的项目画像和仅建议的验证策略。
+# 设计：用捕获型 provider 观察真正传给模型的 system prompt，避免只测试渲染函数而漏掉 Runner 接入。
+async def test_workspace_project_profile_is_injected_into_agent_context(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "package.json").write_text(
+        json.dumps({"name": "web", "scripts": {"build": "unsafe-build --all"}}),
+        encoding="utf-8",
+    )
+    provider = _CapturingProvider(LlmResponse(stop_reason="end_turn", text="done"))
+    runner = AgentRunner(_config(), provider=provider, runs_dir=tmp_path / "runs")
+
+    await runner.run_and_capture("inspect", run_id="run-profile", workspace_root=workspace)
+
+    assert provider.system is not None
+    assert "## Project Profile" in provider.system
+    assert "Detected Project Profile" in provider.system
+    assert "npm run build" in provider.system
+    assert "advisory only" in provider.system
+    assert "unsafe-build --all" not in provider.system
+
+
 # 功能：验证桌面端收到 run.finished 时本轮耗时与 token 已经持久化
 # 设计：在完成事件订阅器中立即读取 meta，锁定先落盘再广播的时序契约
 async def test_session_stats_persisted_before_finished_event(tmp_path: Path) -> None:

--- a/tests/unit/test_spawn_agent_tool.py
+++ b/tests/unit/test_spawn_agent_tool.py
@@ -417,6 +417,33 @@ async def test_budget_fields_propagate_to_child(tmp_path: Path, monkeypatch: pyt
     assert captured[0].max_wall_clock_s == 30
 
 
+# 功能：验证子 agent 会继承父 agent 已检测并渲染好的项目画像上下文
+# 设计：替换 AgentLoop.run 捕获子上下文，避免调用真实模型，并直接断言继承内容不会丢失
+async def test_child_inherits_project_profile_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parent_context = ExecutionContext(
+        run_id="parent-context",
+        goal="parent goal",
+        max_steps=5,
+        project_profile_context="Language: Python\nRecommended unit test: uv run pytest",
+    )
+    captured: list[ExecutionContext] = []
+
+    # 捕获子运行上下文并直接标记成功，隔离继承断言
+    async def fake_run(self: Any, context: ExecutionContext) -> None:
+        captured.append(context)
+        context.mark_success()
+
+    monkeypatch.setattr("sztu_code.core.subagent.tool.AgentLoop.run", fake_run)
+    tool, _, _ = _make_tool(tmp_path, parent_context=parent_context)
+
+    result = await tool.invoke({"description": "child task", "prompt": "inspect project"})
+
+    assert not result.is_error
+    assert captured[0].project_profile_context == parent_context.project_profile_context
+
+
 # 功能：验证父代理的工具并发上限会继承给子 AgentLoop
 # 设计：替换 child loop 的 run 捕获实例私有配置，覆盖多代理传播链而不依赖实际工具执行
 async def test_tool_concurrency_propagates_to_child(

--- a/tests/unit/test_workspace_profile.py
+++ b/tests/unit/test_workspace_profile.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import TypeAdapter
+
+from sztu_code.core.bus.commands import Command, WorkspaceProfileCommand, WorkspaceProfileResult
+from sztu_code.core.workspace import WorkspaceManager
+
+
+# 从画像中的技术结论取名称，保持刷新断言紧凑可读。
+def _language_names(profile: object) -> set[str]:
+    return {
+        finding.name
+        for project in profile.projects
+        for finding in project.languages
+    }
+
+
+# 功能：验证工作区画像默认复用缓存，而显式刷新会重新读取当前项目结构。
+# 设计：先创建 Node 项目，再新增 Python 清单，分别断言缓存稳定性和 refresh=True 的磁盘状态反映。
+def test_workspace_profile_refreshes_detected_workspace_state(tmp_path: Path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "package.json").write_text(json.dumps({"name": "web"}), encoding="utf-8")
+    manager = WorkspaceManager(tmp_path / "workspaces.json")
+    workspace = manager.open(str(root))
+
+    first = manager.profile(workspace.id)
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = 'api'\nversion = '0.1.0'\n",
+        encoding="utf-8",
+    )
+    cached = manager.profile(workspace.id)
+    refreshed = manager.profile(workspace.id, refresh=True)
+
+    assert _language_names(first) == {"Node.js"}
+    assert _language_names(cached) == {"Node.js"}
+    assert _language_names(refreshed) == {"Node.js", "Python"}
+
+
+# 功能：验证 workspace.profile 命令模型可被判别联合解析并序列化结构化画像结果。
+# 设计：用 TypeAdapter 走真实 Command union，再以最小项目画像构造 Result，覆盖协议字段而不依赖 daemon。
+def test_workspace_profile_command_roundtrip_uses_structured_result(tmp_path: Path) -> None:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "package.json").write_text(json.dumps({"name": "web"}), encoding="utf-8")
+    manager = WorkspaceManager(tmp_path / "workspaces.json")
+    workspace = manager.open(str(root))
+
+    command = TypeAdapter(Command).validate_python(
+        {"type": "workspace.profile", "workspace_id": workspace.id, "refresh": True}
+    )
+    result = WorkspaceProfileResult(profile=manager.profile(workspace.id, refresh=True))
+
+    assert isinstance(command, WorkspaceProfileCommand)
+    assert command.refresh is True
+    assert result.model_dump(mode="json")["profile"]["projects"][0]["path"] == "."


### PR DESCRIPTION
## Summary

Fixes #13

实现离线、确定性的项目画像检测与分层验证策略，让 Agent 在开始工作前基于真实工作区结构获得可解释的技术栈和验证建议。

## Behavior

- 组合工程清单、锁文件、构建描述和源码信号，识别 Python、Node.js、Java、C/C++，并为每条结论保留证据文件与规则。
- 为单项目及 Monorepo 子项目生成语言、框架、包管理器、构建工具和五类验证建议（格式化、静态检查、单元测试、集成测试、构建），每条命令带工作目录归属。
- 推荐命令以结构化的 `recommendation_only` 数据进入 Agent 上下文和桌面端，不会自动执行；实际运行仍经过既有工具权限与审批流程。
- 新增 `workspace.profile` IPC；Runner 在运行前注入精简画像，子 Agent 继承父 Agent 的画像上下文。
- Project Inspector 的任务摘要支持查看证据、Monorepo 子项目和分层命令，并支持刷新；刷新失败保留旧结果，工作区切换会忽略过期响应。

## Validation

```text
uv run pytest tests/unit -q --basetemp=<临时目录>
830 passed

uv run pytest tests/integration/test_s4_session_ipc.py -q --basetemp=<临时目录>
2 passed

uv run ruff check src tests scripts
通过

uv run mypy src
Success: no issues found in 182 source files

uv run python scripts/gen_protocol_doc.py --check
通过

cd desktop && npm run test:unit
13 passed

cd desktop && npm run build
通过；仅有 Vite bundle size warning

uv run pytest tests/integration -q --basetemp=<临时目录>
34 passed, 5 failed, 1 skipped；5 个失败均为既有 test_multi_agent_workflow_e2e.py 场景，Windows/WSL 的 Bash 环境缺少 python 命令并暴露 CRLF/LF fixture 差异，与本 PR 改动无关。
```

## Risk

- 检测器是基于常见工程约定的离线启发式；非标准目录或构建流程可能需要后续扩展。扫描有深度和数量上限，达到上限时会标记 `scan_limited`。
- Java 子项目会优先使用组件自身或祖先项目的 Maven/Gradle wrapper；Windows wrapper 使用 `.cmd/.bat`，仍建议维护者在目标平台复核命令。
- 建议命令始终只读入计划、上下文和 UI，不改变既有执行权限边界。

## UI evidence

已附 Project Inspector 视觉核验截图：包含 Monorepo、Python/Node.js 技术栈、证据来源、五类分层命令、路径归属和“仅建议，未执行”提示；刷新入口位于项目画像工具栏。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。
- [x] 用户文档、配置示例和迁移说明不适用，协议参考已同步。
- [x] 提交包含 `Signed-off-by`（DCO）。
<img width="1280" height="720" alt="project-profile-ui" src="https://github.com/user-attachments/assets/52a1e9d7-7eb3-4a56-8d65-47f57423e658" />
<img width="999" height="720" alt="project-profile-ui-lower" src="https://github.com/user-attachments/assets/ec8a9c8c-8ae3-4ac5-bd73-4677b2f84ff5" />
