### PR TITLE
feat(verification): add harness-side verification gating in runner (Part of #94)

### DIFF
--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -5,12 +5,15 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from sztu_code.core.bus.events import (
     ChangeAppliedEvent,
     ContextInjectedEvent,
     RunFinishedEvent,
     RunStartedEvent,
+    VerificationFinishedEvent,
+    VerificationStartedEvent,
 )
 from sztu_code.core.changes import WorkspaceChangeTracker
 from sztu_code.core.compact.compactor import Compactor
@@ -55,6 +58,8 @@ from sztu_code.core.tools.builtin import (
 from sztu_code.core.tools.registry import ToolRegistry
 from sztu_code.core.trace.provider import TracingProvider
 from sztu_code.core.trace.writer import TraceWriter
+from sztu_code.core.verification.executor import VerificationExecutor
+from sztu_code.core.verification.models import VerificationOutcome
 from sztu_code.core.workflow.tool import WorkflowRunTool
 from sztu_code.core.workspace.project_profile import (
     detect_project_profile,
@@ -66,11 +71,22 @@ def _now() -> str:
     return datetime.now(UTC).isoformat()
 
 
+# 基于 change_tracker.finalize() 的记录生成工作区修改状态摘要（纯函数，便于单测）；
+# records 为 None 表示未启用变更追踪，无法采集 → None
+def modification_status_summary(records: list[dict[str, Any]] | None) -> str | None:
+    if records is None:
+        return None
+    return f"modified:{len(records)}" if records else "clean"
+
+
 @dataclass
 class RunOutcome:
     status: str
     result: str
     reason: str | None
+    # 验证结论（VerificationOutcome 字符串值）；None 表示本 run 未执行验证。
+    # 与 status 正交：执行停止（status）与完成判定（verification）是两件事。
+    verification_status: str | None = None
 
 
 class AgentRunner:
@@ -426,8 +442,11 @@ class AgentRunner:
                 if not context.is_done():
                     context.mark_failed("llm_error")
 
+            changes: list[dict[str, Any]] = []
+            modification_status: str | None = None
             if change_tracker is not None:
                 changes = change_tracker.finalize()
+                modification_status = modification_status_summary(changes)
                 if changes:
                     await bus.publish(
                         ChangeAppliedEvent(
@@ -437,6 +456,53 @@ class AgentRunner:
                             ts=_now(),
                         )
                     )
+
+            # issue #94 验证门禁：end_turn 只代表执行停止，最终完成由 Harness 独立检查判定。
+            # 仅在显式开启且存在契约且 run 自称成功时执行；默认关闭，零回归。
+            # 不篡改 context.status 状态机，结论仅通过 verification_status 正交透传。
+            if (
+                self._config.agent.require_verification
+                and context.completion_contract is not None
+                and context.status == "success"
+            ):
+                await bus.publish(
+                    VerificationStartedEvent(
+                        run_id=run_id,
+                        condition_count=len(context.completion_contract.conditions),
+                        ts=_now(),
+                    )
+                )
+                verification_status: str
+                try:
+                    verification = await VerificationExecutor(
+                        change_workspace_root or project_root,
+                        run_path,
+                        check_timeout_s=self._config.agent.verification_check_timeout_s,
+                    ).verify(
+                        context.completion_contract,
+                        # 证据快照：finalize 后 manifest 中变更文件的 after_digest
+                        workspace_digests={
+                            str(record["path"]): str(record["after_digest"])
+                            for record in changes
+                            if record.get("after_digest")
+                        },
+                    )
+                    verification_status = verification.overall.value
+                except asyncio.CancelledError:
+                    # 保持取消语义：直接向上抛，由外层统一处理
+                    raise
+                except Exception:
+                    logging.getLogger(__name__).exception(
+                        "verification executor crashed run_id=%s", run_id
+                    )
+                    verification_status = VerificationOutcome.UNVERIFIED.value
+                context.verification_status = verification_status
+                await bus.publish(
+                    VerificationFinishedEvent(
+                        run_id=run_id, outcome=verification_status, ts=_now()
+                    )
+                )
+
             if compactor is not None:
                 await compactor.wait_pending(cancel_pending=cancelled)
             if session is not None and store is not None:
@@ -465,6 +531,8 @@ class AgentRunner:
                     cache_read_input_tokens=final_stats.cache_read_input_tokens,
                     elapsed_s=final_stats.elapsed_s,
                     context_pct=final_stats.context_pct,
+                    verification_status=context.verification_status,
+                    modification_status=modification_status,
                     ts=_now(),
                 )
             )
@@ -490,4 +558,5 @@ class AgentRunner:
             status=context.status,
             result=context.result,
             reason=context.reason,
+            verification_status=context.verification_status,
         )

