### PR TITLE
feat(verification): discover completion checks from user config and project profile (Part of #94)

### DIFF
--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -58,10 +58,12 @@ from sztu_code.core.tools.builtin import (
 from sztu_code.core.tools.registry import ToolRegistry
 from sztu_code.core.trace.provider import TracingProvider
 from sztu_code.core.trace.writer import TraceWriter
+from sztu_code.core.verification.discovery import build_completion_contract
 from sztu_code.core.verification.executor import VerificationExecutor
 from sztu_code.core.verification.models import VerificationOutcome
 from sztu_code.core.workflow.tool import WorkflowRunTool
 from sztu_code.core.workspace.project_profile import (
+    ProjectProfile,
     detect_project_profile,
     render_project_profile_context,
 )
@@ -248,6 +250,7 @@ class AgentRunner:
 
         project_root = workspace_root or Path.cwd()
         project_profile_context = ""
+        profile: ProjectProfile | None = None
         try:
             project_root = project_root.resolve()
             profile = detect_project_profile(project_root)
@@ -315,6 +318,18 @@ class AgentRunner:
             max_tokens=0,
             max_wall_clock_s=self._config.budget.max_wall_clock_s,
         )
+        # issue #94 分支 3：门禁开启且尚无契约时，从用户声明/项目画像构建完成契约。
+        # profile 探测失败时仅尝试用户声明来源；构建失败不炸 run，契约保持 None，
+        # 门禁自然不触发。require_verification=False 时完全不调用（零回归）。
+        if self._config.agent.require_verification and context.completion_contract is None:
+            try:
+                context.completion_contract = build_completion_contract(
+                    run_id, profile, project_root
+                )
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "completion contract discovery failed run_id=%s", run_id, exc_info=True
+                )
         prefill_len = len(history)
         compactor = None  # 在 try 块外初始化，避免 UnboundLocalError
 

