### PR TITLE
feat(harness): 持久化 run 生命周期记录，重启后 run.get 不再返回 unknown

### DIFF
--- a/src/sztu_code/core/app.py
+++ b/src/sztu_code/core/app.py
@@ -167,6 +167,7 @@ from sztu_code.core.permissions.manager import PermissionManager
 from sztu_code.core.permissions.policy import PermissionMode
 from sztu_code.core.permissions.storage import load_policy_file
 from sztu_code.core.plugins import Marketplace, MarketplaceManager, MarketplacePlugin
+from sztu_code.core.run_store import RunStore
 from sztu_code.core.runner import AgentRunner
 from sztu_code.core.runs import events_file, new_run_id
 from sztu_code.core.session import SessionManager, SessionStore
@@ -236,6 +237,7 @@ class CoreApp:
         self._run_status: dict[str, str] = {}
         self._client_message_runs: dict[tuple[str, str], str] = {}
         self._active_session_runs: dict[str, asyncio.Task[str]] = {}
+        self._run_store: RunStore | None = None
         self._sessions: SessionManager | None = None
         self._permission_manager: PermissionManager | None = None
         self._mcp_manager: McpServerManager | None = None
@@ -285,14 +287,20 @@ class CoreApp:
             self._active_run_tasks.pop(run_id, None)
         if task.cancelled():
             self._run_status[run_id] = "cancelled"
+            if self._run_store is not None:
+                self._run_store.finish(run_id, status="cancelled", reason="cancelled")
             return
         try:
             task.result()
         except Exception:
             self._run_status[run_id] = "completed"
             logger.exception("run failed run_id=%s", run_id)
+            if self._run_store is not None:
+                self._run_store.finish(run_id, status="completed", reason="error")
         else:
             self._run_status[run_id] = "completed"
+            if self._run_store is not None:
+                self._run_store.finish(run_id, status="completed")
 
     # 处理 core.ping 请求，返回服务版本、运行时长和接收时间
     async def _ping_handler(self, params: dict[str, Any]) -> PongResult:
@@ -326,6 +334,8 @@ class CoreApp:
         cmd = AgentRunCommand.model_validate(params)
         session = await self._sessions.create(mode="one_shot", title=cmd.goal[:40])
         run_id = new_run_id()
+        if self._run_store is not None:
+            self._run_store.start(run_id, goal=cmd.goal, session_id=session.id)
         run_task = asyncio.create_task(
             self._sessions.send_message(session.id, cmd.goal, run_id=run_id)
         )
@@ -630,6 +640,8 @@ class CoreApp:
         await self._sessions.get_history(cmd.session_id)
 
         run_id = new_run_id()