--- a/src/sztu_code/core/verification/__init__.py
+++ b/src/sztu_code/core/verification/__init__.py
@@ -1,4 +1,5 @@
-# 完成契约与独立验证的纯数据模型层（issue #94 第一阶段）
+# 完成契约与独立验证：数据模型（issue #94 第一阶段）+ 验证执行器（第二阶段）
+from sztu_code.core.verification.executor import VerificationExecutor, aggregate_outcomes
 from sztu_code.core.verification.models import (
     CompletionCondition,
     CompletionContract,
@@ -17,6 +18,8 @@ __all__ = [
     "ContractSource",
     "Evidence",
     "EvidenceKind",
+    "VerificationExecutor",
     "VerificationOutcome",
     "VerificationResult",
+    "aggregate_outcomes",
 ]

--- a/src/sztu_code/core/verification/executor.py
+++ b/src/sztu_code/core/verification/executor.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+from sztu_code.core.verification.models import (
+    CompletionCondition,
+    CompletionContract,
+    ConditionResult,
+    Evidence,
+    EvidenceKind,
+    VerificationOutcome,
+    VerificationResult,
+)
+
+# 落盘文件名只保留安全字符，防止 condition.id 携带路径分隔符逃逸出 verification/ 目录
+_SAFE_ID_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _safe_filename(condition_id: str) -> str:
+    return _SAFE_ID_RE.sub("_", condition_id) or "condition"
+
+
+# 将各条件结论聚合为 run 级结论（纯函数，便于单测）：
+# - 任一 required 条件 failed → failed
+# - 无任何条件产生通过证据（全部 unverified/env_blocked，或契约为空）→ unverified
+# - 全部 required 条件 verified → verified（可选条件不阻塞整体结论）
+# - 其余（required 中存在 unverified/env_blocked）→ 最多 partial
+# env_blocked 不算失败也不算通过：环境受限不应把 run 判死，但也不构成完成证据
+def aggregate_outcomes(
+    conditions: list[CompletionCondition],
+    results: list[ConditionResult],
+) -> VerificationOutcome:
+    if not results:
+        return VerificationOutcome.UNVERIFIED
+    required_ids = {cond.id for cond in conditions if cond.required}
+    if any(
+        r.outcome is VerificationOutcome.FAILED and r.condition_id in required_ids
+        for r in results
+    ):
+        return VerificationOutcome.FAILED
+    if not any(r.outcome is VerificationOutcome.VERIFIED for r in results):
+        return VerificationOutcome.UNVERIFIED
+    required_results = [r for r in results if r.condition_id in required_ids]
+    if all(r.outcome is VerificationOutcome.VERIFIED for r in required_results):
+        return VerificationOutcome.VERIFIED
+    return VerificationOutcome.PARTIAL
+
+
+class VerificationExecutor:
+    """完成契约验证执行器（issue #94 分支 2）。
+
+    仿 evaluation/harness.py 的子进程验证模式：直接以 argv 形式执行
+    CompletionCondition.check_command，绕过 ToolRegistry 与权限系统——
+    验证是 Harness 的独立判定，不受 Agent 工具链干预。stdout/stderr 落盘
+    到 run_path/verification/<condition_id>.log，不内联大输出。
+    """
+
+    def __init__(
+        self,
+        workspace_root: Path,
+        run_path: Path,
+        *,
+        check_timeout_s: int = 60,
+    ) -> None:
+        self._workspace_root = workspace_root
+        self._output_dir = run_path / "verification"
+        self._check_timeout_s = check_timeout_s
+
+    # 按 priority 降序逐条检查并聚合为 VerificationResult
+    async def verify(
+        self,
+        contract: CompletionContract,
+        *,
+        workspace_digests: dict[str, str] | None = None,
+    ) -> VerificationResult:
+        digests = workspace_digests or {}
+        ordered = sorted(contract.conditions, key=lambda cond: -cond.priority)
+        results = [await self._check_condition(cond, digests) for cond in ordered]
+        return VerificationResult(
+            run_id=contract.run_id,
+            results=results,
+            overall=aggregate_outcomes(contract.conditions, results),
+            verified_at=_now(),
+        )
+
+    # 执行单条完成条件的检查命令，每条独立超时，超时 kill 进程并判 failed
+    async def _check_condition(
+        self,
+        condition: CompletionCondition,
+        digests: dict[str, str],
+    ) -> ConditionResult:
+        # 无检查命令：无法机器验证；required 条件会在聚合时把整体压到最多 partial
+        if not condition.check_command:
+            return ConditionResult(
+                condition_id=condition.id,
+                outcome=VerificationOutcome.UNVERIFIED,
+                message="no check_command; cannot verify automatically",
+            )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *condition.check_command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=str(self._workspace_root),
+            )
+        except OSError as exc:
+            # 命令无法启动（可执行文件缺失/权限不足等）：环境受限，不算失败也不算通过
+            return ConditionResult(
+                condition_id=condition.id,
+                outcome=VerificationOutcome.ENV_BLOCKED,
+                message=f"cannot start check command: {exc}",
+            )
+        timed_out = False
+        try:
+            stdout_bytes, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=self._check_timeout_s
+            )
+        except TimeoutError:
+            timed_out = True
+            proc.kill()
+            stdout_bytes, _ = await proc.communicate()
+        evidence = Evidence(
+            condition_id=condition.id,
+            kind=EvidenceKind.COMMAND_EXIT_CODE,
+            command=" ".join(condition.check_command),
+            exit_code=None if timed_out else proc.returncode,
+            output_path=self._write_output(condition.id, stdout_bytes),
+            workspace_digests=digests,
+            collected_at=_now(),
+        )
+        if timed_out:
+            return ConditionResult(
+                condition_id=condition.id,
+                outcome=VerificationOutcome.FAILED,
+                evidence=evidence,
+                message=f"check timed out after {self._check_timeout_s}s",
+            )
+        if proc.returncode == 0:
+            return ConditionResult(
+                condition_id=condition.id,
+                outcome=VerificationOutcome.VERIFIED,
+                evidence=evidence,
+            )
+        return ConditionResult(
+            condition_id=condition.id,
+            outcome=VerificationOutcome.FAILED,
+            evidence=evidence,
+            message=f"check command exited with code {proc.returncode}",
+        )
+
+    # 将命令输出落盘并返回路径字符串；写入失败时返回空串（证据仍保留退出码）
+    def _write_output(self, condition_id: str, data: bytes) -> str:
+        try:
+            self._output_dir.mkdir(parents=True, exist_ok=True)
+            path = self._output_dir / f"{_safe_filename(condition_id)}.log"
+            path.write_bytes(data)
+        except OSError:
+            return ""
+        return str(path)

