### PR TITLE
fix(tools): make retries explicitly safe

### DIFF
--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -5770,6 +5770,11 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
 | `error_message` | `string` | yes |
 | `elapsed_ms` | `integer` | yes |
 | `attempt` | `integer` | no |
+| `retry_decision` | `string` | no |
+| `retry_reason` | `string` | no |
+| `retry_delay_ms` | `integer` | no |
+| `tool_retry_safe` | `boolean` | no |
+| `execution_state` | `string` | no |
 | `batch_id` | `string` | no |
 | `scheduler_mode` | `string` | no |
 | `queue_ms` | `integer` | no |
@@ -5815,6 +5820,35 @@ Events written to `runs/<run_id>/events.jsonl` and forwarded over IPC to subscri
       "default": 1,
       "title": "Attempt",
       "type": "integer"
+    },
+    "retry_decision": {
+      "default": "stop",
+      "enum": [
+        "retry",
+        "stop"
+      ],
+      "title": "Retry Decision",
+      "type": "string"
+    },
+    "retry_reason": {
+      "default": "",
+      "title": "Retry Reason",
+      "type": "string"
+    },
+    "retry_delay_ms": {
+      "default": 0,
+      "title": "Retry Delay Ms",
+      "type": "integer"
+    },
+    "tool_retry_safe": {
+      "default": false,
+      "title": "Tool Retry Safe",
+      "type": "boolean"
+    },
+    "execution_state": {
+      "default": "completed",
+      "title": "Execution State",
+      "type": "string"
     },
     "batch_id": {
       "default": "",

--- a/src/sztu_code/core/bus/events.py
+++ b/src/sztu_code/core/bus/events.py
@@ -94,6 +94,11 @@ class ToolCallFailedEvent(BaseModel):
     error_message: str
     elapsed_ms: int
     attempt: int = 1  # 1=first attempt, 2=first retry, 3=second retry
+    retry_decision: Literal["retry", "stop"] = "stop"
+    retry_reason: str = ""
+    retry_delay_ms: int = 0
+    tool_retry_safe: bool = False
+    execution_state: str = "completed"
     batch_id: str = ""
     scheduler_mode: ToolSchedulerMode = "serial"
     queue_ms: int = 0

--- a/src/sztu_code/core/tools/base.py
+++ b/src/sztu_code/core/tools/base.py
@@ -14,9 +14,18 @@ _PERMISSION_GRANT_TOKEN = object()
 
 class ToolPermission(StrEnum):
     """工具权限级别，与 PermissionMode 对应"""
-    READ_ONLY = "read_only"            # 只读：read_file, list_dir 等
+
+    READ_ONLY = "read_only"  # 只读：read_file, list_dir 等
     WORKSPACE_WRITE = "workspace_write"  # 工作区内写入：write_file, note_save
     DANGER_FULL_ACCESS = "danger_full_access"  # 高风险：bash, 外部路径操作
+
+
+class ToolExecutionState(StrEnum):
+    """工具失败时，对本次执行状态的判断。"""
+
+    NOT_STARTED = "not_started"
+    COMPLETED = "completed"
+    UNKNOWN = "unknown"
 
 
 @dataclass
@@ -27,6 +36,10 @@ class ToolResult:
     error_type: str | None = None
     # 供内部组合工具读取的结构化执行元数据，不直接展示给模型
     metadata: dict[str, object] = field(default_factory=dict)
+    # 仅由工具实现者为已知的短暂失败显式标记；不能从 runtime_error 文本推断。
+    retryable: bool = False
+    # 超时等无法判断操作是否已生效的情况必须标记为 UNKNOWN。
+    execution_state: ToolExecutionState = ToolExecutionState.COMPLETED
 
 
 class BaseTool(ABC):
@@ -40,12 +53,18 @@ class BaseTool(ABC):
     is_interactive: bool = False
     # 用户交互等待由 run 取消控制，不受普通工具执行超时限制
     allows_indefinite_wait: bool = False
+    # 工具实现者显式确认重复执行安全时才可设为 True；默认绝不重试。
+    retry_safe: bool = False
     # 工具名称别名列表（如 "read" → "read_file"）
     aliases: ClassVar[list[str]] = []
 
     # 执行工具调用，返回结果或错误
     @abstractmethod
     async def invoke(self, params: dict[str, object]) -> ToolResult: ...
+
+    def is_retry_safe(self, params: dict[str, object]) -> bool:
+        """判断当前调用是否可安全重复执行；子类可根据参数覆盖。"""
+        return self.retry_safe
 
     # 动态权限分级：根据输入参数返回实际所需权限级别（子类可覆盖）
     def classify_permission(self, params: dict[str, object]) -> ToolPermission:

--- a/src/sztu_code/core/tools/invocation.py
+++ b/src/sztu_code/core/tools/invocation.py
@@ -22,6 +22,7 @@ from sztu_code.core.llm.types import ToolCallBlock
 from sztu_code.core.tools.base import (
     _PERMISSION_GRANT_KEY,
     _PERMISSION_GRANT_TOKEN,
+    ToolExecutionState,
     ToolPermission,
     ToolResult,
 )
@@ -34,12 +35,50 @@ if TYPE_CHECKING:
 _DEFAULT_TIMEOUT: float = 120.0
 _MAX_RETRIES: int = 2
 _RETRY_BASE_S: float = 2.0  # backoff base; tests can monkeypatch to 0
-# 可重试错误：瞬时失败（超时/限流/偶发运行时错误）值得再试，其余直接失败
-_RETRYABLE: frozenset[str] = frozenset({"runtime_error", "rate_limited", "timeout"})
+_RETRYABLE: frozenset[str] = frozenset({"rate_limited"})
 
 
 def _now() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _retry_reason(
+    error_class: str,
+    retryable: bool,
+    execution_state: ToolExecutionState,
+    tool_retry_safe: bool,
+    attempt: int,
+) -> str:
+    if execution_state == ToolExecutionState.UNKNOWN:
+        return "execution_state_is_unknown"
+    if error_class not in _RETRYABLE:
+        return "error_is_not_explicitly_transient"
+    if not retryable:
+        return "failure_is_not_explicitly_retryable"
+    if not tool_retry_safe:
+        return "tool_is_not_declared_retry_safe"
+    if attempt > _MAX_RETRIES:
+        return "retry_limit_exhausted"
+    return "explicit_transient_failure_on_retry_safe_tool"
+
+
+def _retry_explanation(reason: str) -> str:
+    explanations = {
+        "execution_state_is_unknown": (
+            "Automatic retry was skipped because the operation may still be running."
+        ),
+        "error_is_not_explicitly_transient": (
+            "Automatic retry was skipped because the failure was not explicitly transient."
+        ),
+        "failure_is_not_explicitly_retryable": (
+            "Automatic retry was skipped because the failure was not marked retryable."
+        ),
+        "tool_is_not_declared_retry_safe": (
+            "Automatic retry was skipped because the tool did not declare this call safe to retry."
+        ),
+        "retry_limit_exhausted": "Automatic retry stopped because the retry limit was exhausted.",
+    }
+    return explanations.get(reason, "")
 
 
 # 判断 bash 调用是否为可汇总的常见测试命令
@@ -96,7 +135,19 @@ async def _fail(
     queue_ms: int = 0,
     queued_at: str = "",
     started_at: str = "",
+    retryable: bool = False,
+    execution_state: ToolExecutionState = ToolExecutionState.COMPLETED,
+    retry_reason: str = "",
+    tool_retry_safe: bool = False,
 ) -> ToolResult:
+    if not retry_reason:
+        retry_reason = _retry_reason(
+            error_class,
+            retryable,
+            execution_state,
+            tool_retry_safe,
+            attempt,
+        )
     finished_at = _now()
     await bus.publish(
         ToolCallFailedEvent(
@@ -107,6 +158,9 @@ async def _fail(
             error_message=error_message,
             elapsed_ms=elapsed_ms,
             attempt=attempt,
+            retry_reason=retry_reason,
+            tool_retry_safe=tool_retry_safe,
+            execution_state=execution_state.value,
             batch_id=batch_id,
             scheduler_mode=scheduler_mode,
             queue_ms=queue_ms,
@@ -117,7 +171,21 @@ async def _fail(
         )
     )
     await _publish_test_result(bus, run_id, tool_call, "failed", error_message)
-    return ToolResult(content=error_message, is_error=True, error_type=error_class)
+    explanation = _retry_explanation(retry_reason)
+    result_content = f"{error_message}\n{explanation}" if explanation else error_message
+    return ToolResult(
+        content=result_content,
+        is_error=True,
+        error_type=error_class,
+        metadata={
+            "retry_decision": "stop",
+            "retry_reason": retry_reason,
+            "tool_retry_safe": tool_retry_safe,
+            "execution_state": execution_state.value,
+        },
+        retryable=retryable,
+        execution_state=execution_state,
+    )
 
 
 # 校验参数、检查权限、限时调用工具、发布进度事件，失败时指数退避重试，返回 ToolResult（不抛异常）
@@ -138,11 +206,7 @@ async def invoke_tool(
 ) -> ToolResult:
     t0 = time.monotonic()
     started_at = _now()
-    queue_ms = (
-        max(0, int((t0 - queued_monotonic) * 1000))
-        if queued_monotonic is not None
-        else 0
-    )
+    queue_ms = max(0, int((t0 - queued_monotonic) * 1000)) if queued_monotonic is not None else 0
     tool_call.input = registry.enrich_tool_input(tool_call.name, tool_call.input)
     runtime_params = dict(tool_call.input)
     runtime_params.pop("description", None)
@@ -174,8 +238,12 @@ async def invoke_tool(
     tool = registry.get(tool_call.name)
     if tool is None:
         return await _fail(
-            bus, run_id, tool_call,
-            "runtime_error", f"unknown tool: {tool_call.name}", elapsed(),
+            bus,
+            run_id,
+            tool_call,
+            "runtime_error",
+            f"unknown tool: {tool_call.name}",
+            elapsed(),
             batch_id=batch_id,
             scheduler_mode=scheduler_mode,
             queue_ms=queue_ms,
@@ -188,8 +256,12 @@ async def invoke_tool(
             tool.params_model.model_validate(runtime_params)
         except ValidationError as exc:
             return await _fail(
-                bus, run_id, tool_call,
-                "schema_error", str(exc), elapsed(),
+                bus,
+                run_id,
+                tool_call,
+                "schema_error",
+                str(exc),
+                elapsed(),
                 batch_id=batch_id,
                 scheduler_mode=scheduler_mode,
                 queue_ms=queue_ms,
@@ -220,8 +292,12 @@ async def invoke_tool(
             raise
         except Exception as exc:
             return await _fail(
-                bus, run_id, tool_call,
-                "runtime_error", str(exc), elapsed(),
+                bus,
+                run_id,
+                tool_call,
+                "runtime_error",
+                str(exc),
+                elapsed(),
                 batch_id=batch_id,
                 scheduler_mode=scheduler_mode,
                 queue_ms=queue_ms,
@@ -252,7 +328,9 @@ async def invoke_tool(
                     )
                 )
             return await _fail(
-                bus, run_id, tool_call,
+                bus,
+                run_id,
+                tool_call,
                 "permission_denied",
                 "Permission denied by user. You may not execute this command. "
                 "Try an alternative approach or ask the user what to do.",
@@ -264,9 +342,13 @@ async def invoke_tool(
                 started_at=started_at,
             )
 
+    tool_retry_safe = tool.is_retry_safe(runtime_params)
+
     for attempt in range(1, _MAX_RETRIES + 2):
         error_class: str | None = None
         error_message: str | None = None
+        retryable = False
+        execution_state = ToolExecutionState.COMPLETED
 
         try:
             if tool.allows_indefinite_wait:
@@ -280,6 +362,8 @@ async def invoke_tool(
             if result.is_error:
                 error_class = result.error_type or "runtime_error"
                 error_message = result.content
+                retryable = result.retryable
+                execution_state = result.execution_state
             else:
                 finished_at = _now()
                 await bus.publish(
@@ -304,8 +388,11 @@ async def invoke_tool(
         except RateLimitedError as exc:
             error_class = "rate_limited"
             error_message = str(exc)
+            retryable = True
+            execution_state = ToolExecutionState.NOT_STARTED
         except TimeoutError:
             error_class = "timeout"
+            execution_state = ToolExecutionState.UNKNOWN
             error_message = (
                 f"tool timed out after {timeout}s; the operation may still be running. "
                 "Retry the call, increase the timeout, or break it into smaller steps."
@@ -317,8 +404,16 @@ async def invoke_tool(
         assert error_class is not None and error_message is not None
         ms = elapsed()
 
-        if error_class in _RETRYABLE and attempt <= _MAX_RETRIES:
+        should_retry = (
+            error_class in _RETRYABLE
+            and retryable
+            and execution_state != ToolExecutionState.UNKNOWN
+            and tool_retry_safe
+            and attempt <= _MAX_RETRIES
+        )
+        if should_retry:
             failed_at = _now()
+            retry_delay_s = _RETRY_BASE_S * (2 ** (attempt - 1))
             await bus.publish(
                 ToolCallFailedEvent(
                     run_id=run_id,
@@ -328,6 +423,17 @@ async def invoke_tool(
                     error_message=error_message,
                     elapsed_ms=ms,
                     attempt=attempt,
+                    retry_decision="retry",
+                    retry_reason=_retry_reason(
+                        error_class,
+                        retryable,
+                        execution_state,
+                        tool_retry_safe,
+                        attempt,
+                    ),
+                    retry_delay_ms=int(retry_delay_s * 1000),
+                    tool_retry_safe=tool_retry_safe,
+                    execution_state=execution_state.value,
                     batch_id=batch_id,
                     scheduler_mode=scheduler_mode,
                     queue_ms=queue_ms,
@@ -337,18 +443,32 @@ async def invoke_tool(
                     ts=failed_at,
                 )
             )
-            await asyncio.sleep(_RETRY_BASE_S * (2 ** (attempt - 1)))
+            await asyncio.sleep(retry_delay_s)
             continue
 
         return await _fail(
-            bus, run_id, tool_call,
-            error_class, error_message, ms,
+            bus,
+            run_id,
+            tool_call,
+            error_class,
+            error_message,
+            ms,
             attempt=attempt,
             batch_id=batch_id,
             scheduler_mode=scheduler_mode,
             queue_ms=queue_ms,
             queued_at=queued_at,
             started_at=started_at,
+            retryable=retryable,
+            execution_state=execution_state,
+            retry_reason=_retry_reason(
+                error_class,
+                retryable,
+                execution_state,
+                tool_retry_safe,
+                attempt,
+            ),
+            tool_retry_safe=tool_retry_safe,
         )
 
     # unreachable, but keeps mypy happy

--- a/tests/unit/test_tool_retry.py
+++ b/tests/unit/test_tool_retry.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 import sztu_code.core.tools.invocation as inv_mod
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import ToolCallBlock
-from sztu_code.core.tools.base import BaseTool, ToolResult
+from sztu_code.core.tools.base import (
+    BaseTool,
+    ToolExecutionState,
+    ToolPermission,
+    ToolResult,
+)
 from sztu_code.core.tools.errors import RateLimitedError
 from sztu_code.core.tools.invocation import invoke_tool
 from sztu_code.core.tools.registry import ToolRegistry
 
 # --- stub tools --------------------------------------------------------------
 
+
 class _FailNTimes(BaseTool):
-    """Fails with runtime_error for the first n calls, then succeeds."""
+    """前 n 次返回普通 runtime_error，之后成功。"""
+
     name = "fail_n"
     description = "Fails n times then succeeds"
     input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
@@ -21,8 +30,10 @@ class _FailNTimes(BaseTool):
     def __init__(self, n: int, *, error_type: str = "runtime_error") -> None:
         self._remaining = n
         self._error_type = error_type
+        self.calls = 0
 
     async def invoke(self, params: dict[str, object]) -> ToolResult:
+        self.calls += 1
         if self._remaining > 0:
             self._remaining -= 1
             return ToolResult(content="transient error", is_error=True, error_type=self._error_type)
@@ -30,18 +41,57 @@ class _FailNTimes(BaseTool):
 
 
 class _RateLimitedNTimes(BaseTool):
-    """Raises RateLimitedError for the first n calls, then succeeds."""
+    """前 n 次抛出明确的限流错误，之后成功。"""
+
     name = "rate_n"
     description = "Rate-limits n times then succeeds"
     input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
+    required_permission = ToolPermission.READ_ONLY
 
-    def __init__(self, n: int) -> None:
+    def __init__(self, n: int, *, retry_safe: bool = False) -> None:
         self._remaining = n
+        self.retry_safe = retry_safe
+        self.calls = 0
 
     async def invoke(self, params: dict[str, object]) -> ToolResult:
+        self.calls += 1
         if self._remaining > 0:
             self._remaining -= 1
             raise RateLimitedError("429 Too Many Requests")
+        return ToolResult(content="ok")
+
+
+class _WriteRateLimitedTool(_RateLimitedNTimes):
+    """写工具默认不声明安全重试。"""
+
+    name = "write_rate_limited"
+    required_permission = ToolPermission.WORKSPACE_WRITE
+
+
+class _RetryableResultNTimes(BaseTool):
+    """前 n 次返回显式可重试结果，之后成功。"""
+
+    name = "retryable_result_n"
+    description = "Returns retryable results n times then succeeds"
+    input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
+    required_permission = ToolPermission.READ_ONLY
+    retry_safe = True
+
+    def __init__(self, n: int) -> None:
+        self._remaining = n
+        self.calls = 0
+
+    async def invoke(self, params: dict[str, object]) -> ToolResult:
+        self.calls += 1
+        if self._remaining > 0:
+            self._remaining -= 1
+            return ToolResult(
+                content="temporary service failure",
+                is_error=True,
+                error_type="rate_limited",
+                retryable=True,
+                execution_state=ToolExecutionState.NOT_STARTED,
+            )
         return ToolResult(content="ok")
 
 
@@ -59,122 +109,224 @@ class _AlwaysFails(BaseTool):
 
 # --- helper ------------------------------------------------------------------
 
+
 def _call(name: str) -> ToolCallBlock:
     return ToolCallBlock(id="t1", name=name, input={})
 
 
-async def _run(tool: BaseTool, *, monkeypatch: pytest.MonkeyPatch) -> tuple[ToolResult, list]:
-    monkeypatch.setattr(inv_mod, "_RETRY_BASE_S", 0.0)
+async def _run(
+    tool: BaseTool,
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    retry_base_s: float = 0.0,
+) -> tuple[ToolResult, list]:
+    monkeypatch.setattr(inv_mod, "_RETRY_BASE_S", retry_base_s)
     registry = ToolRegistry()
     registry.register(tool)
     bus = EventBus()
     events: list = []
 
-    async def _collect(e: object) -> None:
-        events.append(e)
+    async def _collect(event: object) -> None:
+        events.append(event)
 
     bus.subscribe(_collect)
     result = await invoke_tool(registry, _call(tool.name), bus, run_id="r")
     return result, events
 
 
+def _failed_events(events: list) -> list:
+    return [event for event in events if event.type == "tool.call_failed"]  # type: ignore[attr-defined]
+
+
 # --- tests -------------------------------------------------------------------
 
 
-# 功能：验证 runtime_error 在首次失败后自动重试，最多 2 次，第 2 次成功时返回 ok
-# 设计：_FailNTimes(1) 第一次返回 runtime_error，第二次成功；monkeypatch 消除 sleep 延迟
-async def test_runtime_error_retries_and_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    result, events = await _run(_FailNTimes(1), monkeypatch=monkeypatch)
-    assert not result.is_error
-    assert result.content == "ok"
-    failed_events = [e for e in events if e.type == "tool.call_failed"]  # type: ignore[attr-defined]
-    assert len(failed_events) == 1
-    assert failed_events[0].attempt == 1  # type: ignore[attr-defined]
+# 功能：普通 runtime_error 默认不重试
+# 设计：第一次失败后工具本可在第二次成功；以调用次数证明没有发生第二次执行
+async def test_runtime_error_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _FailNTimes(1)
 
+    result, events = await _run(tool, monkeypatch=monkeypatch)
 
-# 功能：验证 rate_limited 异常触发重试，重试成功后返回正常结果
-# 设计：_RateLimitedNTimes(1) 抛 RateLimitedError 一次，第二次成功；检查 error_class 字段
-async def test_rate_limited_retries_and_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    result, events = await _run(_RateLimitedNTimes(1), monkeypatch=monkeypatch)
-    assert not result.is_error
-    failed_events = [e for e in events if e.type == "tool.call_failed"]  # type: ignore[attr-defined]
-    assert len(failed_events) == 1
-    assert failed_events[0].error_class == "rate_limited"  # type: ignore[attr-defined]
-
-
-# 功能：验证 runtime_error 超过 2 次重试后最终返回失败，attempt 字段递增
-# 设计：_AlwaysFails 三次都失败；断言最终结果 is_error + 收到 3 个 failed 事件，attempt 为 1/2/3
-async def test_runtime_error_exhausts_retries(monkeypatch: pytest.MonkeyPatch) -> None:
-    result, events = await _run(_AlwaysFails("runtime_error"), monkeypatch=monkeypatch)
     assert result.is_error
     assert result.error_type == "runtime_error"
-    failed_events = [e for e in events if e.type == "tool.call_failed"]  # type: ignore[attr-defined]
-    assert len(failed_events) == 3
-    attempts = [e.attempt for e in failed_events]  # type: ignore[attr-defined]
-    assert attempts == [1, 2, 3]
+    assert tool.calls == 1
+    assert result.metadata["retry_decision"] == "stop"
+    assert result.metadata["retry_reason"] == "error_is_not_explicitly_transient"
+    assert "not explicitly transient" in result.content
+    assert len(_failed_events(events)) == 1
 
 
-# 功能：验证 rate_limited 耗尽重试后最终返回失败，error_class 为 rate_limited
-# 设计：_RateLimitedNTimes(10) 始终抛异常，断言 3 个 failed 事件且 error_class 统一
-async def test_rate_limited_exhausts_retries(monkeypatch: pytest.MonkeyPatch) -> None:
-    result, events = await _run(_RateLimitedNTimes(10), monkeypatch=monkeypatch)
+# 功能：显式声明可安全重试的只读工具，在限流时重试
+# 设计：第一次抛出 RateLimitedError、第二次成功，并断言实际执行两次
+async def test_safe_read_only_rate_limit_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _RateLimitedNTimes(1, retry_safe=True)
+
+    result, events = await _run(tool, monkeypatch=monkeypatch)
+
+    assert not result.is_error
+    assert result.content == "ok"
+    assert tool.calls == 2
+    failed_events = _failed_events(events)
+    assert len(failed_events) == 1
+    assert failed_events[0].error_class == "rate_limited"
+    assert failed_events[0].attempt == 1
+    assert failed_events[0].retry_decision == "retry"
+    assert failed_events[0].retry_reason == "explicit_transient_failure_on_retry_safe_tool"
+    assert failed_events[0].retry_delay_ms == 0
+    assert failed_events[0].tool_retry_safe
+    assert failed_events[0].execution_state == ToolExecutionState.NOT_STARTED.value
+
+
+# 功能：ToolResult 可通过显式元数据声明瞬时失败
+# 设计：返回 retryable=True 与 NOT_STARTED，验证调用按同一安全策略重试
+async def test_explicit_retryable_result_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _RetryableResultNTimes(1)
+
+    result, events = await _run(tool, monkeypatch=monkeypatch)
+
+    assert not result.is_error
+    assert tool.calls == 2
+    assert _failed_events(events)[0].retry_decision == "retry"
+
+
+# 功能：安全重试继续使用 2 秒、4 秒指数退避
+# 设计：记录 sleep 参数和事件中的毫秒值，不进行真实等待
+async def test_safe_retry_uses_exponential_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    delays: list[float] = []
+
+    async def _record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(inv_mod.asyncio, "sleep", _record_sleep)
+    tool = _RateLimitedNTimes(2, retry_safe=True)
+
+    result, events = await _run(tool, monkeypatch=monkeypatch, retry_base_s=2.0)
+
+    assert not result.is_error
+    assert delays == [2.0, 4.0]
+    assert [event.retry_delay_ms for event in _failed_events(events)] == [2000, 4000]
+
+
+# 功能：默认写工具即使限流也不重试
+# 设计：写工具未显式声明 retry_safe；限流后检查只执行一次
+async def test_write_tool_rate_limit_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _WriteRateLimitedTool(1)
+
+    result, events = await _run(tool, monkeypatch=monkeypatch)
+
     assert result.is_error
     assert result.error_type == "rate_limited"
-    failed_events = [e for e in events if e.type == "tool.call_failed"]  # type: ignore[attr-defined]
-    assert len(failed_events) == 3
-    assert all(e.error_class == "rate_limited" for e in failed_events)  # type: ignore[attr-defined]
+    assert tool.calls == 1
+    failed_events = _failed_events(events)
+    assert len(failed_events) == 1
+    assert failed_events[0].retry_decision == "stop"
+    assert failed_events[0].retry_reason == "tool_is_not_declared_retry_safe"
+    assert "did not declare this call safe to retry" in result.content
 
 
-# 功能：验证 schema_error 不触发重试，直接失败
-# 设计：_AlwaysFails("schema_error") 首次即 schema 错误，断言只发一次 failed 事件且 attempt=1
+# 功能：写工具显式声明当前调用安全时允许重试
+# 设计：写工具设置 retry_safe，限流后第二次调用成功
+async def test_explicitly_safe_write_tool_rate_limit_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = _WriteRateLimitedTool(1, retry_safe=True)
+
+    result, events = await _run(tool, monkeypatch=monkeypatch)
+
+    assert not result.is_error
+    assert result.content == "ok"
+    assert tool.calls == 2
+    assert _failed_events(events)[0].retry_decision == "retry"
+
+
+# 功能：可安全重试的限流工具仍保留最大重试次数
+# 设计：持续限流，断言初始调用加两次重试后停止
+async def test_safe_rate_limit_exhausts_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    tool = _RateLimitedNTimes(10, retry_safe=True)
+
+    result, events = await _run(tool, monkeypatch=monkeypatch)
+
+    assert result.is_error
+    assert result.error_type == "rate_limited"
+    assert tool.calls == inv_mod._MAX_RETRIES + 1
+    failed_events = _failed_events(events)
+    assert len(failed_events) == inv_mod._MAX_RETRIES + 1
+    assert [event.attempt for event in failed_events] == [1, 2, 3]
+    assert failed_events[-1].retry_decision == "stop"
+    assert failed_events[-1].retry_reason == "retry_limit_exhausted"
+
+
+# 功能：schema_error 不触发重试
+# 设计：直接返回 schema 错误，检查只产生一次失败事件
 async def test_schema_error_no_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     result, events = await _run(_AlwaysFails("schema_error"), monkeypatch=monkeypatch)
+
     assert result.is_error
     assert result.error_type == "schema_error"
-    failed_events = [e for e in events if e.type == "tool.call_failed"]  # type: ignore[attr-defined]
+    failed_events = _failed_events(events)
     assert len(failed_events) == 1
-    assert failed_events[0].attempt == 1  # type: ignore[attr-defined]
+    assert failed_events[0].retry_decision == "stop"
+    assert failed_events[0].retry_reason == "error_is_not_explicitly_transient"
 
 
-# 功能：验证 timeout 触发重试（瞬时超时值得再试）
-# 设计：SlowTool 配合极短超时，断言每次超时都重试并发出 failed 事件，最终失败
-async def test_timeout_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
-    import asyncio
-
+# 功能：timeout 的未知执行状态不触发第二次执行
+# 设计：短超时中断慢工具；断言调用一次且结果显式标记 UNKNOWN
+async def test_timeout_with_unknown_execution_state_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _SlowTool(BaseTool):
         name = "slow"
-        description = "sleeps"
+        description = "Sleeps"
         input_schema: dict[str, object] = {"type": "object", "properties": {}, "required": []}
+        retry_safe = True
+
+        def __init__(self) -> None:
+            self.calls = 0
 
         async def invoke(self, params: dict[str, object]) -> ToolResult:
+            self.calls += 1
             await asyncio.sleep(60)
             return ToolResult(content="done")
 
+    tool = _SlowTool()
     monkeypatch.setattr(inv_mod, "_RETRY_BASE_S", 0.0)
     registry = ToolRegistry()
-    registry.register(_SlowTool())
+    registry.register(tool)
     bus = EventBus()
     events: list = []
 
-    async def _collect(e: object) -> None:
-        events.append(e)
+    async def _collect(event: object) -> None:
+        events.append(event)
 
     bus.subscribe(_collect)
+
     result = await invoke_tool(registry, _call("slow"), bus, run_id="r", timeout=0.05)
 
     assert result.is_error
     assert result.error_type == "timeout"
-    failed_events = [e for e in events if e.type == "tool.call_failed"]  # type: ignore[attr-defined]
-    # 初始 1 次 + _MAX_RETRIES 次重试，每次都超时并发出 failed 事件
-    assert len(failed_events) == inv_mod._MAX_RETRIES + 1
+    assert result.execution_state == ToolExecutionState.UNKNOWN
+    assert tool.calls == 1
+    failed_events = _failed_events(events)
+    assert len(failed_events) == 1
+    assert failed_events[0].retry_decision == "stop"
+    assert failed_events[0].retry_reason == "execution_state_is_unknown"
+    assert failed_events[0].execution_state == ToolExecutionState.UNKNOWN.value
+    assert "operation may still be running" in result.content
 
 
-# 功能：验证成功后的 tool.call_failed 事件中 error_class 字段存在且取值合法
-# 设计：_FailNTimes(2) 两次失败后成功，检查所有 failed 事件的 error_class 均在合法枚举内
+# 功能：失败事件的 error_class 保持在约定枚举内
+# 设计：运行一次普通错误并检查事件字段
 async def test_failed_event_has_valid_error_class(monkeypatch: pytest.MonkeyPatch) -> None:
-    valid_classes = {"runtime_error", "timeout", "schema_error", "permission_denied", "rate_limited"}
-    result, events = await _run(_FailNTimes(2), monkeypatch=monkeypatch)
-    assert not result.is_error
-    for e in events:
-        if e.type == "tool.call_failed":  # type: ignore[attr-defined]
-            assert e.error_class in valid_classes  # type: ignore[attr-defined]
+    valid_classes = {
+        "runtime_error",
+        "timeout",
+        "schema_error",
+        "permission_denied",
+        "rate_limited",
+    }
+
+    _, events = await _run(_FailNTimes(1), monkeypatch=monkeypatch)
+
+    for event in _failed_events(events):
+        assert event.error_class in valid_classes


### PR DESCRIPTION
## Summary

Fixes #71

- 收紧工具重试策略，避免普通失败、写操作和未知执行状态的超时被自动重复执行。
- 为 `ToolResult` 增加显式的可重试标记和执行状态。
- 新增工具级安全重试声明，支持工具根据本次调用参数判断是否可安全重试。
- 为失败事件补充重试决定、原因、退避时长、工具安全判断和执行状态。
- 重新生成 `docs/reference/wire-protocol.md`。

## Behavior

工具调用只有同时满足以下条件时才自动重试：

- 失败属于明确的瞬时错误（当前为 `rate_limited`）；
- 异常类型或 `ToolResult` 显式表明失败可重试；
- 执行状态不是 `unknown`；
- 工具显式声明本次调用可安全重复执行；
- 尚未超过最大重试次数。

普通 `runtime_error` 默认只执行一次，不再根据宽泛错误字符串自动重试。

超时会返回 `execution_state=unknown`，不会自动发起第二次执行；返回结果会提示 Agent 先确认操作是否仍在运行。

写工具和危险工具默认不重试；只有工具显式确认本次调用安全时才允许重试。工具可以覆盖 `is_retry_safe(params)`，根据参数判断本次调用是否幂等或可安全重复执行。

保留原有最大重试次数和指数退避配置，默认退避仍为 2 秒、4 秒。

`ToolCallFailedEvent` 新增：

- `retry_decision`
- `retry_reason`
- `retry_delay_ms`
- `tool_retry_safe`
- `execution_state`

## Validation

已实际执行并通过：

```text
uv run pytest tests/unit/test_tool_retry.py -q
# 10 passed

uv run pytest tests/unit/test_invocation.py -q
# 8 passed

uv run ruff check src/sztu_code/core/tools/base.py src/sztu_code/core/tools/invocation.py src/sztu_code/core/bus/events.py tests/unit/test_tool_retry.py
# All checks passed!

uv run python scripts/gen_protocol_doc.py --check
# OK: docs/reference/wire-protocol.md is up to date
```

测试覆盖：

- 普通 `runtime_error` 只调用一次；
- 安全只读工具的限流重试；
- `ToolResult.retryable=True` 的显式元数据路径；
- 2 秒、4 秒指数退避；
- 写工具默认不重试；
- 显式安全的写工具允许重试；
- 达到最大重试次数后停止；
- `schema_error` 不重试；
- 超时且执行状态未知时不重试；
- 失败事件中的重试决定和最终停止原因。

### Full-suite notes

尝试运行完整单元测试：

```text
uv run pytest tests/unit -v
```

中断前为 `569 passed, 4 failed`。测试在以下异步取消/压缩测试处长时间无进展，随后手动中断：

```text
tests/unit/test_runner.py::test_cancelled_run_cancels_pending_compaction
```

已在提交前基线版本中复现同一问题，说明该卡住问题早于本 PR，涉及 Runner、异步上下文压缩与取消清理路径；本 PR 未修改这些模块。

4 个失败均为本机 WSL 环境缺少 `/bin/bash`：

```text
execvpe(/bin/bash) failed: No such file or directory
```

完整 Ruff 检查：

```text
uv run ruff check src tests scripts
```

在最新 `upstream/main` 上未通过，报错均不属于本 PR 改动范围：

- `src/sztu_code/core/session/store.py:136`：E501
- `src/sztu_code/core/workspace/manager.py:352`：E501
- `src/sztu_code/core/workspace/manager.py:469`：E501
- `tests/unit/test_workspace_manager.py`：I001

已确认这些问题在 `upstream/main` 中已存在。为保持 Issue #71 范围，本 PR 未混入无关格式修复。

## Risk

风险较低，但默认行为会更保守：

- 未显式声明安全的工具不再自动重试。
- 写工具和危险工具不会仅根据错误字符串被重复执行。
- 超时且执行状态未知时，Agent 需要先确认实际状态。
- 新增的失败事件字段均提供默认值，保持旧事件消费者兼容。
- 不涉及数据迁移、配置迁移或 UI 改动。

## UI evidence

N/A：本次没有 TUI 或桌面端 UI 改动。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`。
- [x] 用户文档、配置示例和迁移说明已同步。
- [x] 提交包含 `Signed-off-by`（DCO）。