### PR TITLE
Fix/110 pytest hangs

### DIFF
--- a/src/sztu_code/core/compact/compactor.py
+++ b/src/sztu_code/core/compact/compactor.py
@@ -230,6 +230,13 @@ class Compactor:
         *,
         sliding_window_size: int = 0,
     ) -> asyncio.Task[None] | None:
+        # single-flight：已有未完成的后台压缩时跳过本次触发。
+        # 否则并发任务共享同一 context，_run 的 len(snapshot) 后缀合并
+        # 假设快照仍是前缀，先完成的任务替换消息后该假设被破坏，
+        # 后完成的旧快照结果会覆盖新结果并丢失中间消息。
+        self._pending_tasks = [t for t in self._pending_tasks if not t.done()]
+        if self._pending_tasks:
+            return None
         # 对当前消息做快照（浅拷贝列表，消息 dict 本身不变）
         snapshot = list(context.messages)
 

--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -254,10 +254,6 @@ class AgentLoop:
         canvas: TaskCanvas = context.canvas
 
         while not context.is_done():
-            # Ensure a prepared summary replaces the oversized snapshot before
-            # the next model request instead of only at runner shutdown.
-            if self._compactor is not None:
-                await self._compactor.wait_pending()
             self._drain_steering(context)
             # 惰性记录 run 开始墙钟（runner/子 agent 都可能未设置）
             if context.started_at <= 0.0:
@@ -665,12 +661,15 @@ class AgentLoop:
                     ):
                         should_compact = False
                     else:
