### PR TITLE
fix(core): 初始化 AgentLoop._steering_queue 并为 BaseTool 增加 retry_safe 默认值

### DIFF
--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -180,6 +180,8 @@ class AgentLoop:
         wrap_up_on_max_steps: bool = True,
         grace_step_on_max_steps: bool = True,
         stuck_tracker: StuckLoopTracker | None = None,
+        # steer 消息队列：运行期间允许外部注入跟进消息；None 表示不启用
+        steering_queue: asyncio.Queue[dict[str, object]] | None = None,
         # 滑动窗口压缩参数
         sliding_window_size: int = 5,
         compact_cooldown_steps: int = 3,
@@ -218,6 +220,7 @@ class AgentLoop:
         self._pricing_model = pricing_model or _infer_pricing_model(provider)
         self._pricing_catalog = pricing_catalog
         self._unknown_pricing_policy = unknown_pricing_policy
+        self._steering_queue = steering_queue
         # 压缩冷却期：两次压缩之间至少间隔 N 步；冷启动即可触发
         self._last_compact_step: int = -15
         # 熔断器日志去重：避免每步都刷屏

--- a/src/sztu_code/core/tools/base.py
+++ b/src/sztu_code/core/tools/base.py
@@ -57,6 +57,8 @@ class BaseTool(ABC):
     manages_timeout: bool = False
     # 工具名称别名列表（如 "read" → "read_file"）
     aliases: ClassVar[list[str]] = []
+    # 默认不可安全重试；幂等工具（如只读查询）可在子类声明为 True
+    retry_safe: ClassVar[bool] = False
 
     # 执行工具调用，返回结果或错误
     @abstractmethod


### PR DESCRIPTION
Fixes #108

修复两处导致 Python 测试套件大面积失败的生产缺陷：

1. `AgentLoop.__init__` 未接受/初始化 `steering_queue`，运行期读取 `self._steering_queue` 抛 AttributeError（63 个用例失败 + TypeError）
2. `BaseTool` 未声明 `retry_safe` ClassVar，`is_retry_safe()` 对未显式声明的子类抛 AttributeError（14 个用例失败）

## 修改内容

- `src/sztu_code/core/loop.py`：`__init__` 新增 `steering_queue` 可选参数（默认 None，不启用 steer 时行为不变），并初始化属性
- `src/sztu_code/core/tools/base.py`：`BaseTool` 新增 `retry_safe: ClassVar[bool] = False` 默认声明（默认不可安全重试，保持保守语义）

两处均为最小侵入式修改，不改变既有默认行为。

## 测试（Windows 11 / Python 3.12.13，uv run pytest tests 全量）

- 修复前 88 failed / 913 passed → 修复后（排除两个预存挂死模块，后续另开 issue 说明）：**12 failed / 989 passed / 1 skipped**
- 宿主机全量验证：跑到预存挂死用例前 675 passed / 6 failed，通过部分与上一致
- 剩余 12 个失败均与本 PR 无关：6 个重试引擎断言不同步（test_tool_retry、test_loop）、1 个 bash 默认 timeout（30s 实现 vs 60s 断言）、5 个 e2e 在 Windows 下内层 pytest 子进程失败（基线上同样失败）

## 备注

建议后续单独跟进：重试引擎的测试/实现同步问题、bash 默认 timeout 期望值、两个测试挂死 bug（另开 issue）。