--- a/src/sztu_code/core/verification/__init__.py
+++ b/src/sztu_code/core/verification/__init__.py
@@ -1,4 +1,8 @@
-# 完成契约与独立验证：数据模型（issue #94 第一阶段）+ 验证执行器（第二阶段）
+# 完成契约与独立验证：数据模型（issue #94 第一阶段）+ 验证执行器（第二阶段）+ 检查发现（第三阶段）
+from sztu_code.core.verification.discovery import (
+    build_completion_contract,
+    select_relevant_checks,
+)
 from sztu_code.core.verification.executor import VerificationExecutor, aggregate_outcomes
 from sztu_code.core.verification.models import (
     CompletionCondition,
@@ -22,4 +26,6 @@ __all__ = [
     "VerificationOutcome",
     "VerificationResult",
     "aggregate_outcomes",
+    "build_completion_contract",
+    "select_relevant_checks",
 ]

--- a/src/sztu_code/core/verification/discovery.py
+++ b/src/sztu_code/core/verification/discovery.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sztu_code.core.verification.models import (
+    CompletionCondition,
+    CompletionContract,
+    ContractSource,
+)
+from sztu_code.core.workspace.project_profile import ProjectProfile, ValidationCategory
+
+logger = logging.getLogger(__name__)
+
+# 用户声明的检查清单文件（相对工作区根）。格式：
+# [[check]]
+# id = "unit-tests"                                      # 可选，缺省生成 user-<n>
+# description = "运行单元测试"                             # 可选，缺省用命令拼接
+# command = ["uv", "run", "pytest", "tests/unit", "-q"]  # argv 数组，必填
+# required = true                                        # 可选，默认 true
+# priority = 0                                           # 可选，默认 0
+CHECKS_FILE = Path(".sztu") / "checks.toml"
+
+# 含 shell 语法的命令无法安全转为 argv（执行器以 create_subprocess_exec 直接执行，无 shell）
+_SHELL_SYNTAX_RE = re.compile(r"[&|;<>`$\n]")
+
+# 门禁类别策略：类别 → (required, priority)。未列出的类别不纳入契约。
+# 规则详见 select_relevant_checks docstring。
+_CATEGORY_POLICY: dict[ValidationCategory, tuple[bool, int]] = {
+    ValidationCategory.STATIC_CHECK: (True, 20),
+    ValidationCategory.UNIT_TEST: (True, 10),
+    ValidationCategory.FORMAT: (False, 0),
+}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# 构建一次 run 的完成契约（issue #94 分支 3：检查发现与契约构建）
+def build_completion_contract(
+    run_id: str,
+    profile: ProjectProfile | None,
+    workspace_root: Path,
+) -> CompletionContract | None:
+    """按来源优先级构建完成契约；两个来源都为空时返回 None（门禁自然不触发）。
+
+    来源优先级：
+    1. 用户声明（source=USER）：workspace_root/.sztu/checks.toml 存在且解析出
+       至少一条合法条件时独占生效，不再混入项目画像来源；
+    2. 项目画像（source=PROJECT_CONFIG）：profile 的 validation_plan 经
+       select_relevant_checks 过滤转换。profile 为 None（探测失败）时跳过。
+    checks.toml 解析失败（TOML 语法错误或任一条目字段非法）记 warning 并整体
+    忽略该文件、回落项目画像——坏配置不炸掉 run。最终条件按 argv 去重
+    （相同命令只保留首条）并按 priority 降序稳定排序。
+    """
+    conditions = _load_user_checks(workspace_root)
+    if not conditions and profile is not None:
+        conditions = select_relevant_checks(profile)
+    conditions = _dedup_and_sort(conditions)
+    if not conditions:
+        return None
+    return CompletionContract(run_id=run_id, conditions=conditions, created_at=_now())
+
+
+# 从项目画像的验证建议中筛选适合门禁的检查并转为完成条件
+def select_relevant_checks(profile: ProjectProfile) -> list[CompletionCondition]:
+    """类别过滤规则（保守、快速优先）：
+
+    - STATIC_CHECK：required=True，priority=20（静态检查快，先跑先失败）；
+    - UNIT_TEST：required=True，priority=10；
+    - FORMAT：required=False，priority=0（格式偏差不应阻塞完成判定）；
+    - INTEGRATION_TEST / BUILD：整体跳过——耗时长、常依赖外部环境或凭据，
+      作为默认门禁过于激进；需要时用户可在 checks.toml 中显式声明。
+    额外跳过（记 debug 日志）：
+    - working_directory 不是工作区根（"." 以外）：执行器固定在根目录执行，
+      无法安全表达子目录 cwd；
+    - 命令含 shell 语法（& | ; < > ` $）或无法 shlex 拆分：无法安全转 argv。
+    id 生成规则稳定：profile-<category>-<n>，n 为该类别内的出现序号。
+    """
+    conditions: list[CompletionCondition] = []
+    counters: dict[ValidationCategory, int] = {}
+    for component in profile.projects:
+        for item in component.validation_plan:
+            policy = _CATEGORY_POLICY.get(item.category)
+            if policy is None:
+                logger.debug(
+                    "skipping non-gating category %s: %s", item.category.value, item.command
+                )
+                continue
+            if item.working_directory not in ("", "."):
+                logger.debug(
+                    "skipping command outside workspace root (%s): %s",
+                    item.working_directory,
+                    item.command,
+                )
+                continue
+            argv = _to_argv(item.command)
+            if argv is None:
+                logger.debug("skipping command not convertible to argv: %s", item.command)
+                continue
+            required, priority = policy
+            counters[item.category] = counters.get(item.category, 0) + 1
+            conditions.append(
+                CompletionCondition(
+                    id=(
+                        f"profile-{item.category.value.replace('_', '-')}"
+                        f"-{counters[item.category]}"
+                    ),
+                    description=item.reason or item.command,
+                    source=ContractSource.PROJECT_CONFIG,
+                    check_command=argv,
+                    required=required,
+                    priority=priority,
+                )
+            )
+    return conditions
+
+
+# 读取并解析用户声明的 checks.toml；文件缺失返回空列表，解析失败记 warning 并整体忽略
+def _load_user_checks(workspace_root: Path) -> list[CompletionCondition]:
+    path = workspace_root / CHECKS_FILE
+    if not path.is_file():
+        return []
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        return _parse_user_checks(data)
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, ValueError) as error:
+        logger.warning("ignoring invalid checks file %s: %s", path, error)
+        return []
+
+
+# 将 checks.toml 数据转为条件列表；任一条目字段非法抛 ValueError（由调用方整体忽略）
+def _parse_user_checks(data: dict[str, Any]) -> list[CompletionCondition]:
+    entries = data.get("check", [])
+    if not isinstance(entries, list):
+        raise ValueError("[[check]] must be an array of tables")
+    conditions: list[CompletionCondition] = []
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"check #{index} must be a table")
+        command = entry.get("command")
+        if (
+            not isinstance(command, list)
+            or not command
+            or not all(isinstance(part, str) and part for part in command)
+        ):
+            raise ValueError(f"check #{index}: command must be a non-empty array of strings")
+        condition_id = entry.get("id", f"user-{index}")
+        if not isinstance(condition_id, str) or not condition_id:
+            raise ValueError(f"check #{index}: id must be a non-empty string")
+        description = entry.get("description", " ".join(command))
+        if not isinstance(description, str):
+            raise ValueError(f"check #{index}: description must be a string")
+        required = entry.get("required", True)
+        if not isinstance(required, bool):
+            raise ValueError(f"check #{index}: required must be a boolean")
+        priority = entry.get("priority", 0)
+        if isinstance(priority, bool) or not isinstance(priority, int):
+            raise ValueError(f"check #{index}: priority must be an integer")
+        conditions.append(
+            CompletionCondition(
+                id=condition_id,
+                description=description,
+                source=ContractSource.USER,
+                check_command=list(command),
+                required=required,
+                priority=priority,
+            )
+        )
+    return conditions
+
+
+# 将命令字符串安全转为 argv；含 shell 语法或拆分失败返回 None
+def _to_argv(command: str) -> list[str] | None:
+    if _SHELL_SYNTAX_RE.search(command):
+        return None
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        return None
+    return argv or None
+
+
+# 按 argv 去重（保留首条）并按 priority 降序稳定排序
+def _dedup_and_sort(conditions: list[CompletionCondition]) -> list[CompletionCondition]:
+    unique: list[CompletionCondition] = []
+    seen: set[tuple[str, ...]] = set()
+    for cond in conditions:
+        key = tuple(cond.check_command or ())
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(cond)
+    return sorted(unique, key=lambda cond: -cond.priority)

