### PR TITLE
feat(verification): add repair loop with triple circuit breaker and stale evidence (Part of #94)

### DIFF
--- a/src/sztu_code/core/config.py
+++ b/src/sztu_code/core/config.py
@@ -76,6 +76,10 @@ class AgentConfig:
     require_verification: bool = False
     # 单条完成条件检查命令的超时秒数
     verification_check_timeout_s: int = 60
+    # 验证失败后自动修复的最大轮数（issue #94 分支 4）；0=关闭修复闭环。
+    # 不另设 enable_repair_loop 开关：门禁本身由 require_verification 守卫，
+    # 本字段置 0 即可单独关闭闭环，再加布尔开关属冗余配置
+    max_repair_attempts: int = 2
 
 
 @dataclass
@@ -444,6 +448,7 @@ def _apply_toml(config: SztuConfig, data: dict[str, Any]) -> None:
             "max_steps", "wrap_up_on_max_steps", "grace_step_on_max_steps",
             "stuck_max_failures", "stuck_max_total", "tool_max_concurrency",
             "require_verification", "verification_check_timeout_s",
+            "max_repair_attempts",
         }
         if unknown_agent:
             raise SystemExit(f"Unknown [agent] keys: {', '.join(sorted(unknown_agent))}")
@@ -490,6 +495,13 @@ def _apply_toml(config: SztuConfig, data: dict[str, Any]) -> None:
                     "Config error: agent.verification_check_timeout_s must be an integer >= 1"
                 )
             config.agent.verification_check_timeout_s = val
+        if "max_repair_attempts" in agent:
+            val = agent["max_repair_attempts"]
+            if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+                raise SystemExit(
+                    "Config error: agent.max_repair_attempts must be a non-negative integer"
+                )
+            config.agent.max_repair_attempts = val
 
     if "budget" in data:
         budget = data["budget"]
@@ -918,6 +930,22 @@ def _apply_env(config: SztuConfig) -> None:
                 f"got: {verification_timeout_str!r}"
             )
         config.agent.verification_check_timeout_s = verification_timeout