--- a/tests/unit/test_verification_executor.py
+++ b/tests/unit/test_verification_executor.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from sztu_code.core.runner import modification_status_summary
+from sztu_code.core.verification import (
+    CompletionCondition,
+    CompletionContract,
+    ConditionResult,
+    ContractSource,
+    EvidenceKind,
+    VerificationExecutor,
+    VerificationOutcome,
+    aggregate_outcomes,
+)
+
+
+def _cond(
+    cid: str,
+    command: list[str] | None = None,
+    *,
+    required: bool = True,
+    priority: int = 0,
+) -> CompletionCondition:
+    return CompletionCondition(
+        id=cid,
+        description=cid,
+        source=ContractSource.USER,
+        check_command=command,
+        required=required,
+        priority=priority,
+    )
+
+
+def _contract(*conds: CompletionCondition) -> CompletionContract:
+    return CompletionContract(
+        run_id="run-1", conditions=list(conds), created_at="2026-08-19T00:00:00Z"
+    )
+
+
+def _result(cid: str, outcome: VerificationOutcome) -> ConditionResult:
+    return ConditionResult(condition_id=cid, outcome=outcome)
+
+
+def _executor(tmp_path: Path, *, timeout: int = 30) -> VerificationExecutor:
+    return VerificationExecutor(tmp_path, tmp_path / "run", check_timeout_s=timeout)
+
+
+# 功能：验证成功命令（退出码 0）产出 verified 条件结果与完整证据
+# 设计：用 sys.executable -c 保证跨平台；断言证据的退出码、落盘日志内容与摘要透传
+async def test_executor_success_command_yields_verified(tmp_path: Path) -> None:
+    contract = _contract(
+        _cond("c1", [sys.executable, "-c", "print('ok'); import sys; sys.exit(0)"])
+    )
+    result = await _executor(tmp_path).verify(
+        contract, workspace_digests={"a.txt": "abc123"}
+    )
+    assert result.overall is VerificationOutcome.VERIFIED
+    assert result.run_id == "run-1"
+    [cr] = result.results
+    assert cr.outcome is VerificationOutcome.VERIFIED
+    assert cr.evidence is not None
+    assert cr.evidence.kind is EvidenceKind.COMMAND_EXIT_CODE
+    assert cr.evidence.exit_code == 0
+    assert cr.evidence.workspace_digests == {"a.txt": "abc123"}
+    log = Path(cr.evidence.output_path)
+    assert log == tmp_path / "run" / "verification" / "c1.log"
+    assert "ok" in log.read_text(encoding="utf-8")
+
+
+# 功能：验证失败命令（非零退出码）产出 failed 条件结果，整体判 failed
+# 设计：required 条件退出码 7，断言证据保留真实退出码且 message 说明失败原因
+async def test_executor_failing_command_yields_failed(tmp_path: Path) -> None:
+    contract = _contract(_cond("c1", [sys.executable, "-c", "import sys; sys.exit(7)"]))
+    result = await _executor(tmp_path).verify(contract)
+    assert result.overall is VerificationOutcome.FAILED
+    [cr] = result.results
+    assert cr.outcome is VerificationOutcome.FAILED
+    assert cr.evidence is not None
+    assert cr.evidence.exit_code == 7
+    assert "exited with code 7" in cr.message
+
+
+# 功能：验证超时的检查命令被 kill 并判 failed，证据退出码为 None
+# 设计：睡眠 30s 的命令配 1s 超时，断言 message 标注超时且整体 failed
+async def test_executor_timeout_kills_process_and_fails(tmp_path: Path) -> None:
+    contract = _contract(_cond("c1", [sys.executable, "-c", "import time; time.sleep(30)"]))
+    result = await _executor(tmp_path, timeout=1).verify(contract)
+    assert result.overall is VerificationOutcome.FAILED
+    [cr] = result.results
+    assert cr.outcome is VerificationOutcome.FAILED
+    assert cr.evidence is not None
+    assert cr.evidence.exit_code is None
+    assert "timed out after 1s" in cr.message
+
+
+# 功能：验证不存在的可执行文件判 env_blocked，且不算失败也不算通过
+# 设计：单条 env_blocked 时整体 unverified（无任何通过证据）；与 verified 条件共存时整体 partial
+async def test_executor_missing_executable_is_env_blocked(tmp_path: Path) -> None:
+    contract = _contract(_cond("c1", ["sztu-definitely-missing-exe-94"]))
+    result = await _executor(tmp_path).verify(contract)
+    [cr] = result.results
+    assert cr.outcome is VerificationOutcome.ENV_BLOCKED
+    assert cr.evidence is None
+    assert "cannot start check command" in cr.message
+    assert result.overall is VerificationOutcome.UNVERIFIED
+
+    mixed = _contract(
+        _cond("ok", [sys.executable, "-c", "raise SystemExit(0)"]),
+        _cond("blocked", ["sztu-definitely-missing-exe-94"]),
+    )
+    assert (await _executor(tmp_path).verify(mixed)).overall is VerificationOutcome.PARTIAL
+
+
+# 功能：验证 check_command=None 的条件判 unverified；required 无法验证时整体最多 partial
+# 设计：纯 None 契约整体 unverified；None+verified 混合契约整体 partial
+async def test_executor_none_command_is_unverified(tmp_path: Path) -> None:
+    result = await _executor(tmp_path).verify(_contract(_cond("c1")))
+    [cr] = result.results
+    assert cr.outcome is VerificationOutcome.UNVERIFIED
+    assert "no check_command" in cr.message
+    assert result.overall is VerificationOutcome.UNVERIFIED
+
+    mixed = _contract(
+        _cond("manual"),
+        _cond("auto", [sys.executable, "-c", "raise SystemExit(0)"]),
+    )
+    assert (await _executor(tmp_path).verify(mixed)).overall is VerificationOutcome.PARTIAL
+
+
+# 功能：验证条件按 priority 降序执行，落盘文件名对非法字符做净化
+# 设计：低优先级条件放前面，断言结果顺序反转；条件 id 带路径分隔符仍落在 verification/ 内
+async def test_executor_priority_order_and_safe_log_name(tmp_path: Path) -> None:
+    ok = [sys.executable, "-c", "raise SystemExit(0)"]
+    contract = _contract(
+        _cond("low", ok, priority=0),
+        _cond("high../x", ok, priority=10),
+    )
+    result = await _executor(tmp_path).verify(contract)
+    assert [cr.condition_id for cr in result.results] == ["high../x", "low"]
+    evidence = result.results[0].evidence
+    assert evidence is not None
+    log = Path(evidence.output_path)
+    assert log.parent == tmp_path / "run" / "verification"
+    assert log.exists()
+
+
+# 功能：验证聚合纯函数的全部分支（failed/verified/partial/unverified 与 required/optional 组合）
+# 设计：直接构造 ConditionResult 列表覆盖每条聚合规则，不启动任何子进程
+def test_aggregate_outcomes_branches() -> None:
+    v, f = VerificationOutcome.VERIFIED, VerificationOutcome.FAILED
+    u, e = VerificationOutcome.UNVERIFIED, VerificationOutcome.ENV_BLOCKED
+    req, opt = _cond("req"), _cond("opt", required=False)
+
+    # 空契约 → unverified
+    assert aggregate_outcomes([], []) is VerificationOutcome.UNVERIFIED
+    # required 失败 → failed（即使其余全通过）
+    assert (
+        aggregate_outcomes([req, opt], [_result("req", f), _result("opt", v)])
+        is VerificationOutcome.FAILED
+    )
+    # optional 失败不阻塞：全部 required 通过 → verified
+    assert (
+        aggregate_outcomes([req, opt], [_result("req", v), _result("opt", f)])
+        is VerificationOutcome.VERIFIED
+    )
+    # 全部 required 通过 → verified
+    assert aggregate_outcomes([req], [_result("req", v)]) is VerificationOutcome.VERIFIED
+    # required unverified + 其他通过 → 最多 partial
+    other = _cond("other")
+    assert (
+        aggregate_outcomes([req, other], [_result("req", u), _result("other", v)])
+        is VerificationOutcome.PARTIAL
+    )
+    # required env_blocked：不算失败但不算通过 → partial
+    assert (
+        aggregate_outcomes([req, other], [_result("req", e), _result("other", v)])
+        is VerificationOutcome.PARTIAL
+    )
+    # 无任何通过证据（全部 env_blocked/unverified）→ unverified
+    assert (
+        aggregate_outcomes([req, other], [_result("req", e), _result("other", u)])
+        is VerificationOutcome.UNVERIFIED
+    )
+
+
+# 功能：验证 modification_status_summary 摘要规则（None 透传 / 空记录 clean / 有记录 modified:N）
+# 设计：runner 门禁的纯函数拆分单测，避免依赖挂起的 test_runner 场景
+def test_modification_status_summary() -> None:
+    assert modification_status_summary(None) is None
+    assert modification_status_summary([]) == "clean"
+    assert modification_status_summary([{"path": "a"}, {"path": "b"}]) == "modified:2"