--- a/tests/unit/test_verification_discovery.py
+++ b/tests/unit/test_verification_discovery.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sztu_code.core.verification import (
+    ContractSource,
+    build_completion_contract,
+    select_relevant_checks,
+)
+from sztu_code.core.workspace.project_profile import (
+    ProjectComponent,
+    ProjectProfile,
+    ValidationCategory,
+    ValidationCommand,
+)
+
+
+def _write_checks(workspace: Path, content: str) -> None:
+    checks_dir = workspace / ".sztu"
+    checks_dir.mkdir(parents=True, exist_ok=True)
+    (checks_dir / "checks.toml").write_text(content, encoding="utf-8")
+
+
+def _vc(
+    category: ValidationCategory,
+    command: str,
+    *,
+    working_directory: str = ".",
+    reason: str = "",
+) -> ValidationCommand:
+    return ValidationCommand(
+        category=category,
+        command=command,
+        working_directory=working_directory,
+        reason=reason or f"reason for {command}",
+    )
+
+
+def _profile(*commands: ValidationCommand) -> ProjectProfile:
+    return ProjectProfile(
+        projects=[ProjectComponent(path=".", validation_plan=list(commands))]
+    )
+
+
+# 功能：合法 checks.toml 独占生效，字段解析正确且 user 条件优先于 profile 来源
+# 设计：文件与 profile 同时存在，断言只产出 USER 条件；覆盖显式/缺省 id、
+# description、required、priority 各字段的解析与默认值
+def test_user_checks_take_precedence_and_parse_fields(tmp_path: Path) -> None:
+    _write_checks(
+        tmp_path,
+        """
+[[check]]
+id = "unit-tests"
+description = "运行单元测试"
+command = ["uv", "run", "pytest", "tests/unit", "-q"]
+required = true
+priority = 5
+
+[[check]]
+command = ["ruff", "check", "."]
+required = false
+""",
+    )
+    profile = _profile(_vc(ValidationCategory.UNIT_TEST, "uv run pytest"))
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    assert contract.run_id == "run-1"
+    assert all(cond.source is ContractSource.USER for cond in contract.conditions)
+    first, second = contract.conditions
+    # priority 降序：显式 priority=5 的排前
+    assert first.id == "unit-tests"
+    assert first.description == "运行单元测试"
+    assert first.check_command == ["uv", "run", "pytest", "tests/unit", "-q"]
+    assert first.required is True
+    assert first.priority == 5
+    # 缺省字段：id 自动生成、description 回落命令拼接、priority=0
+    assert second.id == "user-2"
+    assert second.description == "ruff check ."
+    assert second.required is False
+    assert second.priority == 0
+
+
+# 功能：checks.toml TOML 语法错误时整体忽略并回落 profile 来源
+# 设计：写入非法 TOML，断言产出 PROJECT_CONFIG 条件且记 warning 日志
+def test_invalid_toml_falls_back_to_profile(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write_checks(tmp_path, "[[check]\ncommand = broken")
+    profile = _profile(_vc(ValidationCategory.UNIT_TEST, "uv run pytest"))
+    with caplog.at_level("WARNING"):
+        contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    [cond] = contract.conditions
+    assert cond.source is ContractSource.PROJECT_CONFIG
+    assert any("ignoring invalid checks file" in rec.message for rec in caplog.records)
+
+
+# 功能：checks.toml 条目字段非法（command 非数组）时整体忽略并回落 profile
+# 设计：TOML 语法合法但 schema 非法——部分合法条目也不生效，避免静默丢弃用户检查
+def test_invalid_schema_falls_back_to_profile(tmp_path: Path) -> None:
+    _write_checks(
+        tmp_path,
+        """
+[[check]]
+command = ["ok", "entry"]
+
+[[check]]
+command = "not an array"
+""",
+    )
+    profile = _profile(_vc(ValidationCategory.STATIC_CHECK, "uv run ruff check ."))
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    [cond] = contract.conditions
+    assert cond.source is ContractSource.PROJECT_CONFIG
+
+
+# 功能：无 checks.toml 时 profile 转换的类别过滤规则与 argv 转换
+# 设计：构造覆盖全部 5 个类别的最小 profile（不依赖真实文件探测，跨平台稳定）；
+# 断言 STATIC_CHECK/UNIT_TEST required、FORMAT 可选、INTEGRATION_TEST/BUILD 跳过
+def test_profile_category_filtering_and_conversion(tmp_path: Path) -> None:
+    profile = _profile(
+        _vc(ValidationCategory.FORMAT, "uv run ruff format --check ."),
+        _vc(ValidationCategory.STATIC_CHECK, "uv run ruff check ."),
+        _vc(ValidationCategory.UNIT_TEST, "uv run pytest"),
+        _vc(ValidationCategory.INTEGRATION_TEST, "uv run pytest tests/integration"),
+        _vc(ValidationCategory.BUILD, "uv build"),
+    )
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    by_id = {cond.id: cond for cond in contract.conditions}
+    assert set(by_id) == {"profile-static-check-1", "profile-unit-test-1", "profile-format-1"}
+    static = by_id["profile-static-check-1"]
+    assert static.source is ContractSource.PROJECT_CONFIG
+    assert static.check_command == ["uv", "run", "ruff", "check", "."]
+    assert static.required is True
+    unit = by_id["profile-unit-test-1"]
+    assert unit.check_command == ["uv", "run", "pytest"]
+    assert unit.required is True
+    fmt = by_id["profile-format-1"]
+    assert fmt.required is False
+    # priority 降序：static_check > unit_test > format
+    assert [c.id for c in contract.conditions] == [
+        "profile-static-check-1",
+        "profile-unit-test-1",
+        "profile-format-1",
+    ]
+
+
+# 功能：含 shell 语法的命令与子目录 working_directory 的命令被跳过
+# 设计：&& 串联命令无法安全转 argv；执行器固定在工作区根执行，子目录命令不可表达
+def test_profile_skips_shell_syntax_and_subdirectory_commands(tmp_path: Path) -> None:
+    profile = _profile(
+        _vc(ValidationCategory.UNIT_TEST, "cmake -S . -B build && cmake --build build"),
+        _vc(ValidationCategory.UNIT_TEST, "uv run pytest", working_directory="packages/api"),
+        _vc(ValidationCategory.UNIT_TEST, "uv run pytest"),
+    )
+    conditions = select_relevant_checks(profile)
+    assert len(conditions) == 1
+    # id 序号按类别内出现顺序计数，前两条被跳过不占号后仍保持稳定
+    assert conditions[0].id == "profile-unit-test-1"
+    assert conditions[0].check_command == ["uv", "run", "pytest"]
+
+
+# 功能：相同 argv 去重（只保留首条）与 priority 降序稳定排序
+# 设计：user 来源写两条相同命令 + 不同 priority 的第三条，断言去重与排序结果
+def test_dedup_and_priority_sort(tmp_path: Path) -> None:
+    _write_checks(
+        tmp_path,
+        """
+[[check]]
+id = "a"
+command = ["uv", "run", "pytest"]
+
+[[check]]
+id = "duplicate"
+command = ["uv", "run", "pytest"]
+
+[[check]]
+id = "b"
+command = ["ruff", "check", "."]
+priority = 10
+""",
+    )
+    contract = build_completion_contract("run-1", None, tmp_path)
+    assert contract is not None
+    assert [cond.id for cond in contract.conditions] == ["b", "a"]
+
+
+# 功能：两来源皆空时返回 None（门禁自然不触发）
+# 设计：覆盖三种空场景——无文件且 profile=None、profile 仅含跳过类别、
+# checks.toml 合法但条目为空（回落 profile 后仍为空）
+def test_empty_sources_return_none(tmp_path: Path) -> None:
+    assert build_completion_contract("run-1", None, tmp_path) is None
+
+    skipped_only = _profile(
+        _vc(ValidationCategory.BUILD, "uv build"),
+        _vc(ValidationCategory.INTEGRATION_TEST, "uv run pytest tests/integration"),
+    )
+    assert build_completion_contract("run-1", skipped_only, tmp_path) is None
+
+    _write_checks(tmp_path, "# 没有任何 [[check]] 条目\n")
+    assert build_completion_contract("run-1", None, tmp_path) is None
+
+
+# 功能：checks.toml 合法但条目为空时回落 profile 来源
+# 设计：空文件不视为"用户显式声明无检查"，保守回落项目画像
+def test_empty_checks_file_falls_back_to_profile(tmp_path: Path) -> None:
+    _write_checks(tmp_path, "")
+    profile = _profile(_vc(ValidationCategory.UNIT_TEST, "uv run pytest"))
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    [cond] = contract.conditions
+    assert cond.source is ContractSource.PROJECT_CONFIG
+
+
+# 功能：多组件 monorepo 画像中各组件的根目录命令均被收集且 id 序号跨组件连续
+# 设计：两个组件各带一条根目录 UNIT_TEST 命令，断言 id 稳定递增、无冲突
+def test_profile_multiple_components_stable_ids(tmp_path: Path) -> None:
+    profile = ProjectProfile(
+        monorepo=True,
+        projects=[
+            ProjectComponent(
+                path=".",
+                validation_plan=[_vc(ValidationCategory.UNIT_TEST, "uv run pytest")],
+            ),
+            ProjectComponent(
+                path="tools",
+                validation_plan=[_vc(ValidationCategory.UNIT_TEST, "npm test")],
+            ),
+        ],
+    )
+    conditions = select_relevant_checks(profile)
+    assert [cond.id for cond in conditions] == ["profile-unit-test-1", "profile-unit-test-2"]
+    assert conditions[1].check_command == ["npm", "test"]


### PR DESCRIPTION
## Summary

issue #94 的第三阶段：**契约发现**——补上"检查项从哪来"这块拼图。第 2 层的验证门禁需要 `context.completion_contract` 才会触发，但此前契约只能由代码显式注入；本层让 runner 在门禁开启且尚无契约时，自动从两个来源构建完成契约：

1. 用户显式声明（source=user）：工作区根的 `.sztu/checks.toml`，存在且解析出至少一条合法条件时**独占生效**，不再混入其他来源——用户说了算；
2. 项目画像（source=project_config）：复用既有的 `detect_project_profile` 探测结果，把 `ProjectProfile` 的 validation_plan 经保守过滤转换为完成条件。

本层合入后，`require_verification=true` 才真正对普通用户可用：打开开关即可获得基于项目自身检查命令的完成验证。默认仍关闭，零回归。

## Behavior

- 新增 `src/sztu_code/core/verification/discovery.py`：
  - `build_completion_contract(run_id, profile, workspace_root)`：先读用户声明，为空再回落项目画像；两来源合并后按 argv 去重（相同命令保留首条）、按 priority 降序稳定排序；无任何条件时返回 None（门禁自然不触发）；
  - `.sztu/checks.toml` 格式：`[[check]]` 数组，`command`（argv 字符串数组，必填）、`id` / `description` / `required` / `priority`（可选，有缺省）；TOML 语法错误或任一条目字段非法时记 warning 并**整体忽略该文件、回落项目画像**——坏配置不炸掉 run；
  - `select_relevant_checks(profile)` 类别策略（保守、快速优先）：STATIC_CHECK → required、priority=20（静态检查快，先跑先失败）；UNIT_TEST → required、priority=10；FORMAT → optional、priority=0（格式偏差不阻塞完成判定）；INTEGRATION_TEST / BUILD 整体跳过——耗时长、常依赖外部环境或凭据，作为默认门禁过于激进，需要时用户可在 checks.toml 显式声明；
  - 命令安全转换：字符串命令经 shlex 拆为 argv；含 shell 语法（& | ; < > ` $ 换行）或拆分失败的命令跳过（执行器以 create_subprocess_exec 无 shell 执行，无法安全表达）；working_directory 不是工作区根的命令跳过（执行器固定在根目录执行）；
  - id 生成稳定：画像来源为 `profile-<category>-<n>`，用户来源缺省为 `user-<n>`。
- `core/runner.py`：仅当 `agent.require_verification=True` 且 `context.completion_contract is None` 时调用 `build_completion_contract`；构建抛任何异常降级为 warning 日志，契约保持 None、门禁不触发——发现失败不炸 run；`require_verification=False` 时完全不调用（零回归）。profile 探测失败（None）时仅尝试用户声明来源。

## Validation

本系列（四个堆叠 PR）仅改动 Python 运行时（`src/sztu_code/core/`）与 Python 单测，不触及 packages/（TS 协议包）、desktop/ 与 docs/reference/wire-protocol.md（该文档现由 TS 侧生成），因此未运行 npm run typecheck / npm test / npm run build / npm run docs:protocol / npm run docs:links——无 TS 产物变化。本层也不涉及协议/事件变化，纯 Python 内部逻辑。

实际运行的检查（环境：Windows 11 + Python 3.12 + uv；分支基于 origin/main = 9404504）：

```text
# 仅本层针对性测试（本 PR 新增 tests/unit/test_verification_discovery.py）
uv run pytest tests/unit/test_verification_discovery.py -q
→ 9 passed
  （覆盖：checks.toml 独占优先、坏 TOML/坏 schema 整体忽略并回落、类别策略与跳过规则、
   shell 语法/子目录 cwd 命令跳过、argv 去重与稳定排序、runner 接入的降级路径）

# 静态检查（在四层叠加末端 feat/94-repair-loop = 90bb52f 测得）
uv run mypy src
→ Success: no issues found in 203 source files
uv run ruff check src tests
→ 仅 1 个既有 F401（tests/unit/test_tool_retry.py:277，上游遗留，本系列零改动）

# 全量单测（四层叠加末端 vs 裸 origin/main 基线）
uv run pytest tests/unit -q
→ 四层叠加：7 failed / 1017 passed
→ 裸 origin/main = 9404504 基线：7 failed / 988 passed
→ 失败集合逐项比对完全相同，零新增失败；+29 全部为本系列新增单测（第 2/3/4 层各 8+9+12 个；第 1 层 7 个已随 #112 计入 main 基线）
```

注：TypeScript CI 中 packages/runtime-ts/tests/npm-package.test.ts 的 subtest 19/20（npm entry daemon / --version）为 main 既有失败：该 workflow 自 #106 引入以来在 main 上从未通过，根因是 npm/sztucode-tui/scripts/install.js 在 Linux 上通过 node 执行 esbuild 的原生 ELF 二进制。本 PR 不触及 npm/、packages/runtime-ts/ 或 CI 配置，与该失败无关。

## Risk

- 兼容性：默认关闭（`require_verification=False` 时 discovery 完全不被调用），全量回归失败集合与基线逐项比对零差异。新增文件约定 `.sztu/checks.toml` 此前无任何语义，不与既有配置冲突。
- 安全：契约命令来源均在用户自身信任边界内——checks.toml 是用户在自己工作区显式声明的命令，项目画像来源是项目自身的构建/检查命令；执行经 argv、无 shell，含 shell 语法的命令被明确拒收，不存在拼接注入。恶意仓库的 checks.toml 与"克隆仓库后直接跑构建命令"属同一信任模型，且门禁需用户显式开启 `require_verification` 才会执行。
- 健壮性：坏配置（TOML 语法/schema 错误）与画像探测失败均降级为 warning + 回落/跳过，任何发现失败都不会中断 run。代价是配置写错时用户只能从日志发现检查没生效——保守换取不炸 run。
- 行为面：本层合入后 `require_verification=true` 首次产生用户可感知效果（run 结束多一段串行检查、事件流多 verification.started/finished）；开关仍默认关闭。
- 回滚方式：单 commit（ffddfd5），直接 revert；或置 `require_verification=false` 整体绕开。
- 剩余风险：INTEGRATION_TEST/BUILD 一刀切跳过对个别以集成测试为主的项目会导致契约偏薄（只剩静态检查），此时建议用户在 checks.toml 显式声明；后续可根据实际使用反馈放宽类别策略。

## UI evidence

N/A（Harness 内部契约发现逻辑，无 TUI/桌面端视觉变化）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试（新增 tests/unit/test_verification_discovery.py，9 个用例）。
- [ ] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A：本层无协议变化，纯 Python 内部逻辑；系列级的 TS protocol 包同步声明见第 1/2 层 PR）
- [ ] 用户文档、配置示例和迁移说明已同步。（未同步，如实声明：`.sztu/checks.toml` 是新的用户可见配置文件，其格式说明目前仅存在于 discovery.py 的注释中；建议在本层或第 4 层合入后补一份用户文档/配置示例，可作为 Epic #94 的收尾任务）
- [x] 提交包含 `Signed-off-by`（DCO）。
