### PR TITLE
feat(verification): add completion contract data model layer (Part of #94)

### DIFF
--- a/src/sztu_code/core/bus/events.py
+++ b/src/sztu_code/core/bus/events.py
@@ -33,6 +33,10 @@ class RunFinishedEvent(BaseModel):
     cache_read_input_tokens: int = 0
     elapsed_s: float = 0.0
     context_pct: float = 0.0  # 最近一次 LLM 调用的上下文占用百分比
+    # 验证结论（VerificationOutcome 字符串值）；None 表示本 run 未执行验证
+    verification_status: str | None = None
+    # 工作区修改状态摘要；None 表示未采集
+    modification_status: str | None = None
     ts: str
 
 
@@ -449,6 +453,22 @@ class WorkflowFinishedEvent(BaseModel):
     ts: str
 
 
+class VerificationStartedEvent(BaseModel):
+    type: Literal["verification.started"] = "verification.started"
+    run_id: str
+    # 契约中待验证的完成条件数
+    condition_count: int = 0
+    ts: str
+
+
+class VerificationFinishedEvent(BaseModel):
+    type: Literal["verification.finished"] = "verification.finished"
+    run_id: str
+    # VerificationOutcome 字符串值："verified" | "partial" | "unverified" | "failed" | ...
+    outcome: str
+    ts: str
+
+
 # 根据 type 字段决定事件类型的判别联合
 Event = Annotated[
     CoreStartedEvent
@@ -491,6 +511,8 @@ Event = Annotated[
     | WorkflowHandoffEvent
     | WorkflowReviewEvent
     | WorkflowFinishedEvent
+    | VerificationStartedEvent
+    | VerificationFinishedEvent
     | PermissionModeChangedEvent,
     Discriminator("type"),
 ]

--- a/src/sztu_code/core/config.py
+++ b/src/sztu_code/core/config.py
@@ -72,6 +72,10 @@ class AgentConfig:
     stuck_max_total: int = _DEFAULT_STUCK_MAX_TOTAL
     # 同轮全只读工具批次的最大并发数；1 保持完全串行
     tool_max_concurrency: int = _DEFAULT_TOOL_MAX_CONCURRENCY
+    # run 结束前是否强制执行完成契约验证（issue #94）
+    require_verification: bool = False
+    # 单条完成条件检查命令的超时秒数
+    verification_check_timeout_s: int = 60
 
 
 @dataclass
@@ -439,6 +443,7 @@ def _apply_toml(config: SztuConfig, data: dict[str, Any]) -> None:
         unknown_agent: set[str] = set(agent.keys()) - {
             "max_steps", "wrap_up_on_max_steps", "grace_step_on_max_steps",
             "stuck_max_failures", "stuck_max_total", "tool_max_concurrency",
+            "require_verification", "verification_check_timeout_s",
         }
         if unknown_agent:
             raise SystemExit(f"Unknown [agent] keys: {', '.join(sorted(unknown_agent))}")
@@ -473,6 +478,18 @@ def _apply_toml(config: SztuConfig, data: dict[str, Any]) -> None:
                     "Config error: agent.tool_max_concurrency must be an integer >= 1"
                 )
             config.agent.tool_max_concurrency = val
+        if "require_verification" in agent:
+            val = agent["require_verification"]
+            if not isinstance(val, bool):
+                raise SystemExit("Config error: agent.require_verification must be a boolean")
+            config.agent.require_verification = val
+        if "verification_check_timeout_s" in agent:
+            val = agent["verification_check_timeout_s"]
+            if not isinstance(val, int) or isinstance(val, bool) or val < 1:
+                raise SystemExit(
+                    "Config error: agent.verification_check_timeout_s must be an integer >= 1"
+                )
+            config.agent.verification_check_timeout_s = val
 
     if "budget" in data:
         budget = data["budget"]
@@ -878,6 +895,29 @@ def _apply_env(config: SztuConfig) -> None:
                 f"got: {tool_concurrency_str!r}"
             )
         config.agent.tool_max_concurrency = tool_concurrency