### PR DESCRIPTION
## Summary

issue #94 的第二阶段：在 Harness（AgentRunner）侧落地**验证门禁**——run 自称成功后，不再直接采信，而是运行完成契约中的真实检查命令，用退出码决定 `verification_status`。这是整个 Epic 的核心机制：`end_turn` 只代表执行停止，最终完成与否由 Harness 的独立检查判定。

设计要点：

1. 独立性：新增 `VerificationExecutor` 仿 `evaluation/harness.py` 的子进程验证模式，以 argv 形式直接 `create_subprocess_exec` 执行检查命令（无 shell），**绕过 ToolRegistry 与权限系统**——验证是 Harness 的独立判定，不受 Agent 工具链干预或篡改。
2. 正交性：不篡改 `context.status` 状态机，验证结论仅通过 `verification_status` 字段正交透传（context → RunOutcome → RunFinishedEvent）。
3. 默认关闭：门禁由 `agent.require_verification`（第 1 层引入，默认 False）守卫，且需契约存在、run 自称成功三个条件同时满足才触发，默认路径零回归。

## Behavior

- 新增 `src/sztu_code/core/verification/executor.py`：
  - `VerificationExecutor.verify()` 按 priority 降序逐条执行 `CompletionCondition.check_command`，每条独立超时（`agent.verification_check_timeout_s`，默认 60s），超时 kill 进程并判 failed；命令无法启动（OSError，如可执行文件缺失）判 env_blocked——环境受限不把 run 判死，但也不构成完成证据；
  - stdout/stderr 合流落盘到 `run_path/verification/<condition_id>.log`（文件名经安全字符过滤，防止 condition.id 携带路径分隔符逃逸目录），不内联大输出；写盘失败证据仍保留退出码；
  - 纯函数 `aggregate_outcomes` 聚合 run 级结论：任一 required 条件 failed → failed；无任何通过证据 → unverified；全部 required 条件 verified → verified（可选条件不阻塞）；其余 → partial。