+        if self._run_store is not None:
+            self._run_store.start(run_id, goal=cmd.content, session_id=cmd.session_id)
         if cmd.client_message_id:
             self._client_message_runs[(cmd.session_id, cmd.client_message_id)] = run_id
         run_task = asyncio.create_task(
@@ -663,7 +675,13 @@ class CoreApp:
     # 返回当前进程所知的 run 生命周期状态，供客户端重连后恢复控制状态
     async def _run_get_handler(self, params: dict[str, Any]) -> RunGetResult:
         cmd = RunGetCommand.model_validate(params)
-        status = self._run_status.get(cmd.run_id, "unknown")
+        # 优先内存中的活动状态；重启后回退到持久化 RunStore，避免误报 unknown
+        status: str | None = self._run_status.get(cmd.run_id)
+        if status is None and self._run_store is not None:
+            record = self._run_store.get(cmd.run_id)
+            status = record.status if record is not None else None
+        if status is None:
+            status = "unknown"
         return RunGetResult(run_id=cmd.run_id, status=status)  # type: ignore[arg-type]
 
     # 读取已持久化的运行事件，供客户端在切换或重连后重建工作台状态
@@ -1638,6 +1656,12 @@ class CoreApp:
         _pid_file = Path("~/.sztu/sztu-code.pid").expanduser()
         _pid_file.parent.mkdir(parents=True, exist_ok=True)
         _pid_file.write_text(str(os.getpid()))
+
+        # 启动时对账：把上次崩溃遗留的 running 记录标记为 cancelled，使 run.get 状态与磁盘一致
+        self._run_store = RunStore()
+        reconciled = self._run_store.reconcile()
+        if reconciled:
+            logger.info("run store: reconciled %d interrupted run(s)", len(reconciled))
 
         if self._config.trace.enabled:
             trace_path = Path(self._config.trace.file).expanduser()

--- a/src/sztu_code/core/run_store.py
+++ b/src/sztu_code/core/run_store.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+# run 生命周期状态：running 表示执行中，completed/cancelled 为终态
+RunStatus = Literal["running", "completed", "cancelled"]
+
+# 默认运行记录根目录；测试可通过 SZTU_RUNS_DIR 覆盖
+_DEFAULT_RUNS_DIR = "~/.sztu/runs"
+# 终态集合：进入终态后不允许再被覆盖，保证一个 run 只有一个最终结果
+_TERMINAL: frozenset[str] = frozenset({"completed", "cancelled"})
+
+
+# 返回当前 UTC 时间的 ISO 8601 字符串
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass
+class RunRecord:
+    run_id: str
+    session_id: str = ""
+    status: RunStatus = "running"
+    goal: str = ""
+    started_at: str = ""
+    ended_at: str | None = None
+    result: str = ""
+    reason: str | None = None
+    steps: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    # 从磁盘 dict 还原 RunRecord，容忍缺失或类型异常字段
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunRecord:
+        status = data.get("status", "running")
+        if status not in _TERMINAL and status != "running":
+            status = "running"
+        return cls(
+            run_id=str(data.get("run_id", "")),
+            session_id=str(data.get("session_id", "")),
+            status=status,
+            goal=str(data.get("goal", "")),
+            started_at=str(data.get("started_at", "")),
+            ended_at=str(data["ended_at"]) if data.get("ended_at") else None,
+            result=str(data.get("result", "")),
+            reason=str(data["reason"]) if data.get("reason") is not None else None,
+            steps=max(0, int(data.get("steps", 0) or 0)),
+        )
+
+
+class RunStore:
+    # 初始化运行记录根目录，按需创建
+    def __init__(self, root: Path | None = None) -> None:
+        if root is None:
+            root = Path(os.environ.get("SZTU_RUNS_DIR", _DEFAULT_RUNS_DIR)).expanduser()
+        self._root = root
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    # 返回指定 run_id 的目录路径
+    def run_dir(self, run_id: str) -> Path:
+        return self._root / run_id
+
+    # 返回指定 run_id 的运行记录文件路径
+    def record_path(self, run_id: str) -> Path:
+        return self.run_dir(run_id) / "run.json"
+
+    # 写入一条 running 记录，表示任务已被接收
+    def start(self, run_id: str, *, goal: str = "", session_id: str = "") -> RunRecord:
+        record = RunRecord(
+            run_id=run_id,
+            session_id=session_id,
+            status="running",
+            goal=goal,
+            started_at=_now(),
+        )
+        self._write(record)
+        return record
+
+    # 将 running 记录推进到终态；已终态或不存在时返回原记录/None，保证单一最终结果
+    def finish(
+        self,
+        run_id: str,
+        *,
+        status: RunStatus,
+        reason: str | None = None,
+        steps: int = 0,
+        result: str = "",
+    ) -> RunRecord | None:
+        if status not in _TERMINAL:
+            raise ValueError(f"finish requires a terminal status, got {status!r}")
+        record = self.get(run_id)
+        if record is None or record.status in _TERMINAL:
+            return record
+        record.status = status
+        record.reason = reason
+        record.steps = steps
+        record.result = result
+        record.ended_at = _now()
+        self._write(record)
+        return record
+
+    # 读取指定 run_id 的记录，不存在或损坏时返回 None
+    def get(self, run_id: str) -> RunRecord | None:
+        path = self.record_path(run_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            logger.warning("skip invalid run record path=%s", path)
+            return None
+        if not isinstance(data, dict):
+            return None
+        try:
+            return RunRecord.from_dict(data)
+        except (TypeError, ValueError, KeyError):
+            logger.warning("skip malformed run record path=%s", path)
+            return None
+
+    # 返回所有仍处于 running 状态的记录，供启动对账使用
+    def list_running(self) -> list[RunRecord]:
+        records: list[RunRecord] = []
+        for path in self._root.glob("*/run.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(data, dict) or data.get("status") != "running":
+                continue
+            try:
+                records.append(RunRecord.from_dict(data))
+            except (TypeError, ValueError, KeyError):
+                continue
+        return records
+
+    # 把崩溃遗留的 running 记录标记为 cancelled（daemon 启动时调用）
+    def reconcile(self) -> list[RunRecord]:
+        changed: list[RunRecord] = []
+        for record in self.list_running():
+            record.status = "cancelled"
+            record.reason = "daemon_restarted"
+            record.ended_at = _now()
+            self._write(record)
+            changed.append(record)
+        return changed
+
+    # 原子写入运行记录，避免半写文件被误读为合法状态
+    def _write(self, record: RunRecord) -> None:
+        path = self.record_path(record.run_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(record.to_dict(), ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        tmp.replace(path)

--- a/tests/integration/test_run_restart.py
+++ b/tests/integration/test_run_restart.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from sztu_code.core.run_store import RunStore
+from sztu_code.core.transport.socket_client import SocketClient
+
+
+# 启动 daemon 并等待端口可连接，返回子进程；超时则强杀并报错
+async def _spawn_daemon(port: int, runs_dir: Path) -> subprocess.Popen[bytes]:
+    env = os.environ.copy()
+    env["SZTU_PORT"] = str(port)
+    env["SZTU_RUNS_DIR"] = str(runs_dir)
+    env["SZTU_LOG_FILE"] = ""
+    env["SZTU_LOG_LEVEL"] = "WARNING"
+
+    proc = subprocess.Popen([sys.executable, "-m", "sztu_code.core"], env=env)
+    # /mnt/e 的 drvfs 挂载下冷启动 import openai 较慢，放宽到 60s 避免误判为启动失败
+    deadline = time.monotonic() + 60.0
+    while time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+        try:
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            await writer.wait_closed()
+            return proc
+        except (ConnectionRefusedError, OSError):
+            pass
+    proc.kill()
+    proc.wait()
+    raise RuntimeError("daemon did not start in time")
+
+
+# 强杀子进程并等待其退出，模拟崩溃而非优雅关闭
+def _crash(proc: subprocess.Popen[bytes]) -> None:
+    proc.kill()
+    proc.wait()
+
+
+# 功能：daemon 启动时把崩溃遗留的 running 记录对账为 cancelled，run.get 不再返回 unknown
+# 设计：预写 running 记录后启动真实 daemon，run.get 应返回 cancelled 而非 unknown
+async def test_run_get_reconciles_interrupted_run_after_restart(
+    free_port: int, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    RunStore(runs_dir).start("crashed-run-1", goal="interrupted")
+
+    proc = await _spawn_daemon(free_port, runs_dir)
+    client = SocketClient("127.0.0.1", free_port)
+    await client.connect()
+    loop_task = asyncio.create_task(client.run_event_loop())
+    try:
+        result = await client.send_command("run.get", {"run_id": "crashed-run-1"})
+        assert result.get("status") == "cancelled", result
+    finally:
+        loop_task.cancel()
+        await asyncio.gather(loop_task, return_exceptions=True)
+        await client.close()
+        _crash(proc)
+
+
+# 功能：已完成的 run 跨重启仍返回 completed，不会被对账误改
+# 设计：预写 completed 记录后启动 daemon，run.get 返回 completed 而非 unknown/cancelled
+async def test_completed_run_persists_after_restart(
+    free_port: int, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+    store = RunStore(runs_dir)
+    store.start("done-run-1", goal="done")
+    store.finish("done-run-1", status="completed")
+
+    proc = await _spawn_daemon(free_port, runs_dir)
+    client = SocketClient("127.0.0.1", free_port)
+    await client.connect()
+    loop_task = asyncio.create_task(client.run_event_loop())
+    try:
+        result = await client.send_command("run.get", {"run_id": "done-run-1"})
+        assert result.get("status") == "completed", result
+    finally:
+        loop_task.cancel()
+        await asyncio.gather(loop_task, return_exceptions=True)
+        await client.close()
+        _crash(proc)
+
+
+# 功能：真实 agent.run 在崩溃重启后 run.get 仍返回有效状态，而不是 unknown
+# 设计：触发 run 并等到 run.started 落盘，强杀 daemon 后在同一数据目录重启，
+#       断言 run.get 返回 cancelled/completed 之一（绝不会是 unknown）
+async def test_live_run_not_unknown_after_crash_restart(
+    free_port: int, tmp_path: Path
+) -> None:
+    runs_dir = tmp_path / "runs"
+
+    proc = await _spawn_daemon(free_port, runs_dir)
+    client = SocketClient("127.0.0.1", free_port)
+    await client.connect()
+    started = asyncio.Event()
+    run_id_holder: list[str] = []
+
+    async def on_event(event: dict[str, object]) -> None:
+        if event.get("type") == "run.started":
+            run_id_holder.append(str(event.get("run_id", "")))
+            started.set()
+
+    client.on_event(on_event)
+    loop_task = asyncio.create_task(client.run_event_loop())
+    try:
+        await client.send_command("event.subscribe", {"topics": ["run.*"], "scope": "global"})
+        result = await client.send_command("agent.run", {"goal": "crash recovery"})
+        run_id = str(result["run_id"])
+        await asyncio.wait_for(started.wait(), timeout=8.0)
+        assert run_id_holder and run_id_holder[0] == run_id
+    finally:
+        loop_task.cancel()
+        await asyncio.gather(loop_task, return_exceptions=True)
+        await client.close()
+
+    # 崩溃：不优雅退出，直接强杀，模拟运行中断电/被杀
+    _crash(proc)
+
+    # 用同一数据目录重启，run.get 必须从持久化记录恢复，而不是返回 unknown
+    proc2 = await _spawn_daemon(free_port, runs_dir)
+    client2 = SocketClient("127.0.0.1", free_port)
+    await client2.connect()
+    loop2 = asyncio.create_task(client2.run_event_loop())
+    try:
+        result = await client2.send_command("run.get", {"run_id": run_id})
+        assert result.get("status") in {"cancelled", "completed"}, result
+    finally:
+        loop2.cancel()
+        await asyncio.gather(loop2, return_exceptions=True)
+        await client2.close()
+        _crash(proc2)

--- a/tests/unit/test_run_store.py
+++ b/tests/unit/test_run_store.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sztu_code.core.run_store import RunStore
+
+
+# 功能：start 写入 running 记录，get 能按 run_id 读回完整字段
+# 设计：用临时目录构造 RunStore，断言记录字段完整且状态为 running
+def test_start_and_get_roundtrip(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("run-1", goal="fix bug", session_id="sess-1")
+
+    record = store.get("run-1")
+    assert record is not None
+    assert record.run_id == "run-1"
+    assert record.status == "running"
+    assert record.goal == "fix bug"
+    assert record.session_id == "sess-1"
+    assert record.started_at
+
+
+# 功能：finish 把 running 记录推进到终态并持久化
+# 设计：先 start 再 finish，重新实例化 RunStore 后仍能读到终态，验证落盘而非仅内存
+def test_finish_persists_terminal_status(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("run-1")
+    store.finish("run-1", status="completed", reason="success", steps=3)
+
+    reloaded = RunStore(tmp_path).get("run-1")
+    assert reloaded is not None
+    assert reloaded.status == "completed"
+    assert reloaded.reason == "success"
+    assert reloaded.steps == 3
+    assert reloaded.ended_at
+
+
+# 功能：已终态记录不会被再次覆盖，保证一个 run 只有一个最终结果
+# 设计：先 finish 为 completed，再 finish 为 cancelled，断言仍是 completed
+def test_finish_is_idempotent_on_terminal(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("run-1")
+    store.finish("run-1", status="completed")
+
+    store.finish("run-1", status="cancelled", reason="late cancel")
+    record = store.get("run-1")
+    assert record is not None
+    assert record.status == "completed"
+    assert record.reason != "late cancel"
+
+
+# 功能：finish 要求终态，传入非终态状态时报错
+# 设计：直接用 running 调用 finish，断言抛出 ValueError，避免误写入非终态
+def test_finish_rejects_non_terminal_status(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("run-1")
+    try:
+        store.finish("run-1", status="running")
+    except ValueError:
+        return
+    raise AssertionError("finish should reject a non-terminal status")
+
+
+# 功能：get 对不存在的 run_id 返回 None
+def test_get_unknown_returns_none(tmp_path: Path) -> None:
+    assert RunStore(tmp_path).get("missing") is None
+
+
+# 功能：reconcile 把崩溃遗留的 running 记录标记为 cancelled，且不影响已终态记录
+# 设计：预写 running 与 completed 各一条，reconcile 后断言 running→cancelled、completed 不变
+def test_reconcile_marks_interrupted_runs_cancelled(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("running-1", goal="g")
+    store.start("running-2", goal="g")
+    store.finish("running-2", status="completed")
+
+    changed = store.reconcile()
+    assert {record.run_id for record in changed} == {"running-1"}
+
+    assert store.get("running-1").status == "cancelled"  # type: ignore[union-attr]
+    assert store.get("running-1").reason == "daemon_restarted"  # type: ignore[union-attr]
+    assert store.get("running-2").status == "completed"  # type: ignore[union-attr]
+
+
+# 功能：list_running 只返回仍处于 running 状态的记录
+def test_list_running_filters_by_status(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("a")
+    store.start("b")
+    store.finish("b", status="cancelled")
+
+    assert {record.run_id for record in store.list_running()} == {"a"}
+
+
+# 功能：记录文件损坏时 get 返回 None 而不抛异常
+# 设计：直接写非法 JSON 到记录路径，get 应优雅降级
+def test_get_tolerates_corrupt_record(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    path = store.record_path("bad")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not valid json", encoding="utf-8")
+
+    assert store.get("bad") is None
+
+
+# 功能：运行记录以 JSON 形式落盘，关键字段与内存一致
+# 设计：读取 run.json 原始内容，断言 status/run_id/goal 等字段
+def test_record_file_is_json(tmp_path: Path) -> None:
+    store = RunStore(tmp_path)
+    store.start("run-json", goal="hello")
+
+    data = json.loads(store.record_path("run-json").read_text(encoding="utf-8"))
+    assert data["run_id"] == "run-json"
+    assert data["status"] == "running"
+    assert data["goal"] == "hello"


### PR DESCRIPTION
## Summary

实现 #92「让任务在断线或重启后还能接着做」的第一阶段——统一任务记录（RunStore），核心解决「daemon 重启后 `run.get` 返回 `unknown`」的问题。

## Behavior

- 新增 `RunStore`，把每个 run 的 `run_id`、`session_id`、`status`、`goal`、起止时间与最终结果按 `~/.sztu/runs/<run_id>/run.json` 持久化（可用 `SZTU_RUNS_DIR` 覆盖，便于测试隔离）。
- `agent.run` / `session.send_message` 在返回 `run_id` 前先写入 `running` 记录；run 结束后写入 `completed` 或 `cancelled`，终态不可被再次覆盖（一个 run 只有一个最终结果）。
- `run.get` 优先读取内存中的活动状态，daemon 重启后回退到磁盘 RunStore，不再返回 `unknown`。
- daemon 启动时对账：把上次崩溃遗留的 `running` 记录标记为 `cancelled`（`reason=daemon_restarted`），使界面显示状态与磁盘记录一致。

## Behavior 补充：非目标

- 不覆盖子 Agent / 工作流子 run（属 #73 与 #92 后续阶段）。
- 不新增事件顺序号、排队/转向/中断/恢复命令（属后续阶段）。

## Validation

在 WSL（Ubuntu-24.04）中运行：

```text
.venv/bin/python -m pytest tests/unit/test_run_store.py -v        # 9 passed
.venv/bin/python -m pytest tests/integration/test_run_restart.py -v  # 3 passed
.venv/bin/ruff check src tests scripts                            # All checks passed
.venv/bin/mypy src                                                # Success: 183 source files
.venv/bin/python scripts/gen_protocol_doc.py --check              # up to date
```

## Risk

- 未改变协议、配置或数据格式，仅新增 `run.json` 记录文件，不影响现有客户端。
- 多 daemon 实例共享 `~/.sztu/runs` 时，后启动实例会把先启动实例的 `running` 记录对账为 `cancelled`；当前 daemon 通过端口探测避免同端口冲突，不同端口并跑属边界场景。
- 本 PR 只覆盖顶层 `agent.run` 与 `session.send_message`，子 run 持久化留待后续。

## UI evidence

N/A

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`（无协议变化，`--check` 通过）。
- [x] 用户文档、配置示例和迁移说明已同步（无用户配置变化）。
- [x] 提交包含 `Signed-off-by`（DCO）。