+
+    max_repair_attempts_str = os.environ.get("SZTU_MAX_REPAIR_ATTEMPTS")
+    if max_repair_attempts_str is not None:
+        try:
+            max_repair_attempts = int(max_repair_attempts_str)
+        except ValueError:
+            raise SystemExit(
+                "Config error: SZTU_MAX_REPAIR_ATTEMPTS must be an integer, "
+                f"got: {max_repair_attempts_str!r}"
+            )
+        if max_repair_attempts < 0:
+            raise SystemExit(
+                "Config error: SZTU_MAX_REPAIR_ATTEMPTS must be >= 0, "
+                f"got: {max_repair_attempts_str!r}"
+            )
+        config.agent.max_repair_attempts = max_repair_attempts
 
     # --- 多智能体工作流环境变量 ---
     for _env, _attr, _minimum in (

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -60,7 +60,14 @@ from sztu_code.core.trace.provider import TracingProvider
 from sztu_code.core.trace.writer import TraceWriter
 from sztu_code.core.verification.discovery import build_completion_contract
 from sztu_code.core.verification.executor import VerificationExecutor
-from sztu_code.core.verification.models import VerificationOutcome
+from sztu_code.core.verification.models import VerificationOutcome, VerificationResult
+from sztu_code.core.verification.repair import (
+    RepairCircuitBreaker,
+    build_repair_prompt,
+    digests_from_change_records,
+    failure_signature,
+    mark_stale_evidence,
+)
 from sztu_code.core.workflow.tool import WorkflowRunTool
 from sztu_code.core.workspace.project_profile import (
     ProjectProfile,
@@ -224,6 +231,70 @@ class AgentRunner:
     async def run(self, goal: str, *, run_id: str | None = None) -> None:
         await self.run_and_capture(goal, run_id=run_id)
 
+    # issue #94 分支 4：验证失败后的修复闭环。复用同一 AgentLoop 与消息历史驱动修复
+    # 回合（与 steering/拒绝干预注入同构）：把失败详情作为 user 消息追加、状态复位
+    # running 后重新进入 loop.run，既有 max_steps/墙钟/卡死等守卫全部继续生效。
+    # 循环直至 verified 或三重熔断触发；熔断时保留最后一次真实验证结果，不伪装。
+    # 返回 (最后一次验证结果, 修复后重新 finalize 的变更记录或 None)。
+    async def _repair_loop(
+        self,
+        *,
+        context: ExecutionContext,
+        loop: AgentLoop,
+        executor: VerificationExecutor,
+        first_result: VerificationResult,
+        change_tracker: WorkspaceChangeTracker | None,
+        initial_changes: list[dict[str, Any]],
+    ) -> tuple[VerificationResult, list[dict[str, Any]] | None]:
+        log = logging.getLogger(__name__)
+        contract = context.completion_contract
+        if contract is None:  # 门禁守卫已排除；防御式直接返回
+            return first_result, None
+        breaker = RepairCircuitBreaker(self._config.agent.max_repair_attempts)
+        breaker.record(failure_signature(first_result))
+        result = first_result
+        latest_changes: list[dict[str, Any]] | None = None
+        current_digests = digests_from_change_records(initial_changes)
+        while result.overall is VerificationOutcome.FAILED:
+            reason = breaker.stop_reason()
+            if reason is not None:
+                log.warning(
+                    "verification repair stopped by circuit breaker (%s) run_id=%s; "
+                    "keeping last real verification outcome=%s",
+                    reason,
+                    context.run_id,
+                    result.overall.value,
+                )
+                break
+            context.messages.append(
+                {"role": "user", "content": build_repair_prompt(result, contract)}
+            )
+            # 状态复位仅为驱动下一回合；最终 status 以修复回合真实结局为准，
+            # 不新增状态值也不绕过 mark_* 语义（loop 内仍由 mark_* 落定）
+            context.status = "running"
+            context.reason = None
+            breaker.note_attempt()
+            await loop.run(context)
+            if context.status != "success":
+                log.warning(
+                    "repair round did not finish cleanly (status=%s reason=%s) run_id=%s",
+                    context.status,
+                    context.reason,
+                    context.run_id,
+                )
+                break
+            if change_tracker is not None:
+                latest_changes = change_tracker.finalize()
+                current_digests = digests_from_change_records(latest_changes)
+            # 上一轮证据与当前工作区摘要比对，不一致标 stale（stale 不计入通过）
+            if mark_stale_evidence(result, contract, current_digests):
+                log.info(
+                    "previous verification evidence marked stale run_id=%s", context.run_id
+                )
+            result = await executor.verify(contract, workspace_digests=current_digests)
+            breaker.record(failure_signature(result))
+        return result, latest_changes
+
     # 执行 agent run 并返回 RunOutcome（含最终文字结果）
     async def run_and_capture(
         self,
@@ -332,6 +403,7 @@ class AgentRunner:
                 )
         prefill_len = len(history)
         compactor = None  # 在 try 块外初始化，避免 UnboundLocalError
+        loop: AgentLoop | None = None  # 门禁修复闭环需要复用同一 loop 驱动修复回合
 
         async with EventWriter(run_path / "events.jsonl") as writer:
             writer.subscribe(bus)
@@ -489,19 +561,35 @@ class AgentRunner:
                 )
                 verification_status: str
                 try:
-                    verification = await VerificationExecutor(
+                    executor = VerificationExecutor(
                         change_workspace_root or project_root,
                         run_path,
                         check_timeout_s=self._config.agent.verification_check_timeout_s,
-                    ).verify(
+                    )
+                    verification = await executor.verify(
                         context.completion_contract,
                         # 证据快照：finalize 后 manifest 中变更文件的 after_digest
-                        workspace_digests={
-                            str(record["path"]): str(record["after_digest"])
-                            for record in changes
-                            if record.get("after_digest")
-                        },
+                        workspace_digests=digests_from_change_records(changes),
                     )
+                    # issue #94 分支 4：验证失败时驱动修复闭环（三重熔断内重试）。
+                    # max_repair_attempts=0 关闭闭环，行为退回分支 2 的单次验证。
+                    if (
+                        verification.overall is VerificationOutcome.FAILED
+                        and loop is not None
+                        and self._config.agent.max_repair_attempts > 0
+                    ):
+                        verification, repaired_changes = await self._repair_loop(
+                            context=context,
+                            loop=loop,
+                            executor=executor,
+                            first_result=verification,
+                            change_tracker=change_tracker,
+                            initial_changes=changes,
+                        )
+                        # 修复回合可能新增/回滚文件：刷新变更记录与修改状态摘要
+                        if repaired_changes is not None:
+                            changes = repaired_changes
+                            modification_status = modification_status_summary(changes)
                     verification_status = verification.overall.value
                 except asyncio.CancelledError:
                     # 保持取消语义：直接向上抛，由外层统一处理

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -58,10 +58,12 @@ from sztu_code.core.tools.builtin import (
 from sztu_code.core.tools.registry import ToolRegistry
 from sztu_code.core.trace.provider import TracingProvider
 from sztu_code.core.trace.writer import TraceWriter
+from sztu_code.core.verification.discovery import build_completion_contract
 from sztu_code.core.verification.executor import VerificationExecutor
 from sztu_code.core.verification.models import VerificationOutcome
 from sztu_code.core.workflow.tool import WorkflowRunTool
 from sztu_code.core.workspace.project_profile import (
+    ProjectProfile,
     detect_project_profile,
     render_project_profile_context,
 )
@@ -248,6 +250,7 @@ class AgentRunner:
 
         project_root = workspace_root or Path.cwd()
         project_profile_context = ""
+        profile: ProjectProfile | None = None
         try:
             project_root = project_root.resolve()
             profile = detect_project_profile(project_root)
@@ -315,6 +318,18 @@ class AgentRunner:
             max_tokens=0,
             max_wall_clock_s=self._config.budget.max_wall_clock_s,
         )
+        # issue #94 分支 3：门禁开启且尚无契约时，从用户声明/项目画像构建完成契约。
+        # profile 探测失败时仅尝试用户声明来源；构建失败不炸 run，契约保持 None，
+        # 门禁自然不触发。require_verification=False 时完全不调用（零回归）。
+        if self._config.agent.require_verification and context.completion_contract is None:
+            try:
+                context.completion_contract = build_completion_contract(
+                    run_id, profile, project_root
+                )
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "completion contract discovery failed run_id=%s", run_id, exc_info=True
+                )
         prefill_len = len(history)
         compactor = None  # 在 try 块外初始化，避免 UnboundLocalError
 

--- a/src/sztu_code/core/verification/__init__.py
+++ b/src/sztu_code/core/verification/__init__.py
@@ -1,4 +1,8 @@
-# 完成契约与独立验证：数据模型（issue #94 第一阶段）+ 验证执行器（第二阶段）
+# 完成契约与独立验证：数据模型（issue #94 第一阶段）+ 验证执行器（第二阶段）+ 检查发现（第三阶段）
+from sztu_code.core.verification.discovery import (
+    build_completion_contract,
+    select_relevant_checks,
+)
 from sztu_code.core.verification.executor import VerificationExecutor, aggregate_outcomes
 from sztu_code.core.verification.models import (
     CompletionCondition,
@@ -22,4 +26,6 @@ __all__ = [
     "VerificationOutcome",
     "VerificationResult",
     "aggregate_outcomes",
+    "build_completion_contract",
+    "select_relevant_checks",
 ]

--- a/src/sztu_code/core/verification/__init__.py
+++ b/src/sztu_code/core/verification/__init__.py
@@ -1,4 +1,4 @@
-# 完成契约与独立验证：数据模型（issue #94 第一阶段）+ 验证执行器（第二阶段）+ 检查发现（第三阶段）
+# 完成契约与独立验证（issue #94）：数据模型 + 验证执行器 + 检查发现 + 修复闭环
 from sztu_code.core.verification.discovery import (
     build_completion_contract,
     select_relevant_checks,
@@ -14,6 +14,14 @@ from sztu_code.core.verification.models import (
     VerificationOutcome,
     VerificationResult,
 )
+from sztu_code.core.verification.repair import (
+    FailureSignature,
+    RepairCircuitBreaker,
+    build_repair_prompt,
+    digests_from_change_records,
+    failure_signature,
+    mark_stale_evidence,
+)
 
 __all__ = [
     "CompletionCondition",
@@ -22,10 +30,16 @@ __all__ = [
     "ContractSource",
     "Evidence",
     "EvidenceKind",
+    "FailureSignature",
+    "RepairCircuitBreaker",
     "VerificationExecutor",
     "VerificationOutcome",
     "VerificationResult",
     "aggregate_outcomes",
     "build_completion_contract",
+    "build_repair_prompt",
+    "digests_from_change_records",
+    "failure_signature",
+    "mark_stale_evidence",
     "select_relevant_checks",
 ]

--- a/src/sztu_code/core/verification/discovery.py
+++ b/src/sztu_code/core/verification/discovery.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import tomllib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sztu_code.core.verification.models import (
+    CompletionCondition,
+    CompletionContract,
+    ContractSource,
+)
+from sztu_code.core.workspace.project_profile import ProjectProfile, ValidationCategory
+
+logger = logging.getLogger(__name__)
+
+# 用户声明的检查清单文件（相对工作区根）。格式：
+# [[check]]
+# id = "unit-tests"                                      # 可选，缺省生成 user-<n>
+# description = "运行单元测试"                             # 可选，缺省用命令拼接
+# command = ["uv", "run", "pytest", "tests/unit", "-q"]  # argv 数组，必填
+# required = true                                        # 可选，默认 true
+# priority = 0                                           # 可选，默认 0
+CHECKS_FILE = Path(".sztu") / "checks.toml"
+
+# 含 shell 语法的命令无法安全转为 argv（执行器以 create_subprocess_exec 直接执行，无 shell）
+_SHELL_SYNTAX_RE = re.compile(r"[&|;<>`$\n]")
+
+# 门禁类别策略：类别 → (required, priority)。未列出的类别不纳入契约。
+# 规则详见 select_relevant_checks docstring。
+_CATEGORY_POLICY: dict[ValidationCategory, tuple[bool, int]] = {
+    ValidationCategory.STATIC_CHECK: (True, 20),
+    ValidationCategory.UNIT_TEST: (True, 10),
+    ValidationCategory.FORMAT: (False, 0),
+}
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# 构建一次 run 的完成契约（issue #94 分支 3：检查发现与契约构建）
+def build_completion_contract(
+    run_id: str,
+    profile: ProjectProfile | None,
+    workspace_root: Path,
+) -> CompletionContract | None:
+    """按来源优先级构建完成契约；两个来源都为空时返回 None（门禁自然不触发）。
+
+    来源优先级：
+    1. 用户声明（source=USER）：workspace_root/.sztu/checks.toml 存在且解析出
+       至少一条合法条件时独占生效，不再混入项目画像来源；
+    2. 项目画像（source=PROJECT_CONFIG）：profile 的 validation_plan 经
+       select_relevant_checks 过滤转换。profile 为 None（探测失败）时跳过。
+    checks.toml 解析失败（TOML 语法错误或任一条目字段非法）记 warning 并整体
+    忽略该文件、回落项目画像——坏配置不炸掉 run。最终条件按 argv 去重
+    （相同命令只保留首条）并按 priority 降序稳定排序。
+    """
+    conditions = _load_user_checks(workspace_root)
+    if not conditions and profile is not None:
+        conditions = select_relevant_checks(profile)
+    conditions = _dedup_and_sort(conditions)
+    if not conditions:
+        return None
+    return CompletionContract(run_id=run_id, conditions=conditions, created_at=_now())
+
+
+# 从项目画像的验证建议中筛选适合门禁的检查并转为完成条件
+def select_relevant_checks(profile: ProjectProfile) -> list[CompletionCondition]:
+    """类别过滤规则（保守、快速优先）：
+
+    - STATIC_CHECK：required=True，priority=20（静态检查快，先跑先失败）；
+    - UNIT_TEST：required=True，priority=10；
+    - FORMAT：required=False，priority=0（格式偏差不应阻塞完成判定）；
+    - INTEGRATION_TEST / BUILD：整体跳过——耗时长、常依赖外部环境或凭据，
+      作为默认门禁过于激进；需要时用户可在 checks.toml 中显式声明。
+    额外跳过（记 debug 日志）：
+    - working_directory 不是工作区根（"." 以外）：执行器固定在根目录执行，
+      无法安全表达子目录 cwd；
+    - 命令含 shell 语法（& | ; < > ` $）或无法 shlex 拆分：无法安全转 argv。
+    id 生成规则稳定：profile-<category>-<n>，n 为该类别内的出现序号。
+    """
+    conditions: list[CompletionCondition] = []
+    counters: dict[ValidationCategory, int] = {}
+    for component in profile.projects:
+        for item in component.validation_plan:
+            policy = _CATEGORY_POLICY.get(item.category)
+            if policy is None:
+                logger.debug(
+                    "skipping non-gating category %s: %s", item.category.value, item.command
+                )
+                continue
+            if item.working_directory not in ("", "."):
+                logger.debug(
+                    "skipping command outside workspace root (%s): %s",
+                    item.working_directory,
+                    item.command,
+                )
+                continue
+            argv = _to_argv(item.command)
+            if argv is None:
+                logger.debug("skipping command not convertible to argv: %s", item.command)
+                continue
+            required, priority = policy
+            counters[item.category] = counters.get(item.category, 0) + 1
+            conditions.append(
+                CompletionCondition(
+                    id=(
+                        f"profile-{item.category.value.replace('_', '-')}"
+                        f"-{counters[item.category]}"
+                    ),
+                    description=item.reason or item.command,
+                    source=ContractSource.PROJECT_CONFIG,
+                    check_command=argv,
+                    required=required,
+                    priority=priority,
+                )
+            )
+    return conditions
+
+
+# 读取并解析用户声明的 checks.toml；文件缺失返回空列表，解析失败记 warning 并整体忽略
+def _load_user_checks(workspace_root: Path) -> list[CompletionCondition]:
+    path = workspace_root / CHECKS_FILE
+    if not path.is_file():
+        return []
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        return _parse_user_checks(data)
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, ValueError) as error:
+        logger.warning("ignoring invalid checks file %s: %s", path, error)
+        return []
+
+
+# 将 checks.toml 数据转为条件列表；任一条目字段非法抛 ValueError（由调用方整体忽略）
+def _parse_user_checks(data: dict[str, Any]) -> list[CompletionCondition]:
+    entries = data.get("check", [])
+    if not isinstance(entries, list):
+        raise ValueError("[[check]] must be an array of tables")
+    conditions: list[CompletionCondition] = []
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            raise ValueError(f"check #{index} must be a table")
+        command = entry.get("command")
+        if (
+            not isinstance(command, list)
+            or not command
+            or not all(isinstance(part, str) and part for part in command)
+        ):
+            raise ValueError(f"check #{index}: command must be a non-empty array of strings")
+        condition_id = entry.get("id", f"user-{index}")
+        if not isinstance(condition_id, str) or not condition_id:
+            raise ValueError(f"check #{index}: id must be a non-empty string")
+        description = entry.get("description", " ".join(command))
+        if not isinstance(description, str):
+            raise ValueError(f"check #{index}: description must be a string")
+        required = entry.get("required", True)
+        if not isinstance(required, bool):
+            raise ValueError(f"check #{index}: required must be a boolean")
+        priority = entry.get("priority", 0)
+        if isinstance(priority, bool) or not isinstance(priority, int):
+            raise ValueError(f"check #{index}: priority must be an integer")
+        conditions.append(
+            CompletionCondition(
+                id=condition_id,
+                description=description,
+                source=ContractSource.USER,
+                check_command=list(command),
+                required=required,
+                priority=priority,
+            )
+        )
+    return conditions
+
+
+# 将命令字符串安全转为 argv；含 shell 语法或拆分失败返回 None
+def _to_argv(command: str) -> list[str] | None:
+    if _SHELL_SYNTAX_RE.search(command):
+        return None
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        return None
+    return argv or None
+
+
+# 按 argv 去重（保留首条）并按 priority 降序稳定排序
+def _dedup_and_sort(conditions: list[CompletionCondition]) -> list[CompletionCondition]:
+    unique: list[CompletionCondition] = []
+    seen: set[tuple[str, ...]] = set()
+    for cond in conditions:
+        key = tuple(cond.check_command or ())
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(cond)
+    return sorted(unique, key=lambda cond: -cond.priority)

--- a/src/sztu_code/core/verification/repair.py
+++ b/src/sztu_code/core/verification/repair.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from sztu_code.core.verification.executor import aggregate_outcomes
+from sztu_code.core.verification.models import (
+    CompletionContract,
+    VerificationOutcome,
+    VerificationResult,
+)
+
+# 失败签名：排序后的 (condition_id, outcome, exit_code) 元组列表。
+# 连续两轮验证签名相同说明修复未产生任何效果，应当熔断而非继续烧预算。
+FailureSignature = tuple[tuple[str, str, int | None], ...]
+
+# 修复提示中每条失败日志保留的尾部行数与字符上限（防止大日志撑爆上下文）
+_LOG_TAIL_LINES = 20
+_LOG_TAIL_MAX_CHARS = 2_000
+
+
+# 从一次验证结果提取失败签名（纯函数，便于单测）。
+# condition_id 在契约内唯一，仅按 (id, outcome) 排序即可稳定，
+# 同时避免 exit_code 的 None 与 int 直接比较。
+def failure_signature(result: VerificationResult) -> FailureSignature:
+    entries = [
+        (
+            cond_result.condition_id,
+            cond_result.outcome.value,
+            cond_result.evidence.exit_code if cond_result.evidence is not None else None,
+        )
+        for cond_result in result.results
+    ]
+    return tuple(sorted(entries, key=lambda entry: (entry[0], entry[1])))
+
+
+# 从 changes.json 的变更记录提取 {path: after_digest} 作为当前工作区证据摘要。
+# 复用 core/changes.py 的 _digest（sha256）结果，不重新实现 hash。
+def digests_from_change_records(records: list[dict[str, Any]] | None) -> dict[str, str]:
+    if not records:
+        return {}
+    return {
+        str(record["path"]): str(record["after_digest"])
+        for record in records
+        if record.get("after_digest")
+    }
+
+
+# 把与当前工作区摘要不一致的证据标记 stale=True；stale 证据不得计入通过，
+# 因此依赖 stale 证据的 verified 结论降级为 stale，并重算 overall。
+# 返回是否有证据被标记（供调用方记日志）。
+def mark_stale_evidence(
+    result: VerificationResult,
+    contract: CompletionContract,
+    current_digests: dict[str, str],
+) -> bool:
+    changed = False
+    for cond_result in result.results:
+        evidence = cond_result.evidence
+        if evidence is None or evidence.stale:
+            continue
+        if evidence.workspace_digests != current_digests:
+            evidence.stale = True
+            changed = True
+            if cond_result.outcome is VerificationOutcome.VERIFIED:
+                cond_result.outcome = VerificationOutcome.STALE
+    if changed:
+        result.overall = aggregate_outcomes(contract.conditions, result.results)
+    return changed
+
+
+# 读取验证日志尾部若干行；日志缺失/不可读时返回空串（提示中省略该段）
+def _log_tail(output_path: str, *, lines: int = _LOG_TAIL_LINES) -> str:
+    if not output_path:
+        return ""
+    try:
+        text = Path(output_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    tail = "\n".join(text.splitlines()[-lines:])
+    return tail[-_LOG_TAIL_MAX_CHARS:]
+
+
+# 构造修复提示：逐条列出失败条件的 id/描述/退出码/日志尾部，
+# 日志来自 run_path/verification/<id>.log（Evidence.output_path）。
+def build_repair_prompt(result: VerificationResult, contract: CompletionContract) -> str:
+    descriptions = {cond.id: cond.description for cond in contract.conditions}
+    sections = [
+        "[Verification failed] Independent verification of the completion contract "
+        "FAILED — the task is NOT complete yet.",
+        "Fix the failed conditions below, then end your turn; "
+        "verification will run again automatically.",
+    ]
+    for cond_result in result.results:
+        if cond_result.outcome is not VerificationOutcome.FAILED:
+            continue
+        evidence = cond_result.evidence
+        exit_code = evidence.exit_code if evidence is not None else None
+        lines = [
+            f"- condition: {cond_result.condition_id}",
+            f"  description: {descriptions.get(cond_result.condition_id, '')}",
+            f"  exit_code: {exit_code}",
+        ]
+        if cond_result.message:
+            lines.append(f"  message: {cond_result.message}")
+        tail = _log_tail(evidence.output_path) if evidence is not None else ""
+        if tail:
+            lines.extend(["  log tail:", "```", tail, "```"])
+        sections.append("\n".join(lines))
+    return "\n\n".join(sections)
+
+
+class RepairCircuitBreaker:
+    """修复闭环三重熔断（issue #94 分支 4）。
+
+    任一触发即停止修复，最终以最后一次真实验证结果落盘，不得伪装 verified：
+    a. 修复轮数达到 max_repair_attempts；
+    b. 相同失败签名：连续两次验证签名相同，说明修复无效；
+    c. A/B 震荡：签名回到上上轮的值记一次翻转（A→B→A 计 1 次），累计 3 次即停。
+       首次出现新签名不算翻转——那可能是修复取得了进展。
+    """
+
+    _OSCILLATION_LIMIT = 3
+
+    def __init__(self, max_attempts: int) -> None:
+        self._max_attempts = max_attempts
+        self._attempts = 0
+        self._signatures: list[FailureSignature] = []
+        self._flips = 0
+
+    # 记录一次验证的失败签名（含首轮验证），维护震荡翻转计数
+    def record(self, signature: FailureSignature) -> None:
+        if (
+            len(self._signatures) >= 2
+            and signature != self._signatures[-1]
+            and signature == self._signatures[-2]
+        ):
+            self._flips += 1
+        self._signatures.append(signature)
+
+    # 记录发起了一轮修复尝试
+    def note_attempt(self) -> None:
+        self._attempts += 1
+
+    # 返回熔断原因；None 表示允许继续修复
+    def stop_reason(self) -> str | None:
+        if self._attempts >= self._max_attempts:
+            return f"max_repair_attempts reached ({self._max_attempts})"
+        if len(self._signatures) >= 2 and self._signatures[-1] == self._signatures[-2]:
+            return "identical failure signature across consecutive verifications"
+        if self._flips >= self._OSCILLATION_LIMIT:
+            return f"failure signature oscillation (flips={self._flips})"
+        return None

--- a/tests/unit/test_verification_discovery.py
+++ b/tests/unit/test_verification_discovery.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sztu_code.core.verification import (
+    ContractSource,
+    build_completion_contract,
+    select_relevant_checks,
+)
+from sztu_code.core.workspace.project_profile import (
+    ProjectComponent,
+    ProjectProfile,
+    ValidationCategory,
+    ValidationCommand,
+)
+
+
+def _write_checks(workspace: Path, content: str) -> None:
+    checks_dir = workspace / ".sztu"
+    checks_dir.mkdir(parents=True, exist_ok=True)
+    (checks_dir / "checks.toml").write_text(content, encoding="utf-8")
+
+
+def _vc(
+    category: ValidationCategory,
+    command: str,
+    *,
+    working_directory: str = ".",
+    reason: str = "",
+) -> ValidationCommand:
+    return ValidationCommand(
+        category=category,
+        command=command,
+        working_directory=working_directory,
+        reason=reason or f"reason for {command}",
+    )
+
+
+def _profile(*commands: ValidationCommand) -> ProjectProfile:
+    return ProjectProfile(
+        projects=[ProjectComponent(path=".", validation_plan=list(commands))]
+    )
+
+
+# 功能：合法 checks.toml 独占生效，字段解析正确且 user 条件优先于 profile 来源
+# 设计：文件与 profile 同时存在，断言只产出 USER 条件；覆盖显式/缺省 id、
+# description、required、priority 各字段的解析与默认值
+def test_user_checks_take_precedence_and_parse_fields(tmp_path: Path) -> None:
+    _write_checks(
+        tmp_path,
+        """
+[[check]]
+id = "unit-tests"
+description = "运行单元测试"
+command = ["uv", "run", "pytest", "tests/unit", "-q"]
+required = true
+priority = 5
+
+[[check]]
+command = ["ruff", "check", "."]
+required = false
+""",
+    )
+    profile = _profile(_vc(ValidationCategory.UNIT_TEST, "uv run pytest"))
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    assert contract.run_id == "run-1"
+    assert all(cond.source is ContractSource.USER for cond in contract.conditions)
+    first, second = contract.conditions
+    # priority 降序：显式 priority=5 的排前
+    assert first.id == "unit-tests"
+    assert first.description == "运行单元测试"
+    assert first.check_command == ["uv", "run", "pytest", "tests/unit", "-q"]
+    assert first.required is True
+    assert first.priority == 5
+    # 缺省字段：id 自动生成、description 回落命令拼接、priority=0
+    assert second.id == "user-2"
+    assert second.description == "ruff check ."
+    assert second.required is False
+    assert second.priority == 0
+
+
+# 功能：checks.toml TOML 语法错误时整体忽略并回落 profile 来源
+# 设计：写入非法 TOML，断言产出 PROJECT_CONFIG 条件且记 warning 日志
+def test_invalid_toml_falls_back_to_profile(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write_checks(tmp_path, "[[check]\ncommand = broken")
+    profile = _profile(_vc(ValidationCategory.UNIT_TEST, "uv run pytest"))
+    with caplog.at_level("WARNING"):
+        contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    [cond] = contract.conditions
+    assert cond.source is ContractSource.PROJECT_CONFIG
+    assert any("ignoring invalid checks file" in rec.message for rec in caplog.records)
+
+
+# 功能：checks.toml 条目字段非法（command 非数组）时整体忽略并回落 profile
+# 设计：TOML 语法合法但 schema 非法——部分合法条目也不生效，避免静默丢弃用户检查
+def test_invalid_schema_falls_back_to_profile(tmp_path: Path) -> None:
+    _write_checks(
+        tmp_path,
+        """
+[[check]]
+command = ["ok", "entry"]
+
+[[check]]
+command = "not an array"
+""",
+    )
+    profile = _profile(_vc(ValidationCategory.STATIC_CHECK, "uv run ruff check ."))
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    [cond] = contract.conditions
+    assert cond.source is ContractSource.PROJECT_CONFIG
+
+
+# 功能：无 checks.toml 时 profile 转换的类别过滤规则与 argv 转换
+# 设计：构造覆盖全部 5 个类别的最小 profile（不依赖真实文件探测，跨平台稳定）；
+# 断言 STATIC_CHECK/UNIT_TEST required、FORMAT 可选、INTEGRATION_TEST/BUILD 跳过
+def test_profile_category_filtering_and_conversion(tmp_path: Path) -> None:
+    profile = _profile(
+        _vc(ValidationCategory.FORMAT, "uv run ruff format --check ."),
+        _vc(ValidationCategory.STATIC_CHECK, "uv run ruff check ."),
+        _vc(ValidationCategory.UNIT_TEST, "uv run pytest"),
+        _vc(ValidationCategory.INTEGRATION_TEST, "uv run pytest tests/integration"),
+        _vc(ValidationCategory.BUILD, "uv build"),
+    )
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    by_id = {cond.id: cond for cond in contract.conditions}
+    assert set(by_id) == {"profile-static-check-1", "profile-unit-test-1", "profile-format-1"}
+    static = by_id["profile-static-check-1"]
+    assert static.source is ContractSource.PROJECT_CONFIG
+    assert static.check_command == ["uv", "run", "ruff", "check", "."]
+    assert static.required is True
+    unit = by_id["profile-unit-test-1"]
+    assert unit.check_command == ["uv", "run", "pytest"]
+    assert unit.required is True
+    fmt = by_id["profile-format-1"]
+    assert fmt.required is False
+    # priority 降序：static_check > unit_test > format
+    assert [c.id for c in contract.conditions] == [
+        "profile-static-check-1",
+        "profile-unit-test-1",
+        "profile-format-1",
+    ]
+
+
+# 功能：含 shell 语法的命令与子目录 working_directory 的命令被跳过
+# 设计：&& 串联命令无法安全转 argv；执行器固定在工作区根执行，子目录命令不可表达
+def test_profile_skips_shell_syntax_and_subdirectory_commands(tmp_path: Path) -> None:
+    profile = _profile(
+        _vc(ValidationCategory.UNIT_TEST, "cmake -S . -B build && cmake --build build"),
+        _vc(ValidationCategory.UNIT_TEST, "uv run pytest", working_directory="packages/api"),
+        _vc(ValidationCategory.UNIT_TEST, "uv run pytest"),
+    )
+    conditions = select_relevant_checks(profile)
+    assert len(conditions) == 1
+    # id 序号按类别内出现顺序计数，前两条被跳过不占号后仍保持稳定
+    assert conditions[0].id == "profile-unit-test-1"
+    assert conditions[0].check_command == ["uv", "run", "pytest"]
+
+
+# 功能：相同 argv 去重（只保留首条）与 priority 降序稳定排序
+# 设计：user 来源写两条相同命令 + 不同 priority 的第三条，断言去重与排序结果
+def test_dedup_and_priority_sort(tmp_path: Path) -> None:
+    _write_checks(
+        tmp_path,
+        """
+[[check]]
+id = "a"
+command = ["uv", "run", "pytest"]
+
+[[check]]
+id = "duplicate"
+command = ["uv", "run", "pytest"]
+
+[[check]]
+id = "b"
+command = ["ruff", "check", "."]
+priority = 10
+""",
+    )
+    contract = build_completion_contract("run-1", None, tmp_path)
+    assert contract is not None
+    assert [cond.id for cond in contract.conditions] == ["b", "a"]
+
+
+# 功能：两来源皆空时返回 None（门禁自然不触发）
+# 设计：覆盖三种空场景——无文件且 profile=None、profile 仅含跳过类别、
+# checks.toml 合法但条目为空（回落 profile 后仍为空）
+def test_empty_sources_return_none(tmp_path: Path) -> None:
+    assert build_completion_contract("run-1", None, tmp_path) is None
+
+    skipped_only = _profile(
+        _vc(ValidationCategory.BUILD, "uv build"),
+        _vc(ValidationCategory.INTEGRATION_TEST, "uv run pytest tests/integration"),
+    )
+    assert build_completion_contract("run-1", skipped_only, tmp_path) is None
+
+    _write_checks(tmp_path, "# 没有任何 [[check]] 条目\n")
+    assert build_completion_contract("run-1", None, tmp_path) is None
+
+
+# 功能：checks.toml 合法但条目为空时回落 profile 来源
+# 设计：空文件不视为"用户显式声明无检查"，保守回落项目画像
+def test_empty_checks_file_falls_back_to_profile(tmp_path: Path) -> None:
+    _write_checks(tmp_path, "")
+    profile = _profile(_vc(ValidationCategory.UNIT_TEST, "uv run pytest"))
+    contract = build_completion_contract("run-1", profile, tmp_path)
+    assert contract is not None
+    [cond] = contract.conditions
+    assert cond.source is ContractSource.PROJECT_CONFIG
+
+
+# 功能：多组件 monorepo 画像中各组件的根目录命令均被收集且 id 序号跨组件连续
+# 设计：两个组件各带一条根目录 UNIT_TEST 命令，断言 id 稳定递增、无冲突
+def test_profile_multiple_components_stable_ids(tmp_path: Path) -> None:
+    profile = ProjectProfile(
+        monorepo=True,
+        projects=[
+            ProjectComponent(
+                path=".",
+                validation_plan=[_vc(ValidationCategory.UNIT_TEST, "uv run pytest")],
+            ),
+            ProjectComponent(
+                path="tools",
+                validation_plan=[_vc(ValidationCategory.UNIT_TEST, "npm test")],
+            ),
+        ],
+    )
+    conditions = select_relevant_checks(profile)
+    assert [cond.id for cond in conditions] == ["profile-unit-test-1", "profile-unit-test-2"]
+    assert conditions[1].check_command == ["npm", "test"]

--- a/tests/unit/test_verification_repair.py
+++ b/tests/unit/test_verification_repair.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from sztu_code.core.config import SztuConfig
+from sztu_code.core.llm.types import LlmResponse
+from sztu_code.core.loop import AgentLoop
+from sztu_code.core.runner import AgentRunner
+from sztu_code.core.verification import (
+    CompletionCondition,
+    CompletionContract,
+    ConditionResult,
+    ContractSource,
+    Evidence,
+    EvidenceKind,
+    RepairCircuitBreaker,
+    VerificationOutcome,
+    VerificationResult,
+    build_repair_prompt,
+    failure_signature,
+    mark_stale_evidence,
+)
+
+# ---- 构造辅助：直接拼装模型对象，不启动任何子进程 ----
+
+
+def _cond(cid: str, *, required: bool = True) -> CompletionCondition:
+    return CompletionCondition(
+        id=cid,
+        description=f"desc-{cid}",
+        source=ContractSource.USER,
+        check_command=["echo", cid],
+        required=required,
+    )
+
+
+def _contract(*conds: CompletionCondition) -> CompletionContract:
+    return CompletionContract(
+        run_id="run-1", conditions=list(conds), created_at="2026-08-19T00:00:00Z"
+    )
+
+
+def _evidence(
+    cid: str,
+    exit_code: int | None,
+    *,
+    digests: dict[str, str] | None = None,
+    output_path: str = "",
+) -> Evidence:
+    return Evidence(
+        condition_id=cid,
+        kind=EvidenceKind.COMMAND_EXIT_CODE,
+        command=f"check {cid}",
+        exit_code=exit_code,
+        output_path=output_path,
+        workspace_digests=digests or {},
+        collected_at="2026-08-19T00:00:00Z",
+    )
+
+
+def _cond_result(
+    cid: str,
+    outcome: VerificationOutcome,
+    *,
+    exit_code: int | None = None,
+    evidence: Evidence | None = None,
+    message: str = "",
+) -> ConditionResult:
+    if evidence is None and exit_code is not None:
+        evidence = _evidence(cid, exit_code)
+    return ConditionResult(
+        condition_id=cid, outcome=outcome, evidence=evidence, message=message
+    )
+
+
+def _vresult(
+    overall: VerificationOutcome, *results: ConditionResult
+) -> VerificationResult:
+    return VerificationResult(
+        run_id="run-1",
+        results=list(results),
+        overall=overall,
+        verified_at="2026-08-19T00:00:00Z",
+    )
+
+
+def _failed(cid: str = "tests", exit_code: int = 1) -> VerificationResult:
+    return _vresult(
+        VerificationOutcome.FAILED,
+        _cond_result(cid, VerificationOutcome.FAILED, exit_code=exit_code),
+    )
+
+
+def _verified(cid: str = "tests") -> VerificationResult:
+    return _vresult(
+        VerificationOutcome.VERIFIED,
+        _cond_result(cid, VerificationOutcome.VERIFIED, exit_code=0),
+    )
+
+
+# 每次 chat 直接 end_turn 的 provider：一次 loop.run == 一次 chat 调用，
+# 用调用次数断言"初始回合 + 修复回合"的轮数
+class _EndTurnProvider:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.user_prompts: list[str] = []
+
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: object,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+    ) -> LlmResponse:
+        self.calls += 1
+        last = messages[-1]
+        if isinstance(last.get("content"), str):
+            self.user_prompts.append(str(last["content"]))
+        return LlmResponse(stop_reason="end_turn", text=f"round {self.calls}")
+
+
+# 每次 chat 往工作区写入不同内容再 end_turn，模拟修复回合真实改动文件
+class _WritingProvider(_EndTurnProvider):
+    def __init__(self, target: Path) -> None:
+        super().__init__()
+        self._target = target
+
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: object,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+    ) -> LlmResponse:
+        response = await super().chat(
+            messages, tool_schemas, bus, run_id, step=step, system=system
+        )
+        self._target.write_text(f"v{self.calls}", encoding="utf-8")
+        return response
+
+
+# 生成按脚本顺序吐出验证结果的 fake executor 类（替换 runner.VerificationExecutor），
+# 同时记录每次 verify 收到的 workspace_digests，不起任何真子进程
+def _scripted_executor(
+    script: list[VerificationResult],
+    digest_calls: list[dict[str, str]] | None = None,
+) -> type:
+    class _Fake:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def verify(
+            self,
+            contract: CompletionContract,
+            *,
+            workspace_digests: dict[str, str] | None = None,
+        ) -> VerificationResult:
+            if digest_calls is not None:
+                digest_calls.append(dict(workspace_digests or {}))
+            return script.pop(0)
+
+    return _Fake
+
+
+# 组装并执行一次带脚本化验证的 run；返回 (RunOutcome, provider, 收集到的事件)
+async def _run_with_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    script: list[VerificationResult],
+    *,
+    max_attempts: int = 2,
+    require: bool = True,
+    provider: _EndTurnProvider | None = None,
+    workspace_root: Path | None = None,
+    digest_calls: list[dict[str, str]] | None = None,
+) -> tuple[Any, _EndTurnProvider, list[BaseModel]]:
+    config = SztuConfig()
+    config.agent.require_verification = require
+    config.agent.max_repair_attempts = max_attempts
+    # main 既有破坏：AgentLoop.__init__ 未初始化 _steering_queue，_drain_steering 直接 AttributeError。
+    # 与本分支无关且禁改 loop.py，这里补一个类属性绕过（修复后实例属性会自然遮盖它）
+    monkeypatch.setattr(AgentLoop, "_steering_queue", None, raising=False)
+    contract = _contract(_cond("tests"))
+    monkeypatch.setattr(
+        "sztu_code.core.runner.build_completion_contract",
+        lambda run_id, profile, root: contract,
+    )
+    monkeypatch.setattr(
+        "sztu_code.core.runner.VerificationExecutor",
+        _scripted_executor(script, digest_calls),
+    )
+    provider = provider or _EndTurnProvider()
+    events: list[BaseModel] = []
+
+    async def _collect(event: BaseModel) -> None:
+        events.append(event)
+
+    runner = AgentRunner(
+        config,
+        provider=provider,
+        runs_dir=tmp_path / "runs",
+        extra_handlers=[_collect],
+    )
+    outcome = await runner.run_and_capture(
+        "goal",
+        system_prompt_override="You are a test agent.",
+        workspace_root=workspace_root,
+    )
+    return outcome, provider, events
+
+
+# 功能：验证失败签名按 (condition_id, outcome) 排序稳定，且透传证据退出码/无证据为 None
+# 设计：乱序构造两个条件（一个带退出码证据、一个无证据），断言排序结果与元组内容
+def test_failure_signature_sorted_and_carries_exit_code() -> None:
+    result = _vresult(
+        VerificationOutcome.FAILED,
+        _cond_result("z-late", VerificationOutcome.FAILED, exit_code=7),
+        _cond_result("a-early", VerificationOutcome.UNVERIFIED),
+    )
+    assert failure_signature(result) == (
+        ("a-early", "unverified", None),
+        ("z-late", "failed", 7),
+    )
+
+
+# 功能：验证熔断器 a——修复轮数达到 max_repair_attempts 即停
+# 设计：max_attempts=2，每轮签名互不相同（排除签名熔断干扰），第 3 次询问返回熔断原因
+def test_circuit_breaker_stops_at_max_attempts() -> None:
+    breaker = RepairCircuitBreaker(2)
+    breaker.record(failure_signature(_failed(exit_code=1)))
+    assert breaker.stop_reason() is None
+    breaker.note_attempt()
+    breaker.record(failure_signature(_failed(exit_code=2)))
+    assert breaker.stop_reason() is None
+    breaker.note_attempt()
+    breaker.record(failure_signature(_failed(exit_code=3)))
+    reason = breaker.stop_reason()
+    assert reason is not None and "max_repair_attempts" in reason
+
+
+# 功能：验证熔断器 b——连续两次验证签名相同（修复无效）即停，优先于轮数上限
+# 设计：max_attempts 给足 5，两次记录相同签名后 stop_reason 返回相同签名原因
+def test_circuit_breaker_stops_on_identical_signature() -> None:
+    breaker = RepairCircuitBreaker(5)
+    breaker.record(failure_signature(_failed(exit_code=1)))
+    breaker.note_attempt()
+    breaker.record(failure_signature(_failed(exit_code=1)))
+    reason = breaker.stop_reason()
+    assert reason is not None and "identical failure signature" in reason
+
+
+# 功能：验证熔断器 c——签名 A/B 来回震荡累计 3 次翻转即停
+# 设计：翻转定义为签名回到上上轮的值（A→B→A 计 1 次）；序列 A,B,A,B,A 产生 3 次翻转，
+# 期间每步 stop_reason 保持 None，最后一步返回震荡原因
+def test_circuit_breaker_stops_on_oscillation() -> None:
+    breaker = RepairCircuitBreaker(10)
+    sig_a = failure_signature(_failed(exit_code=1))
+    sig_b = failure_signature(_failed(exit_code=2))
+    for signature in (sig_a, sig_b, sig_a, sig_b):
+        breaker.record(signature)
+        assert breaker.stop_reason() is None
+        breaker.note_attempt()
+    breaker.record(sig_a)  # 第 3 次翻转
+    reason = breaker.stop_reason()
+    assert reason is not None and "oscillation" in reason
+
+
+# 功能：验证 stale 标记——证据摘要与当前工作区摘要不一致时标 stale，verified 结论降级不计入通过
+# 设计：verified 证据摘要为旧值 → stale=True、条件降级 stale、overall 由 verified 重算为 unverified；
+# 摘要一致的结果不被误标
+def test_mark_stale_evidence_downgrades_verified() -> None:
+    contract = _contract(_cond("tests"))
+    stale_result = _vresult(
+        VerificationOutcome.VERIFIED,
+        _cond_result(
+            "tests",
+            VerificationOutcome.VERIFIED,
+            evidence=_evidence("tests", 0, digests={"a.py": "old-digest"}),
+        ),
+    )
+    assert mark_stale_evidence(stale_result, contract, {"a.py": "new-digest"}) is True
+    [cond_result] = stale_result.results
+    assert cond_result.evidence is not None and cond_result.evidence.stale is True
+    assert cond_result.outcome is VerificationOutcome.STALE
+    assert stale_result.overall is VerificationOutcome.UNVERIFIED
+
+    fresh_result = _vresult(
+        VerificationOutcome.VERIFIED,
+        _cond_result(
+            "tests",
+            VerificationOutcome.VERIFIED,
+            evidence=_evidence("tests", 0, digests={"a.py": "same"}),
+        ),
+    )
+    assert mark_stale_evidence(fresh_result, contract, {"a.py": "same"}) is False
+    assert fresh_result.overall is VerificationOutcome.VERIFIED
+
+
+# 功能：验证修复提示包含失败条件的 id/描述/退出码/日志尾部，且不含已通过条件
+# 设计：落盘一个多行日志文件，断言提示含末尾行而不含超出尾部窗口的首行
+def test_build_repair_prompt_contents(tmp_path: Path) -> None:
+    log_path = tmp_path / "verification" / "tests.log"
+    log_path.parent.mkdir(parents=True)
+    log_lines = [f"line-{i}" for i in range(40)]
+    log_path.write_text("\n".join(log_lines), encoding="utf-8")
+    contract = _contract(_cond("tests"), _cond("lint"))
+    result = _vresult(
+        VerificationOutcome.FAILED,
+        _cond_result(
+            "tests",
+            VerificationOutcome.FAILED,
+            evidence=_evidence("tests", 7, output_path=str(log_path)),
+            message="check command exited with code 7",
+        ),
+        _cond_result("lint", VerificationOutcome.VERIFIED, exit_code=0),
+    )
+    prompt = build_repair_prompt(result, contract)
+    assert "condition: tests" in prompt
+    assert "desc-tests" in prompt
+    assert "exit_code: 7" in prompt
+    assert "line-39" in prompt  # 日志尾部保留
+    assert "line-0" not in prompt  # 超出 20 行尾部窗口被裁掉
+    assert "condition: lint" not in prompt  # 已通过条件不进提示
+
+
+# 功能：验证修复成功路径——首轮验证失败触发一轮修复，重验通过后落盘 verified
+# 设计：脚本 [failed, verified]；断言 provider 跑了 2 个回合、修复提示被注入、
+# RunOutcome 状态仍为 success 且 verification_status=verified，事件只发一对
+async def test_repair_loop_success_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outcome, provider, events = await _run_with_script(
+        tmp_path, monkeypatch, [_failed(), _verified()]
+    )
+    assert outcome.status == "success"
+    assert outcome.verification_status == "verified"
+    assert provider.calls == 2
+    assert any("[Verification failed]" in p for p in provider.user_prompts)
+    finished = [e for e in events if getattr(e, "type", "") == "verification.finished"]
+    assert [getattr(e, "outcome") for e in finished] == ["verified"]
+
+
+# 功能：验证 max_repair_attempts 熔断——轮数用尽后停止修复，落盘最后一次真实结果
+# 设计：max_attempts=1，脚本给 2 个签名不同的 failed（排除签名熔断）；
+# 断言只发生 1 轮修复（共 2 个回合）、脚本恰好耗尽、结果保持 failed 不伪装
+async def test_repair_loop_max_attempts_breaker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = [_failed(exit_code=1), _failed(exit_code=2)]
+    outcome, provider, events = await _run_with_script(
+        tmp_path, monkeypatch, script, max_attempts=1
+    )
+    assert outcome.verification_status == "failed"
+    assert provider.calls == 2  # 初始回合 + 1 轮修复
+    assert script == []  # 两次验证全部执行
+    finished = [e for e in events if getattr(e, "type", "") == "verification.finished"]
+    assert [getattr(e, "outcome") for e in finished] == ["failed"]
+
+
+# 功能：验证相同失败签名熔断——修复一轮后签名不变即停，不再烧掉剩余轮数
+# 设计：max_attempts 给足 5，脚本两个 failed 退出码相同（签名一致）；
+# 断言仅 1 轮修复后停止且结果为 failed
+async def test_repair_loop_identical_signature_breaker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = [_failed(exit_code=1), _failed(exit_code=1)]
+    outcome, provider, _ = await _run_with_script(
+        tmp_path, monkeypatch, script, max_attempts=5
+    )
+    assert outcome.verification_status == "failed"
+    assert provider.calls == 2  # 第 2 次验证签名相同 → 熔断，不再发起第 2 轮修复
+    assert script == []
+
+
+# 功能：验证 A/B 震荡熔断——签名在两个值间来回翻转累计 3 次即停
+# 设计：max_attempts=10，脚本按 A,B,A,B,A 给 5 个 failed；第 5 次验证产生第 3 次翻转，
+# 断言恰好 4 轮修复（共 5 个回合）后停止
+async def test_repair_loop_oscillation_breaker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = [
+        _failed(exit_code=1),
+        _failed(exit_code=2),
+        _failed(exit_code=1),
+        _failed(exit_code=2),
+        _failed(exit_code=1),
+    ]
+    outcome, provider, _ = await _run_with_script(
+        tmp_path, monkeypatch, script, max_attempts=10
+    )
+    assert outcome.verification_status == "failed"
+    assert provider.calls == 5  # 初始回合 + 4 轮修复
+    assert script == []
+
+
+# 功能：验证 require_verification=False 时零行为变化——不验证、不修复、不发验证事件
+# 设计：脚本留一个 failed 哨兵；断言 provider 只跑 1 回合、脚本未被消费、
+# verification_status 为 None 且事件流无 verification.*
+async def test_repair_loop_disabled_is_zero_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script = [_failed()]
+    outcome, provider, events = await _run_with_script(
+        tmp_path, monkeypatch, script, require=False
+    )
+    assert outcome.status == "success"
+    assert outcome.verification_status is None
+    assert provider.calls == 1
+    assert script == [_failed()]  # 哨兵未被消费
+    assert not [e for e in events if str(getattr(e, "type", "")).startswith("verification")]
+
+
+# 功能：验证 Evidence 摘要接通真实数据源——每轮验证收到 change tracker 的 after_digest，
+# 修复回合改动文件后摘要刷新，旧一轮证据被标 stale
+# 设计：provider 每回合往工作区写不同内容；断言两次 verify 收到的摘要分别是 v1/v2 的
+# sha256（复用 changes.py 的 digest 语义）且互不相同，首轮 failed 证据在重验前被标 stale
+async def test_repair_loop_digest_wiring_and_stale_marking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "f.txt"
+    target.write_text("v0", encoding="utf-8")
+    first = _vresult(
+        VerificationOutcome.FAILED,
+        _cond_result(
+            "tests",
+            VerificationOutcome.FAILED,
+            evidence=_evidence("tests", 1, digests={"f.txt": "captured-at-round-1"}),
+        ),
+    )
+    digest_calls: list[dict[str, str]] = []
+    outcome, provider, _ = await _run_with_script(
+        tmp_path,
+        monkeypatch,
+        [first, _verified()],
+        provider=_WritingProvider(target),
+        workspace_root=workspace,
+        digest_calls=digest_calls,
+    )
+    assert outcome.verification_status == "verified"
+    assert provider.calls == 2
+    assert digest_calls[0]["f.txt"] == hashlib.sha256(b"v1").hexdigest()
+    assert digest_calls[1]["f.txt"] == hashlib.sha256(b"v2").hexdigest()
+    assert digest_calls[0] != digest_calls[1]
+    # 重验前旧证据与新摘要不一致 → stale，且不再计入通过
+    [first_cond] = first.results
+    assert first_cond.evidence is not None and first_cond.evidence.stale is True
+    assert first_cond.outcome is VerificationOutcome.FAILED  # failed 保持原判，不被改写


### PR DESCRIPTION
## Summary

issue #94 的第四阶段（收尾）：**修复闭环**——门禁验证失败时不再直接落一个 failed 就结束，而是把失败详情（条件、退出码、日志尾部）作为 user 消息回注给同一个 Agent，驱动修复回合，修完再验，循环直至 verified 或熔断。配合三重熔断（轮数上限 / 相同失败签名 / A-B 震荡）防止无效修复烧预算，配合陈旧证据标记防止"改了代码还引用旧证据"的假通过。

不可动摇的底线贯穿实现：熔断或修复回合异常时，**保留最后一次真实验证结果落盘，绝不伪装成 verified**。

## Behavior

- 新增 `src/sztu_code/core/verification/repair.py`（除熔断器外均为纯函数，便于单测）：
  - `failure_signature(result)`：把一次验证结果压成排序后的 (condition_id, outcome, exit_code) 元组列表——连续两轮签名相同说明修复没有产生任何效果；
  - `RepairCircuitBreaker` 三重熔断，任一触发即停：a) 修复轮数达到 `max_repair_attempts`；b) 相同失败签名：连续两次验证签名相同；c) A/B 震荡：签名回到上上轮的值记一次翻转（A→B→A 计 1 次，首次出现新签名不算——那可能是进展），累计 3 次即停；
  - `build_repair_prompt`：逐条列出失败条件的 id/描述/退出码/日志尾部（尾部取 20 行、上限 2000 字符，防大日志撑爆上下文），日志读自第 2 层落盘的 `run_path/verification/<id>.log`；
  - `mark_stale_evidence`：证据的 workspace_digests 与当前工作区摘要不一致即标 `stale=True`；stale 证据不得计入通过，依赖它的 verified 结论降级为 stale 并重算 overall；
  - `digests_from_change_records`：从 changes.json 变更记录提取 {path: after_digest}，复用 `core/changes.py` 的 sha256，不重新实现 hash。