- `core/runner.py`：
  - 在 change_tracker.finalize() 之后、RunFinishedEvent 发布之前插入门禁块：仅当 `require_verification=True` 且 `context.completion_contract is not None` 且 `context.status == "success"` 时执行；发布 `VerificationStartedEvent` / `VerificationFinishedEvent`（第 1 层已定义，本层开始实际发布）；
  - 证据快照携带 finalize 后变更文件的 after_digest（复用 `core/changes.py` 的 sha256 结果），为第 4 层的陈旧证据检测铺路；
  - 取消语义保留：`asyncio.CancelledError` 直接向上抛，由外层统一处理；执行器自身崩溃记 exception 日志并把结论落为 unverified——**任何异常路径都不会伪装成 verified**；
  - `verification_status` 写入 `context`、透传到 `RunOutcome`（新增字段）与 `RunFinishedEvent`；
  - 新增纯函数 `modification_status_summary`：基于 finalize 记录生成工作区修改状态摘要（`modified:<n>` / `clean` / None=未启用追踪），填充 `RunFinishedEvent.modification_status`。

注意边界：本层不含契约构建逻辑——`context.completion_contract` 只能由调用方以编程方式注入（单测即如此驱动），从用户配置与项目画像**自动发现**契约是第 3 层的内容。因此本层合入后，普通用户即使打开 `require_verification` 也不会有可感知变化（无契约则门禁不触发）。