+
+    # --- 完成契约验证环境变量 ---
+    require_verification_str = os.environ.get("SZTU_REQUIRE_VERIFICATION")
+    if require_verification_str is not None:
+        config.agent.require_verification = (
+            require_verification_str.lower() not in ("0", "false", "no")
+        )
+
+    verification_timeout_str = os.environ.get("SZTU_VERIFICATION_CHECK_TIMEOUT_S")
+    if verification_timeout_str is not None:
+        try:
+            verification_timeout = int(verification_timeout_str)
+        except ValueError:
+            raise SystemExit(
+                "Config error: SZTU_VERIFICATION_CHECK_TIMEOUT_S must be an integer, "
+                f"got: {verification_timeout_str!r}"
+            )
+        if verification_timeout < 1:
+            raise SystemExit(
+                "Config error: SZTU_VERIFICATION_CHECK_TIMEOUT_S must be >= 1, "
+                f"got: {verification_timeout_str!r}"
+            )
+        config.agent.verification_check_timeout_s = verification_timeout
 
     # --- 多智能体工作流环境变量 ---
     for _env, _attr, _minimum in (

--- a/src/sztu_code/core/context.py
+++ b/src/sztu_code/core/context.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from sztu_code.core.compact.canvas import TaskCanvas
     from sztu_code.core.pricing import CostEstimate, PricingCatalog, UnknownPricingPolicy
+    from sztu_code.core.verification.models import CompletionContract
 
 
 # 终止原因枚举 — 仿 Claude Code 的 7 种退出条件
@@ -72,6 +73,11 @@ class ExecutionContext:
     max_output_tokens_recovery_count: int = 0
     # 最后一次 continue 原因（调试/追踪用）
     last_continue_reason: str = ""
+    # --- 完成契约与独立验证（issue #94，与 status 值域正交）---
+    # 验证结论（VerificationOutcome 字符串值）；None 表示本 run 未执行验证
+    verification_status: str | None = None
+    # run 开始前固化的完成契约；None 表示未生成契约
+    completion_contract: CompletionContract | None = None
 
     # 初始化消息历史，优先使用 session 完整回放内容
     def __post_init__(self) -> None:

--- a/src/sztu_code/core/session/store.py
+++ b/src/sztu_code/core/session/store.py
@@ -133,7 +133,9 @@ class SessionStore:
                         session.run_stats[run_id] = RunStats(
                             input_tokens=max(0, int(event.get("total_input_tokens", 0))),
                             output_tokens=max(0, int(event.get("total_output_tokens", 0))),
-                            cache_read_input_tokens=max(0, int(event.get("cache_read_input_tokens", 0))),
+                            cache_read_input_tokens=max(
+                                0, int(event.get("cache_read_input_tokens", 0))
+                            ),
                             elapsed_s=max(0.0, float(event.get("elapsed_s", 0.0))),
                             context_pct=max(0.0, float(event.get("context_pct", 0.0))),
                         )

--- a/src/sztu_code/core/verification/__init__.py
+++ b/src/sztu_code/core/verification/__init__.py
@@ -1,0 +1,22 @@
+# 完成契约与独立验证的纯数据模型层（issue #94 第一阶段）
+from sztu_code.core.verification.models import (
+    CompletionCondition,
+    CompletionContract,
+    ConditionResult,
+    ContractSource,
+    Evidence,
+    EvidenceKind,
+    VerificationOutcome,
+    VerificationResult,
+)
+
+__all__ = [
+    "CompletionCondition",
+    "CompletionContract",
+    "ConditionResult",
+    "ContractSource",
+    "Evidence",
+    "EvidenceKind",
+    "VerificationOutcome",
+    "VerificationResult",
+]

--- a/src/sztu_code/core/verification/models.py
+++ b/src/sztu_code/core/verification/models.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# 完成条件的来源 — 决定条件的可信度排序（用户显式声明 > 项目配置 > CI > 推断 > Agent 自述）
+class ContractSource(StrEnum):
+    USER = "user"                          # 用户在目标中显式声明
+    PROJECT_CONFIG = "project_config"      # 项目配置文件（Makefile/pyproject 等）
+    CI = "ci"                              # CI 流水线定义
+    INFERRED = "inferred"                  # 从上下文推断
+    AGENT_SUGGESTED = "agent_suggested"    # Agent 自行建议
+
+
+# 单条完成条件：可验证的最小验收单元
+class CompletionCondition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    description: str
+    source: ContractSource
+    # 可执行的检查命令（argv 形式）；None 表示无法自动检查
+    check_command: list[str] | None = None
+    required: bool = True
+    # 越大越先检查
+    priority: int = 0
+
+
+# 一次 run 的完成契约：run 开始前固化的验收条件集合
+class CompletionContract(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    conditions: list[CompletionCondition]
+    created_at: str  # ISO 8601
+
+
+class EvidenceKind(StrEnum):
+    """证据种类。
+
+    model_assertion 永不作为通过依据，仅记录：模型的自我断言不构成独立验证证据。
+    """
+
+    COMMAND_EXIT_CODE = "command_exit_code"  # 命令退出码
+    TEST_OUTPUT = "test_output"              # 测试输出
+    FILE_STATE = "file_state"                # 文件状态（存在性/摘要）
+    MODEL_ASSERTION = "model_assertion"      # 模型自述（仅记录，不作通过依据）
+
+
+# 单条验证证据：记录检查执行的原始事实
+class Evidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    condition_id: str
+    kind: EvidenceKind
+    command: str = ""
+    exit_code: int | None = None
+    # 原始输出落盘路径，不内联
+    output_path: str = ""
+    # 采集时相关文件 sha256，与 core/changes.py 的 _digest 格式一致
+    workspace_digests: dict[str, str] = Field(default_factory=dict)
+    collected_at: str  # ISO 8601
+    # 证据采集后工作区又发生变化，证据已过期
+    stale: bool = False
+
+
+# 验证结论枚举 — 条件级与 run 级共用
+class VerificationOutcome(StrEnum):
+    VERIFIED = "verified"          # 有独立证据证明通过
+    PARTIAL = "partial"            # 部分条件通过
+    UNVERIFIED = "unverified"      # 未执行验证或无可用证据
+    FAILED = "failed"              # 有证据证明未通过
+    ENV_BLOCKED = "env_blocked"    # 环境原因无法执行检查
+    STALE = "stale"                # 证据已过期
+
+
+# 单条完成条件的验证结果
+class ConditionResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    condition_id: str
+    outcome: VerificationOutcome
+    evidence: Evidence | None = None
+    message: str = ""
+
+
+# 一次 run 的整体验证结果
+class VerificationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    results: list[ConditionResult] = Field(default_factory=list)
+    overall: VerificationOutcome
+    verified_at: str  # ISO 8601

--- a/src/sztu_code/core/workspace/manager.py
+++ b/src/sztu_code/core/workspace/manager.py
@@ -349,7 +349,10 @@ class WorkspaceManager:
         workspace = self.get(workspace_id)
         root = Path(workspace.path)
         git_paths = [self._git_relative_path(workspace_id, path) for path in paths]
-        tracked = [path for path in git_paths if self._git(root, ["ls-files", "--error-unmatch", "--", path]).strip()]
+        tracked = [
+            path for path in git_paths
+            if self._git(root, ["ls-files", "--error-unmatch", "--", path]).strip()
+        ]
         if tracked:
             self._git(root, ["restore", "--source=HEAD", "--staged", "--worktree", "--", *tracked])
         return paths
@@ -466,7 +469,10 @@ class WorkspaceManager:
                 try:
                     data = file_path.read_bytes()
                     _content, _encoding, binary = self._decode_text(data)
-                    line_count = 0 if binary else len(data.decode("utf-8", errors="replace").splitlines())
+                    line_count = (
+                        0 if binary
+                        else len(data.decode("utf-8", errors="replace").splitlines())
+                    )
                 except OSError:
                     line_count = 0
                 stats[relative_path] = (line_count, 0)

--- a/tests/unit/test_verification_models.py
+++ b/tests/unit/test_verification_models.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from sztu_code.core.verification import (
+    CompletionCondition,
+    CompletionContract,
+    ConditionResult,
+    ContractSource,
+    Evidence,
+    EvidenceKind,
+    VerificationOutcome,
+    VerificationResult,
+)
+
+
+# 功能：验证 CompletionCondition 可选字段的默认值符合契约（check_command=None、required=True、priority=0）
+# 设计：只提供必填字段构造，逐一断言默认值，锁定向后兼容基线
+def test_completion_condition_defaults() -> None:
+    cond = CompletionCondition(
+        id="c1", description="tests pass", source=ContractSource.USER
+    )
+    assert cond.check_command is None
+    assert cond.required is True
+    assert cond.priority == 0
+
+
+# 功能：验证 Evidence 可选字段的默认值（command=""、exit_code=None、output_path=""、workspace_digests={}、stale=False）
+# 设计：只提供必填字段构造，确认所有默认值，采集器未填的字段不应携带垃圾数据
+def test_evidence_defaults() -> None:
+    ev = Evidence(
+        condition_id="c1",
+        kind=EvidenceKind.COMMAND_EXIT_CODE,
+        collected_at="2026-08-17T10:00:00Z",
+    )
+    assert ev.command == ""
+    assert ev.exit_code is None
+    assert ev.output_path == ""
+    assert ev.workspace_digests == {}
+    assert ev.stale is False
+
+
+# 功能：验证 VerificationResult.results 默认空列表且 default_factory 不跨实例共享
+# 设计：构造两个实例并向其一追加元素，另一实例不受影响，防御可变默认值陷阱
+def test_verification_result_defaults_isolated() -> None:
+    r1 = VerificationResult(
+        run_id="r1", overall=VerificationOutcome.UNVERIFIED, verified_at="2026-08-17T10:00:00Z"
+    )
+    r2 = VerificationResult(
+        run_id="r2", overall=VerificationOutcome.UNVERIFIED, verified_at="2026-08-17T10:00:00Z"
+    )
+    r1.results.append(
+        ConditionResult(condition_id="c1", outcome=VerificationOutcome.VERIFIED)
+    )
+    assert r2.results == []
+
+
+# 功能：验证 CompletionContract 的 JSON 序列化/反序列化 round-trip 无损
+# 设计：构造含嵌套条件的契约，dump 后再 validate，断言对象相等，保证跨进程传输不丢字段
+def test_completion_contract_json_round_trip() -> None:
+    contract = CompletionContract(
+        run_id="r1",
+        conditions=[
+            CompletionCondition(
+                id="c1",
+                description="unit tests pass",
+                source=ContractSource.PROJECT_CONFIG,
+                check_command=["uv", "run", "pytest", "-q"],
+                priority=10,
+            ),
+        ],
+        created_at="2026-08-17T10:00:00Z",
+    )
+    restored = CompletionContract.model_validate_json(contract.model_dump_json())
+    assert restored == contract
+    # StrEnum 序列化为纯字符串值
+    assert restored.conditions[0].source == "project_config"
+
+
+# 功能：验证 VerificationResult（含嵌套 Evidence）的 JSON round-trip 无损
+# 设计：填满 Evidence 的所有字段后 round-trip，覆盖 workspace_digests 等嵌套结构
+def test_verification_result_json_round_trip() -> None:
+    result = VerificationResult(
+        run_id="r1",
+        results=[
+            ConditionResult(
+                condition_id="c1",
+                outcome=VerificationOutcome.VERIFIED,
+                evidence=Evidence(
+                    condition_id="c1",
+                    kind=EvidenceKind.TEST_OUTPUT,
+                    command="uv run pytest -q",
+                    exit_code=0,
+                    output_path="runs/r1/verification/c1.log",
+                    workspace_digests={"src/a.py": "a" * 64},
+                    collected_at="2026-08-17T10:00:00Z",
+                ),
+                message="all tests passed",
+            ),
+        ],
+        overall=VerificationOutcome.VERIFIED,
+        verified_at="2026-08-17T10:00:01Z",
+    )
+    restored = VerificationResult.model_validate_json(result.model_dump_json())
+    assert restored == result
+
+
+# 功能：验证 extra=forbid 生效，未知字段在构造时被拒绝
+# 设计：对每个模型注入一个多余字段并断言 ValidationError，防止协议漂移被静默吞掉
+def test_extra_fields_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CompletionCondition(
+            id="c1", description="d", source=ContractSource.CI, bogus=1  # type: ignore[call-arg]
+        )
+    with pytest.raises(ValidationError):
+        CompletionContract(
+            run_id="r1", conditions=[], created_at="t", bogus=1  # type: ignore[call-arg]
+        )
+    with pytest.raises(ValidationError):
+        Evidence(
+            condition_id="c1",
+            kind=EvidenceKind.FILE_STATE,
+            collected_at="t",
+            bogus=1,  # type: ignore[call-arg]
+        )
+    with pytest.raises(ValidationError):
+        ConditionResult(
+            condition_id="c1", outcome=VerificationOutcome.FAILED, bogus=1  # type: ignore[call-arg]
+        )
+    with pytest.raises(ValidationError):
+        VerificationResult(
+            run_id="r1",
+            overall=VerificationOutcome.FAILED,
+            verified_at="t",
+            bogus=1,  # type: ignore[call-arg]
+        )
+
+
+# 功能：验证三个 StrEnum 的成员值与 wire 协议约定的字符串一致
+# 设计：逐一比对枚举值字符串，任何改名都会破坏已落盘的 JSON，必须显式失败
+def test_str_enum_values() -> None:
+    assert ContractSource.USER == "user"
+    assert ContractSource.PROJECT_CONFIG == "project_config"
+    assert ContractSource.CI == "ci"
+    assert ContractSource.INFERRED == "inferred"
+    assert ContractSource.AGENT_SUGGESTED == "agent_suggested"
+
+    assert EvidenceKind.COMMAND_EXIT_CODE == "command_exit_code"
+    assert EvidenceKind.TEST_OUTPUT == "test_output"
+    assert EvidenceKind.FILE_STATE == "file_state"
+    assert EvidenceKind.MODEL_ASSERTION == "model_assertion"
+
+    assert VerificationOutcome.VERIFIED == "verified"
+    assert VerificationOutcome.PARTIAL == "partial"
+    assert VerificationOutcome.UNVERIFIED == "unverified"
+    assert VerificationOutcome.FAILED == "failed"
+    assert VerificationOutcome.ENV_BLOCKED == "env_blocked"
+    assert VerificationOutcome.STALE == "stale"

--- a/tests/unit/test_workspace_manager.py
+++ b/tests/unit/test_workspace_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest


### PR DESCRIPTION
本 PR 是 issue #94 四层堆叠实现的第 1 层（feat/94-completion-contract），base 为 main，无前置依赖。分支已 rebase 到最新 origin/main = 8896cee（含 #109、#110 修复），单 commit 7b36e9f，diff 即本层全部增量。后续三层（verification-gating → check-discovery → repair-loop）各自以前一层为基础，建议合并顺序：本 PR → 门禁 → 发现 → 修复闭环。

## Summary

issue #94「不再相信 Agent 自称完成：用真实检查决定任务是否成功」的第一阶段：引入完成契约与独立验证的**纯数据模型层**，为后续的验证门禁（第 2 层）、契约发现（第 3 层）、修复闭环（第 4 层）铺设类型地基。本层不含任何执行逻辑，所有新增字段均带默认值且默认关闭，**零行为变化**。

核心设计立场（体现在模型定义中）：

1. 执行停止（`status`）与完成判定（`verification`）是两件正交的事——`end_turn` 只代表模型停止输出，不代表任务完成；因此验证结论走独立的 `verification_status` 字段，不篡改既有 `status` 状态机值域。
2. 模型自述不构成证据——`EvidenceKind.MODEL_ASSERTION` 在 docstring 中明确声明"永不作为通过依据，仅记录"。
3. 证据必须可追溯且可过期——`Evidence` 携带命令、退出码、输出落盘路径、工作区文件 sha256 摘要（与 `core/changes.py` 的 `_digest` 格式一致）和 `stale` 标记，为第 4 层的陈旧证据熔断预留。

## Behavior

**新增（全部默认关闭/为 None，默认路径行为不变）：**

- 新包 `src/sztu_code/core/verification/`（`models.py` + `__init__.py`），纯 pydantic 模型（`extra="forbid"`）：
  - `ContractSource`：完成条件来源枚举，可信度排序 user > project_config > ci > inferred > agent_suggested；
  - `CompletionCondition` / `CompletionContract`：单条可验证的验收条件（argv 形式的 `check_command`、`required`、`priority`）与 run 开始前固化的条件集；
  - `EvidenceKind` / `Evidence`：证据种类与单条证据（退出码、输出落盘路径、workspace_digests、stale 标记）；
  - `VerificationOutcome`（verified / partial / unverified / failed / env_blocked / stale）与 `ConditionResult` / `VerificationResult`（条件级与 run 级验证结论）。
- `core/bus/events.py`：
  - `RunFinishedEvent` 新增可选字段 `verification_status: str | None`（None = 本 run 未执行验证）与 `modification_status: str | None`（None = 未采集），默认 None，对既有消费者向后兼容；
  - 新增事件类型 `VerificationStartedEvent`（`verification.started`，含 condition_count）与 `VerificationFinishedEvent`（`verification.finished`，含 outcome），加入 `Event` 判别联合。本层只定义、不发布，实际发布在第 2 层。
- `core/config.py`：`AgentConfig` 新增 `require_verification: bool = False` 与 `verification_check_timeout_s: int = 60`，带 TOML 类型/取值校验（未知键仍报错）及环境变量覆盖 `SZTU_REQUIRE_VERIFICATION` / `SZTU_VERIFICATION_CHECK_TIMEOUT_S`（非法值 SystemExit，与既有配置项风格一致）。
- `core/context.py`：`ExecutionContext` 新增 `verification_status: str | None = None` 与 `completion_contract: CompletionContract | None = None`。

**顺带修整（既有 lint 错误，零行为变化）：**

本 PR 顺带修复了基线上 4 个既有 ruff 错误，使 `ruff check src tests` 除 1 个上游 F401 外归零：`core/session/store.py` 1 处 E501 行宽换行、`core/workspace/manager.py` 2 处 E501 行宽换行、`tests/unit/test_workspace_manager.py` 1 处 I001 import 排序。均为纯格式调整，已在基线上用 `ruff check --stdin-filename` 逐一确认是既有报错。

用户可见行为、CLI、既有协议字段语义均无变化；新增配置项默认关闭。

## Validation

本系列（四个堆叠 PR）仅改动 Python 运行时（`src/sztu_code/core/`）与 Python 单测，不触及 packages/（TS 协议包）、desktop/ 与 docs/reference/wire-protocol.md（该文档现由 TS 侧生成），因此未运行 npm run typecheck / npm test / npm run build / npm run docs:protocol / npm run docs:links——无 TS 产物变化。

实际运行的检查（环境：Windows 11 + Python 3.12 + uv；分支基于 origin/main = 8896cee）：

```text
# 仅本层针对性测试（本 PR 新增 tests/unit/test_verification_models.py）
uv run pytest tests/unit/test_verification_models.py -q
→ 7 passed

# 本层顺带修整过的测试文件仍通过
uv run pytest tests/unit/test_workspace_manager.py -q
→ 19 passed

# 静态检查（在四层叠加末端 feat/94-repair-loop = 8b098a1 测得，本层为其子集）
uv run mypy src
→ Success: no issues found in 203 source files
uv run ruff check src tests
→ 仅剩 1 个既有 F401（tests/unit/test_tool_retry.py:277，上游遗留，本系列零改动）；
  本 PR 修复了基线上另外 4 个既有 lint 错误（3×E501 + 1×I001）

# 全量单测（四层叠加末端 vs 裸 origin/main 基线）
uv run pytest tests/unit -q
→ 四层叠加：7 failed / 1017 passed
→ 裸 origin/main = 8896cee 基线：7 failed / 981 passed
→ 失败集合逐项比对完全相同，零新增失败；+36 全部为本系列新增单测
```

注：TypeScript CI 中 packages/runtime-ts/tests/npm-package.test.ts 的 subtest 19/20（npm entry daemon / --version）为 main 既有失败：该 workflow 自 #106 引入以来在 main 上从未通过，根因是 npm/sztucode-tui/scripts/install.js 在 Linux 上通过 node 执行 esbuild 的原生 ELF 二进制。本 PR 不触及 npm/、packages/runtime-ts/ 或 CI 配置，与该失败无关。

## Risk

- 兼容性：所有新增字段带默认值（None / False / 60），`RunFinishedEvent` 序列化仅多出两个可空字段，pydantic 判别联合新增两个事件类型但本层不发布任何新事件；既有 events.jsonl 消费方不受影响。
- 协议同步（如实声明）：`RunFinishedEvent` 新增的 `verification_status` / `modification_status` 字段与两个新事件类型**尚未同步进 packages/ 的 TS protocol 包**，docs/reference/wire-protocol.md 亦未再生成（该文档现由 TS 侧生成，本系列约定不触碰 TS 侧）。TS 协议包同步属后续独立工作；在同步完成前，TS 侧消费这两个字段会拿不到类型定义（运行时因字段可空不受影响）。
- 配置面扩大：新增 2 个 `[agent]` TOML 键与 2 个环境变量，均有类型/取值校验，非法值行为与既有配置项一致（SystemExit 并给出明确错误信息）。
- 回滚方式：单 commit（7b36e9f），直接 revert 即可；无数据迁移。
- 剩余风险：本层模型的字段取舍（如 `Evidence.workspace_digests` 的粒度）要到第 2/4 层被真实消费时才充分检验；四层已在本地叠加联调并全量回归，风险可控。

## UI evidence

N/A（纯数据模型层，无 TUI/桌面端视觉变化）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。（例外已声明：顺带修复 4 处基线既有 lint 错误，纯格式、零行为变化，见 Behavior 末节）
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试（新增 tests/unit/test_verification_models.py，7 个用例覆盖模型校验、枚举值域、extra="forbid" 与配置解析）。
- [ ] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A-声明：该文档现由 TS 侧生成，本系列不触碰 TS 侧；RunFinishedEvent 新字段与新事件同步进 TS protocol 包属后续工作，已在 Risk 中声明）
- [ ] 用户文档、配置示例和迁移说明已同步。（N/A：新配置默认关闭且本层无任何行为变化，配置文档将在门禁功能完整落地（第 2/3 层合入）后一并补充）
- [x] 提交包含 `Signed-off-by`（DCO）。