- `core/runner.py`：
  - 新增 `_repair_loop`：门禁验证结论为 failed 时，**复用同一 AgentLoop 与 ExecutionContext** 驱动修复回合（与既有 steering/拒绝干预注入同构）——消息历史保留、`max_steps`/墙钟/卡死等既有守卫全部继续生效（修复回合不是免费的额外预算）；把失败详情 append 为 user 消息、状态复位 running 后重新进入 loop.run；回合未正常以 success 结束（含预算耗尽）记 warning 并退出闭环；
  - 每轮修复后重新 finalize 变更、刷新工作区摘要，先对上一轮证据做陈旧标记再重新验证；每轮验证签名喂给熔断器；
  - 熔断触发记 warning，最终 `verification_status` 以最后一次真实验证结果为准；修复回合可能新增/回滚文件，变更记录与 `modification_status` 摘要同步刷新；
  - 闭环仅在 `verification.overall is FAILED` 且 `max_repair_attempts > 0` 时进入；置 0 行为退回第 2 层的单次验证。
- `core/config.py`：`AgentConfig` 新增 `max_repair_attempts: int = 2`（0 = 关闭修复闭环；不另设布尔开关——门禁本身由 `require_verification` 守卫，再加开关属冗余配置），带 TOML 校验与环境变量 `SZTU_MAX_REPAIR_ATTEMPTS` 覆盖。