## Validation

本系列（四个堆叠 PR）仅改动 Python 运行时（`src/sztu_code/core/`）与 Python 单测，不触及 packages/（TS 协议包）、desktop/ 与 docs/reference/wire-protocol.md（该文档现由 TS 侧生成），因此未运行 npm run typecheck / npm test / npm run build / npm run docs:protocol / npm run docs:links——无 TS 产物变化。

实际运行的检查（环境：Windows 11 + Python 3.12 + uv；分支基于 origin/main = 9404504）：

```text
# 仅本层针对性测试（本 PR 新增 tests/unit/test_verification_executor.py）
uv run pytest tests/unit/test_verification_executor.py -q
→ 8 passed
  （覆盖：退出码 0/非 0、超时 kill、OSError→env_blocked、输出落盘与文件名安全过滤、
   aggregate_outcomes 各分支、runner 门禁触发/不触发与事件发布）

# 静态检查（在四层叠加末端 feat/94-repair-loop = 90bb52f 测得）
uv run mypy src
→ Success: no issues found in 203 source files
uv run ruff check src tests
→ 仅 1 个既有 F401（tests/unit/test_tool_retry.py:277，上游遗留，本系列零改动）

# 全量单测（四层叠加末端 vs 裸 origin/main 基线）
uv run pytest tests/unit -q
→ 四层叠加：7 failed / 1017 passed
→ 裸 origin/main = 9404504 基线：7 failed / 988 passed
→ 失败集合逐项比对完全相同，零新增失败；+29 全部为本系列新增单测（第 2/3/4 层各 8+9+12 个；第 1 层 7 个已随 #112 计入 main 基线）
```