-                        # 滑动窗口异步压缩 — 不阻塞 Agent 继续处理下一步
-                        self._compactor.compact_async(
+                        # 滑动窗口异步压缩 — 不阻塞 Agent 继续处理下一步；
+                        # single-flight 跳过（返回 None）时不更新冷却步，
+                        # 在飞任务完成后若仍超阈值可立即重新触发
+                        task = self._compactor.compact_async(
                             context, self._provider,
                             sliding_window_size=self._sliding_window_size,
                         )
-                        self._last_compact_step = context.step
+                        if task is not None:
+                            self._last_compact_step = context.step
 
             await self._bus.publish(
                 StepFinishedEvent(run_id=context.run_id, step=context.step, ts=_now())

--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -53,11 +53,18 @@ def _now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+# _unwrap_provider 的最大解包层数：真实 wrapper 嵌套远小于此值；上限防御
+# 动态属性对象（每次 getattr 都返回新对象，seen 集合永远追不上）导致死循环
+_MAX_PROVIDER_UNWRAP_DEPTH = 32
+
+
 # 解开 Trace 等 provider wrapper，拿到底层模型提供者
 def _unwrap_provider(provider: LLMProvider) -> object:
     current: object = provider
     seen: set[int] = set()
-    while hasattr(current, "_inner") and id(current) not in seen:
+    for _ in range(_MAX_PROVIDER_UNWRAP_DEPTH):
+        if not hasattr(current, "_inner") or id(current) in seen:
+            break
         seen.add(id(current))
         current = getattr(current, "_inner")
     return current

--- a/tests/unit/test_compactor.py
+++ b/tests/unit/test_compactor.py
@@ -195,3 +195,52 @@ async def test_wait_pending_can_cancel_background_tasks(tmp_path: Path) -> None:
 
     assert cancel_seen.is_set()
     assert task.cancelled() is True
+
+
+# 功能：验证 compact_async 的 single-flight 语义 — 在飞任务未完成时重复触发被跳过，
+#       跳过期间追加的消息不丢失，任务完成后可再次触发
+# 设计：门控 provider 阻塞第一个后台任务；期间追加消息并再次 compact_async，
+#       断言返回 None（不产生基于过期快照的并发任务）；放行后断言合并
+#       保留了追加消息，且后续触发又能创建新任务
+# 背景：并发任务共享 context 时，_run 的 len(snapshot) 后缀合并会被先完成
+#       的任务破坏前提，旧快照结果覆盖新结果并丢失中间消息
+async def test_compact_async_single_flight_skips_concurrent_trigger(tmp_path: Path) -> None:
+    gate = asyncio.Event()
+    summary = "## 1. Original Goal\nTest\n## 2. Completed Steps\n- done"
+
+    async def _chat(**_: Any) -> LlmResponse:
+        await gate.wait()
+        return LlmResponse(
+            stop_reason="end_turn",
+            text=summary,
+            usage=UsageStats(input_tokens=100, output_tokens=30),
+        )
+
+    provider = MagicMock()
+    provider.chat = AsyncMock(side_effect=_chat)
+    compactor = Compactor(EventBus(), tmp_path, "sess-1")
+    ctx = ExecutionContext(run_id="r1", goal="test", max_steps=5)
+    ctx.messages = _make_messages()
+
+    task1 = compactor.compact_async(ctx, provider)
+    assert task1 is not None
+    await asyncio.sleep(0)
+
+    # 快照后追加新消息，再次触发 → single-flight 跳过
+    appended = {"role": "user", "content": "appended after snapshot"}
+    ctx.messages.append(appended)
+    assert compactor.compact_async(ctx, provider) is None
+
+    gate.set()
+    await task1
+
+    # 合并保留了快照后追加的消息，且前缀被摘要对替换
+    assert ctx.compacted is True
+    assert ctx.messages[-1] is appended
+    assert len(ctx.messages) == 3
+
+    # 在飞任务完成后，新触发可创建任务（done 任务被清理）
+    task2 = compactor.compact_async(ctx, provider)
+    assert task2 is not None
+    await compactor.wait_pending()
+


### PR DESCRIPTION
## Summary

修复 issue #110 报告的两处 pytest 永久挂死（Fixes #110）：

1. **Bug A**：`AgentLoop.__init__` 的价格推断经 `_unwrap_provider` 解包 provider wrapper 时，对具有动态属性生成能力的对象（如 `unittest.mock.Mock/AsyncMock`）陷入无限循环——`hasattr(current, "_inner")` 恒为 True，且每次 `getattr` 返回全新子对象（新 id），`seen` 集合永远无法终止循环，导致 `tests/unit/test_spawn_agent_tool.py` 全模块挂死。
2. **Bug B**：`AgentLoop.run` 的 while 循环顶部存在 `await self._compactor.wait_pending()` 阻塞等待，将"异步后台压缩"（`compact_async` 的设计意图）变成主循环硬屏障。当压缩任务的完成依赖主循环推进时（test_runner 中 3 个 pending-compaction 取消用例的门控 mock provider 正是这种结构），主循环与压缩任务互相等待形成死锁。

## Behavior

- **Bug A 修复**：`_unwrap_provider` 增加最大解包深度常数 `_MAX_PROVIDER_UNWRAP_DEPTH = 32`，改为有界 for 循环，保留原有 seen-id 环检测。真实 wrapper 嵌套（如 `TracingProvider`）仅 1-2 层，生产行为不变；对任意病理对象保证终止。生产代码不引入 `unittest.mock` 或任何类型嗅探。
- **Bug B 修复**：删除 `AgentLoop.run` 循环顶部的 4 行 `wait_pending` 阻塞等待。git 考古表明：398b310（#77，加入这 3 个测试及 runner shutdown 契约时）loop.py 并无此等待；该等待由侧分支 1a6bdd1 引入；85b5666 恢复 Python 运行时时将两者合并到 main 才重新引入死锁。Runner 侧 shutdown 契约完整保留——`runner.py` 在 run 结束事件前 `wait_pending(cancel_pending=cancelled)`、session 持久化前再次 `wait_pending`，压缩结果仍保证在会话落盘前生效。
- **并发防护（single-flight）**：移除循环顶部等待后，冷却期满可在前一个后台压缩仍在飞时再次触发；并发任务共享同一 context，`compact_async` 的 `len(snapshot)` 后缀合并逻辑假设快照仍是 `context.messages` 前缀，先完成的任务替换消息后该假设被破坏，旧快照结果会覆盖新结果并丢失中间消息。因此 `Compactor.compact_async` 增加 single-flight 门禁：存在未完成的后台压缩任务时直接返回 None 不创建新任务（顺带清理已完成任务引用）；loop 侧仅在真正创建任务时更新 `_last_compact_step`，被跳过的触发在在飞任务完成后若仍超阈值可立即重新触发，不会形成重试风暴。

改动极小：生产代码仅 `src/sztu_code/core/loop.py` 与 `src/sztu_code/core/compact/compactor.py`，另新增 1 个 single-flight 单测；拆为两个独立 commit。用户可见协议、配置、数据格式均无变化。

## Validation

本 PR 仅改动 Python 运行时（`src/sztu_code/core/`）与 Python 单测，未触及 TypeScript 侧（`packages/`、`desktop/`、协议定义），因此未运行 `npm run typecheck` / `npm test` / `npm run build` / `npm run docs:protocol` / `npm run docs:links`——无 TS 产物变化，wire protocol 未改动。

实际运行的检查（环境：Windows 11 + Python 3.12 + uv，基线 origin/main = 885bef8）：

```text
# 修复前复现（uv run --with pytest-timeout，thread 模式抓栈）
- test_spawn_agent_tool.py：第一个用例即超时，栈终止于 loop.py:60 _unwrap_provider × mock._get_child_mock（无限分配子 mock）
- test_runner.py 3 个 pending-compaction 用例：永久等待 provider.compact_started.wait()，事件循环空转
- 基线全量（必须排除上述 19+3 个挂死用例才能跑完）：91 failed / 874 passed，70.75s，失败全部为 issue #108 既有回归

# 修复后
uv run pytest tests/unit/test_spawn_agent_tool.py -q
  → 1.19s 跑完不再挂起（10 failed / 9 passed，失败全部为 #108 既有的 retry_safe/_steering_queue 断言，与本 PR 无关）
uv run pytest tests/unit/test_compactor.py -q
  → 11 passed in 0.98s（含新增单测 test_compact_async_single_flight_skips_concurrent_trigger）
uv run pytest tests/unit -q   # 全量、无任何排除、无任何挂死
  → 仅本 PR：101 failed / 884 passed（= 基线 91F/874P + spawn 文件 10F/9P + 新增单测 1P；失败集合与修复前逐项比对零差异，零新增失败）
  → 本 PR + 本地临时叠加 PR #109 的 2 行修复：65 failed / 923 passed，94.64s（3 个 pending-compaction 用例 3 passed，剩余失败均为 #108 相关级联，逐项比对零差异）
uv run ruff check src tests
  → 5 错误，与基线完全相同（既有，均不在本 PR 触碰的文件）
uv run mypy src
  → 5 错误，与基线完全相同（全部为 #108 既有的 retry_safe/_steering_queue）
```

注：3 个 pending-compaction 用例完全转绿依赖 PR #109 合入（纯基线上 #108 的 `_steering_queue` AttributeError 使 run 提前死亡、compact 永不触发）；本 PR 修复的是 #109 之后暴露的 wait_pending 死锁。建议合并顺序：先 #109，再本 PR。

## Risk

- **兼容性**：无协议、配置、数据格式变化；公开 API 仅 `Compactor.compact_async` 返回值语义细化（在飞时返回 None），仓库内唯一调用方（loop.py）已同步适配。
- **Bug A**：深度上限 32 远大于真实 wrapper 嵌套深度（当前最多 2 层），生产路径行为不变；唯一差异是病理对象在 32 层后返回当前对象而非死循环，最坏影响是 pricing 推断降级为未知 provider，不影响上下文/预算硬防线（其依赖 `response.usage`）。
- **Bug B**：移除循环顶部等待后，压缩摘要不再保证在"下一次模型请求前"生效，而是就绪后异步替换——与 `compact_async` 设计注释及 #77 加入测试时的行为一致；上下文溢出仍由 blocking limit（context_pct > 0.98 即中断）兜底，token 预算控制不依赖此屏障；runner shutdown/持久化前的两处 `wait_pending` 契约未动，会话落盘一致性不受影响。
- **single-flight**：在飞压缩期间的新触发被跳过而非排队；若完成后上下文仍超阈值，下一步立即重新触发（跳过不更新冷却步），压缩机会不丢失。极端情况下压缩吞吐从"并发多任务"降为"串行单任务"，但并发模式本身就是会互相覆盖结果、丢失消息的错误行为，无实际损失。
- **回滚方式**：两个 commit 相互独立，可单独 revert；revert Bug B 的 commit 即恢复循环顶部屏障（同时恢复 #110 的死锁）。

## UI evidence

N/A（纯后端/测试稳定性修复，无 TUI/桌面端视觉变化）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试（新增 `test_compact_async_single_flight_skips_concurrent_trigger`）。
- [x] 协议变化已重新生成 `docs/reference/wire-protocol.md`（本 PR 无协议变化，N/A）。
- [x] 用户文档、配置示例和迁移说明已同步（无用户可见行为/配置变化，N/A）。
- [x] 提交包含 `Signed-off-by`（DCO）。
```