默认路径（`require_verification=False`）行为与前置层逐字节一致，零回归。

## Validation

本系列（四个堆叠 PR）仅改动 Python 运行时（`src/sztu_code/core/`）与 Python 单测，不触及 packages/（TS 协议包）、desktop/ 与 docs/reference/wire-protocol.md（该文档现由 TS 侧生成），因此未运行 npm run typecheck / npm test / npm run build / npm run docs:protocol / npm run docs:links——无 TS 产物变化。本层无协议/事件变化。

实际运行的检查（环境：Windows 11 + Python 3.12 + uv；分支 = 四层叠加末端 90bb52f，基于 origin/main = 9404504）：

```text
# 仅本层针对性测试（本 PR 新增 tests/unit/test_verification_repair.py，全部用 fakes，无真实子进程/LLM）
uv run pytest tests/unit/test_verification_repair.py -q
→ 12 passed
  （覆盖：失败签名的稳定排序与 None 退出码、三重熔断各分支与"新签名不算翻转"、
   修复提示的日志尾部截断、陈旧证据标记与 verified→stale 降级重聚合、
   runner 修复闭环的成功收敛/熔断退出/回合异常退出、max_repair_attempts=0 关闭路径）

# 静态检查
uv run mypy src
→ Success: no issues found in 203 source files
uv run ruff check src tests
→ 仅 1 个既有 F401（tests/unit/test_tool_retry.py:277，上游遗留，本系列零改动）

# 全量单测（本分支即四层叠加末端 vs 裸 origin/main 基线）
uv run pytest tests/unit -q
→ 本分支：7 failed / 1017 passed
→ 裸 origin/main = 9404504 基线：7 failed / 988 passed
→ 失败集合逐项比对完全相同，零新增失败；+29 全部为本系列新增单测（第 2/3/4 层各 8+9+12 个；第 1 层 7 个已随 #112 计入 main 基线）
```