注：TypeScript CI 中 packages/runtime-ts/tests/npm-package.test.ts 的 subtest 19/20（npm entry daemon / --version）为 main 既有失败：该 workflow 自 #106 引入以来在 main 上从未通过，根因是 npm/sztucode-tui/scripts/install.js 在 Linux 上通过 node 执行 esbuild 的原生 ELF 二进制。本 PR 不触及 npm/、packages/runtime-ts/ 或 CI 配置，与该失败无关。

## Risk

- 兼容性：`require_verification` 默认 False，门禁块整体不执行，默认路径与前置层行为完全一致（零回归，全量回归失败集合与基线逐项比对零差异）。`RunOutcome` 新增字段带默认值 None，既有调用方不受影响。
- 安全：VerificationExecutor 以 argv 直接执行契约中的命令、绕过权限系统。本层契约只能由代码显式注入（无用户可达路径）；第 3 层引入用户配置来源时，命令来自用户自己声明的 checks.toml 或项目画像，均为用户自身权限内的本地检查命令，无提权面；执行无 shell，不存在注入拼接。
- 性能：门禁串行执行检查命令，run 结束延迟增加取决于检查耗时，且每条有超时上限；默认关闭时零开销。
- 协议同步（延续第 1 层声明）：verification.started / verification.finished 事件与 RunFinishedEvent 新字段尚未同步进 TS protocol 包，属后续工作。
- 回滚方式：单 commit（783ae94），直接 revert；或运行时置 `require_verification=false` 即完全绕开本层逻辑。
- 剩余风险：超时判 failed（而非 env_blocked）是刻意选择——检查跑不完视为未通过，宁可保守；若个别项目检查天然超 60s，可通过 `verification_check_timeout_s` 调大。

## UI evidence

N/A（Harness 内部门禁逻辑，无 TUI/桌面端视觉变化）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试（新增 tests/unit/test_verification_executor.py，8 个用例）。
- [ ] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A-声明：该文档现由 TS 侧生成，本系列不触碰 TS 侧；事件与字段同步进 TS protocol 包属后续工作，已在 Risk 中声明）
- [ ] 用户文档、配置示例和迁移说明已同步。（N/A：本层无用户可达的行为变化——契约发现在第 3 层；配置文档将在第 3 层合入后一并补充）
- [x] 提交包含 `Signed-off-by`（DCO）。