注：TypeScript CI 中 packages/runtime-ts/tests/npm-package.test.ts 的 subtest 19/20（npm entry daemon / --version）为 main 既有失败：该 workflow 自 #106 引入以来在 main 上从未通过，根因是 npm/sztucode-tui/scripts/install.js 在 Linux 上通过 node 执行 esbuild 的原生 ELF 二进制。本 PR 不触及 npm/、packages/runtime-ts/ 或 CI 配置，与该失败无关。

## Risk

- 兼容性：默认路径零回归（全量回归失败集合与基线逐项比对零差异）。新配置 `max_repair_attempts` 默认 2，但只有 `require_verification=true` 且验证 failed 时才可能进入闭环；两开关正交，任意一侧关闭即无修复回合。
- 预算与成本：修复回合复用同一 context，`max_steps`、墙钟预算继续计数而非重置——修复不是无限免费重试，预算耗尽时闭环随 loop 的既有守卫自然终止，并按"回合未正常结束"路径退出。极端情况下开启门禁+闭环的 run 耗时/token 成本上界约为 (1 + max_repair_attempts) 倍的检查与修复开销，由三重熔断和既有预算共同封顶。
- 正确性底线：所有退出路径（熔断、回合异常、修复后仍失败）都持久化最后一次真实验证结果；陈旧证据机制保证"修复后没重验的旧通过证据"不会被计入——不存在伪装 verified 的路径。
- 震荡熔断的边界：A→B→A 翻转阈值 3 次是经验值，过松会多烧几轮预算（仍被轮数上限封顶），过紧可能误杀正在收敛的修复；当前取值偏保守，后续可按实际评测数据调整。
- 回滚方式：单 commit（90bb52f），直接 revert 即退回第 3 层（门禁+发现、无闭环）；或运行时置 `max_repair_attempts=0` 达到同等效果，无需回滚代码。
- 协议同步（系列级声明收口）：RunFinishedEvent 的 verification_status / modification_status 字段与 verification.started / verification.finished 事件同步进 packages/ 的 TS protocol 包，属本系列之后的独立后续工作；在此之前 TS 侧无这些字段的类型定义（运行时因字段可空不受影响）。

## UI evidence

N/A（Harness 内部修复闭环逻辑，无 TUI/桌面端视觉变化）。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加或更新与风险匹配的测试（新增 tests/unit/test_verification_repair.py，12 个用例，全部使用 fakes）。
- [ ] 协议变化已重新生成 `docs/reference/wire-protocol.md`。（N/A：本层无协议变化；该文档现由 TS 侧生成，系列级 TS protocol 包同步声明见 Risk 末条）
- [ ] 用户文档、配置示例和迁移说明已同步。（未同步，如实声明：`require_verification` / `verification_check_timeout_s` / `max_repair_attempts` 与 `.sztu/checks.toml` 的用户文档建议在四层合入后统一补一份，作为 Epic #94 的收尾任务）
- [x] 提交包含 `Signed-off-by`（DCO）。