### PR TITLE
Fix background subagent lifecycle cleanup

### DIFF
--- a/docs/reference/wire-protocol.md
+++ b/docs/reference/wire-protocol.md
@@ -57,6 +57,7 @@
 - `session.compact`
 - `session.create`
 - `session.delete`
+- `session.fork`
 - `session.get`
 - `session.get_history`
 - `session.history`
@@ -205,6 +206,14 @@
 | `mode` | `"one_shot" \| "chat"` | no |
 | `title` | `string` | no |
 | `workspace_id` | `string \| null` | no |
+
+### SessionForkParams
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `type` | `"session.fork"` | no |
+| `session_id` | `string` | yes |
+| `title` | `string` | no |
 
 ### SessionGetParams
 

--- a/npm/sztucode-tui/scripts/install.js
+++ b/npm/sztucode-tui/scripts/install.js
@@ -1,6 +1,7 @@
 import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
 import { prepareSkillAssets } from "../../../scripts/prepare-skill-assets.js";
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -19,9 +20,7 @@ const cliSource = resolve(repositoryRoot, "packages/cli/src/main.ts"); const cli
 rmSync(cliTarget, { recursive: true, force: true }); mkdirSync(cliTarget, { recursive: true });
 const runtimeTarget = resolve(packageRoot, "runtime"); rmSync(runtimeTarget, { recursive: true, force: true }); mkdirSync(runtimeTarget, { recursive: true });
 const runtimeSource = resolve(repositoryRoot, "packages/runtime-ts/src/main.ts");
-const esbuild = resolve(repositoryRoot, "node_modules/esbuild/bin/esbuild");
-const cliBundle = await import("node:child_process").then(({ spawnSync }) => spawnSync(process.execPath, [esbuild, cliSource, "--bundle", "--platform=node", "--format=esm", `--outfile=${resolve(cliTarget, "main.js")}`], { cwd: repositoryRoot, stdio: "inherit", windowsHide: true }));
-if (cliBundle.status !== 0) process.exit(cliBundle.status ?? 1);
-const bundled = await import("node:child_process").then(({ spawnSync }) => spawnSync(process.execPath, [esbuild, runtimeSource, "--bundle", "--platform=node", "--format=esm", `--outfile=${resolve(runtimeTarget, "main.js")}`], { cwd: repositoryRoot, stdio: "inherit", windowsHide: true }));
-if (bundled.status !== 0) process.exit(bundled.status ?? 1);
+const sharedBuildOptions = { bundle: true, platform: "node", format: "esm", absWorkingDir: repositoryRoot };
+await build({ ...sharedBuildOptions, entryPoints: [cliSource], outfile: resolve(cliTarget, "main.js") });
+await build({ ...sharedBuildOptions, entryPoints: [runtimeSource], outfile: resolve(runtimeTarget, "main.js") });
 console.log("Bundled the TypeScript runtime and CLI for npm publishing.");

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -48,6 +48,7 @@ export interface WorkspaceSummary { workspace_id: string; path: string; name: st
 export interface WorkspaceOpenResult { workspace: WorkspaceSummary }
 export interface WorkspaceListResult { workspaces: WorkspaceSummary[] }
 export interface SessionCreateParams { type?: "session.create"; mode?: "one_shot" | "chat"; title?: string; workspace_id?: string | null }
+export interface SessionForkParams { type?: "session.fork"; session_id: string; title?: string }
 export interface SessionGetParams { type?: "session.get"; session_id: string }
 export interface SessionListParams { type?: "session.list"; include_archived?: boolean }
 export interface SessionHistoryParams { type?: "session.history" | "session.get_history"; session_id: string }

--- a/packages/runtime-ts/src/server.ts
+++ b/packages/runtime-ts/src/server.ts
@@ -1,5 +1,5 @@
 import net from "node:net";
-import type { JsonRpcRequest, JsonRpcResponse, EventEnvelope, AgentRunParams, PingParams, RunCancelParams, RunGetParams, RunReplayParams, PermissionRespondParams, SessionCreateParams, SessionGetParams, SessionListParams, SessionHistoryParams, SessionSendMessageParams } from "@sztucode/protocol";
+import type { JsonRpcRequest, JsonRpcResponse, EventEnvelope, AgentRunParams, PingParams, RunCancelParams, RunGetParams, RunReplayParams, PermissionRespondParams, SessionCreateParams, SessionForkParams, SessionGetParams, SessionListParams, SessionHistoryParams, SessionSendMessageParams } from "@sztucode/protocol";
 import { EventBus } from "./event-bus.js";
 import { RunManager } from "./run-manager.js";
 import { SessionStore } from "./session-store.js";
@@ -322,6 +322,7 @@ export class RuntimeServer {
         return ok(request.id, { accepted, ok: accepted });
       }
       case "session.rename": { const params = request.params as { session_id: string; title: string }; return ok(request.id, { session: toSessionSummary(await this.sessions.rename(params.session_id, params.title)) }); }
+      case "session.fork": { const params = request.params as unknown as SessionForkParams; if (this.runs.hasActiveSession(params.session_id)) throw new RpcDispatchError(SESSION_BUSY, "session busy"); const forked = await this.sessions.fork(params.session_id, params.title ?? ""); this.events.publish({ type: "session.created", session_id: forked.id, mode: forked.mode, ts: new Date().toISOString() }); return ok(request.id, { session: toSessionSummary(forked) }); }
       case "session.archive": { const params = request.params as { session_id: string }; if (this.runs.hasActiveSession(params.session_id)) throw new RpcDispatchError(SESSION_BUSY, "session busy"); return ok(request.id, { session: toSessionSummary(await this.sessions.setArchived(params.session_id, true)) }); }
       case "session.resume": { const params = request.params as { session_id: string }; if (this.runs.hasActiveSession(params.session_id)) throw new RpcDispatchError(SESSION_BUSY, "session busy"); return ok(request.id, { session: toSessionSummary(await this.sessions.setArchived(params.session_id, false)) }); }
       // Pinning only changes session metadata, so it remains available while a

--- a/packages/runtime-ts/src/session-store.ts
+++ b/packages/runtime-ts/src/session-store.ts
@@ -17,6 +17,20 @@ export class SessionStore {
     const session: Session = { id, mode, status: "active", title: title.trim().slice(0, 200) || "新会话", created_at: ts, updated_at: ts, run_ids: [], run_stats: {}, archived: false, pinned: false, workspace_id: workspaceId };
     await this.save(session); return session;
   }
+  // Fork a persisted session: 分配新 ID，复制源 session 的 user/assistant 可见历史，
+  // 继承 workspace_id 与 mode，但不复制 run 统计或 active 状态（对齐 Python SessionManager.fork）。
+  async fork(sessionId: string, title = ""): Promise<Session> {
+    const source = await this.get(sessionId);
+    const id = randomUUID(); const ts = new Date().toISOString();
+    const forked: Session = { id, mode: source.mode, status: "waiting_for_input", title: title.trim().slice(0, 200) || `Fork of ${source.title || source.id}`, created_at: ts, updated_at: ts, run_ids: [], run_stats: {}, archived: false, pinned: false, workspace_id: source.workspace_id };
+    await this.save(forked);
+    for (const message of await this.history(sessionId)) {
+      if (message.role === "user" || message.role === "assistant") {
+        await this.appendMessage(id, { role: message.role, content: message.content });
+      }
+    }
+    return forked;
+  }
   async get(id: string): Promise<Session> { return JSON.parse(await readFile(path.join(this.root, id, "meta.json"), "utf8")) as Session; }
   async rename(id: string, title: string): Promise<Session> { const session = await this.get(id); session.title = title.trim().slice(0, 200); session.updated_at = new Date().toISOString(); await this.save(session); return session; }
   async setArchived(id: string, archived: boolean): Promise<Session> { const session = await this.get(id); session.archived = archived; if (archived) session.pinned = false; else if (session.mode === "chat") session.status = "waiting_for_input"; session.updated_at = new Date().toISOString(); await this.save(session); return session; }

--- a/packages/runtime-ts/tests/offload.test.ts
+++ b/packages/runtime-ts/tests/offload.test.ts
@@ -51,13 +51,14 @@ test("disabled offload creates no files", async () => {
 
 test("agent loop falls back to bounded context when offload storage fails", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-offload-fallback-"));
+  const events = new EventBus(path.join(root, "events.jsonl"));
   try {
     const blocked = path.join(root, "not-a-directory"); await writeFile(blocked, "file");
     let calls = 0; let observed = "";
     const provider: ModelProvider = { complete: async (messages) => { calls += 1; if (calls === 1) return { text: "", tool_calls: [{ id: "large", name: "read_file", input: { path: "large.txt" } }], stop_reason: "tool_use" }; observed = String(messages.at(-1)?.content ?? ""); return { text: "done", tool_calls: [], stop_reason: "end_turn" }; } };
     await writeFile(path.join(root, "large.txt"), "x".repeat(20_000));
-    const loop = new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, new EventBus(path.join(root, "events.jsonl")), { check: async () => true }, { offloadRoot: blocked, offloadMinChars: 100 });
+    const loop = new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, events, { check: async () => true }, { offloadRoot: blocked, offloadMinChars: 100 });
     assert.equal((await loop.run("fallback", "read it", 3)).text, "done");
     assert.match(observed, /chars omitted/); assert.ok(observed.length <= 4_000);
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });

--- a/packages/runtime-ts/tests/runtime.test.ts
+++ b/packages/runtime-ts/tests/runtime.test.ts
@@ -52,8 +52,9 @@ test("workflow scope upgrades only out-of-scope file writes", async () => {
 
 test("agent loop publishes thinking deltas and preserves signed blocks in history", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-thinking-loop-"));
+  const events = new EventBus(path.join(root, "events.jsonl"));
   try {
-    const events = new EventBus(path.join(root, "events.jsonl")); const thinking: string[] = [];
+    const thinking: string[] = [];
     events.subscribe((event) => { if (event.type === "llm.thinking") thinking.push(event.thinking); });
     const provider: ModelProvider = { complete: async (_messages, _tools, _signal, _onToken, _invocation, onThinking) => {
       onThinking?.("inspect "); onThinking?.("files");
@@ -62,13 +63,14 @@ test("agent loop publishes thinking deltas and preserves signed blocks in histor
     const result = await new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, events, { check: async () => true }).run("thinking-run", "work", 1);
     assert.deepEqual(thinking, ["inspect ", "files"]);
     assert.deepEqual(result.messages.at(-1)?.content, [{ type: "thinking", thinking: "inspect files", signature: "signed-1" }, { type: "text", text: "done" }]);
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });
 
 test("agent loop auto-compacts at the configured threshold and preserves the initial goal", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-auto-compact-"));
+  const events = new EventBus(path.join(root, "events.jsonl"));
   try {
-    const events = new EventBus(path.join(root, "events.jsonl")); const compacted: any[] = []; const purposes: string[] = [];
+    const compacted: any[] = []; const purposes: string[] = [];
     events.subscribe((event) => { if (event.type === "context.compacted") compacted.push(event); });
     let agentCalls = 0; const provider: ModelProvider = { complete: async (_messages, _tools, _signal, _onToken, invocation) => {
       purposes.push(invocation?.purpose ?? "agent");
@@ -79,7 +81,7 @@ test("agent loop auto-compacts at the configured threshold and preserves the ini
     const history = [{ role: "user" as const, content: "original goal" }, ...Array.from({ length: 8 }, (_, index) => ({ role: index % 2 ? "user" as const : "assistant" as const, content: `turn-${index} ${"detail ".repeat(20)}` }))];
     const result = await new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, events, { check: async () => true }, { sessionId: "session-1", contextWindow: 100, compactThreshold: 0.70, slidingWindowSize: 2, compactMinimumOldTokens: 0 }).run("compact-run", "continue", 2, history);
     assert.deepEqual(purposes, ["agent", "compaction", "agent"]); assert.equal(result.compacted, true); assert.equal(result.contextPct, 0.8); assert.equal(result.messages.some((message) => message.content === "original goal"), true); assert.equal(compacted.length, 1);
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });
 
 test("agent loop treats a 0 context window as auto and never reports 100% usage", async () => {
@@ -112,6 +114,7 @@ test("agent loop stops automatic compaction after consecutive summary failures",
 
 test("agent loop uses a tool-free conclusion when the final allowed step calls tools", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-max-step-conclusion-"));
+  const events = new EventBus(path.join(root, "events.jsonl"));
   try {
     const toolCounts: number[] = []; const progress: Array<{ steps: number; output: number }> = []; let calls = 0;
     const provider: ModelProvider = { complete: async (_messages, tools) => {
@@ -120,10 +123,10 @@ test("agent loop uses a tool-free conclusion when the final allowed step calls t
       return { text: "[COMPLETE] finished at the boundary", tool_calls: [], stop_reason: "end_turn", usage: { input_tokens: 12, output_tokens: 4 } };
     } };
     await writeFile(path.join(root, "package.json"), "{}", "utf8");
-    const result = await new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, new EventBus(path.join(root, "events.jsonl")), { check: async () => true }, { onProgress: ({ steps, usage }) => progress.push({ steps, output: usage.output_tokens }) }).run("max-step", "inspect", 1);
+    const result = await new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, events, { check: async () => true }, { onProgress: ({ steps, usage }) => progress.push({ steps, output: usage.output_tokens }) }).run("max-step", "inspect", 1);
     assert.equal(result.text, "finished at the boundary"); assert.equal(result.steps, 1); assert.equal(result.usage.output_tokens, 6);
     assert.ok(toolCounts[0]! > 0); assert.equal(toolCounts[1], 0); assert.deepEqual(progress, [{ steps: 1, output: 2 }, { steps: 1, output: 6 }]);
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });
 
 test("run manager reports real progress when a step-limited run remains incomplete", async () => {
@@ -151,15 +154,17 @@ test("agent loop applies dynamic bash permission before approval", async () => {
 
 test("permission always decisions persist while full-access calls still require approval", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-permission-policy-"));
+  const eventBuses: EventBus[] = [];
   try {
     const policyPath = path.join(root, "policy.toml");
-    const firstEvents = new EventBus(path.join(root, "first-events.jsonl"));
+    const firstEvents = new EventBus(path.join(root, "first-events.jsonl")); eventBuses.push(firstEvents);
     const first = new PermissionManager(firstEvents, 100, policyPath);
     const pending = first.check("run-1", "permission-1", "write_file", { path: "src/a.ts" }, "workspace_write");
     assert.equal(first.respond("permission-1", "always_allow"), true);
     assert.equal(await pending, true);
 
-    const second = new PermissionManager(new EventBus(path.join(root, "second-events.jsonl")), 10, policyPath);
+    const secondEvents = new EventBus(path.join(root, "second-events.jsonl")); eventBuses.push(secondEvents);
+    const second = new PermissionManager(secondEvents, 10, policyPath);
     assert.equal(await second.check("run-2", "permission-2", "write_file", { path: "src/b.ts" }, "workspace_write"), true);
     assert.equal(await second.check("run-2", "permission-3", "write_file", { path: "docs/b.ts" }, "danger_full_access"), false);
     assert.match(await readFile(policyPath, "utf8"), /write_file = "allow"/);
@@ -167,15 +172,16 @@ test("permission always decisions persist while full-access calls still require 
     const denyPending = second.check("run-2", "permission-4", "edit_file", { path: "src/a.ts" }, "workspace_write");
     assert.equal(second.respond("permission-4", "always_deny"), true);
     assert.equal(await denyPending, false);
-    const third = new PermissionManager(new EventBus(path.join(root, "third-events.jsonl")), 10, policyPath);
+    const thirdEvents = new EventBus(path.join(root, "third-events.jsonl")); eventBuses.push(thirdEvents);
+    const third = new PermissionManager(thirdEvents, 10, policyPath);
     assert.equal(await third.check("run-3", "permission-5", "edit_file", { path: "src/b.ts" }, "workspace_write"), false);
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await Promise.all(eventBuses.map((bus) => bus.flush())); await rm(root, { recursive: true, force: true }); }
 });
 
 test("agent loop injects a traceable intervention after repeated permission denials", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-denial-intervention-"));
+  const events = new EventBus(path.join(root, "events.jsonl"));
   try {
-    const events = new EventBus(path.join(root, "events.jsonl"));
     const trace: string[] = [];
     events.subscribe((event) => trace.push(event.type));
     const seenMessages: string[] = [];
@@ -190,7 +196,7 @@ test("agent loop injects a traceable intervention after repeated permission deni
     assert.equal(result.text, "changed approach");
     assert.match(seenMessages[3] ?? "", /repeatedly rejected/);
     assert.ok(trace.includes("denial.intervention"));
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });
 
 test("agent loop injects a traceable intervention after the same tool failure repeats", async () => {

--- a/packages/runtime-ts/tests/schema-validator.test.ts
+++ b/packages/runtime-ts/tests/schema-validator.test.ts
@@ -19,12 +19,13 @@ test("schema validator enforces nested types, ranges, enums, and required fields
 
 test("agent loop rejects invalid tool JSON before permission or invocation", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-schema-boundary-"));
+  const events = new EventBus(path.join(root, "events.jsonl"));
   try {
     let permissions = 0; let calls = 0; const failures: Array<{ error_class: string; error_message: string }> = [];
-    const events = new EventBus(path.join(root, "events.jsonl")); events.subscribe((event) => { if (event.type === "tool.call_failed") failures.push(event); });
+    events.subscribe((event) => { if (event.type === "tool.call_failed") failures.push(event); });
     const provider: ModelProvider = { complete: async () => { calls += 1; return calls === 1 ? { text: "", tool_calls: [{ id: "bad", name: "bash", input: { command: 42, timeout: 500 } }], stop_reason: "tool_use" } : { text: "fixed", tool_calls: [], stop_reason: "end_turn" }; } };
     const loop = new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, events, { check: async () => { permissions += 1; return true; } });
     assert.equal((await loop.run("schema", "run", 3)).text, "fixed");
     assert.equal(permissions, 0); assert.equal(failures[0]?.error_class, "schema_error"); assert.match(failures[0]?.error_message ?? "", /command must be string/);
-  } finally { await rm(root, { recursive: true, force: true }); }
+  } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });

--- a/packages/runtime-ts/tests/server.test.ts
+++ b/packages/runtime-ts/tests/server.test.ts
@@ -97,6 +97,40 @@ test("workflow runs can be cancelled and queried through the shared run controls
   } finally { await server.close(); restoreEnv("SZTU_DATA_DIR", previous); await rm(root, { recursive: true, force: true }); }
 });
 
+test("session.fork clones history into a new session and leaves the original intact", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-runtime-fork-test-")); const previous = process.env.SZTU_DATA_DIR; process.env.SZTU_DATA_DIR = root;
+  const server = new RuntimeServer("127.0.0.1", 0);
+  const address = await server.listen(); const port = Number(address.split(":").at(-1)); const socket = net.createConnection({ host: "127.0.0.1", port }); await new Promise<void>((resolve, reject) => { socket.once("connect", () => resolve()); socket.once("error", reject); });
+  try {
+    const created = await rpc(socket, "session.create", { mode: "chat", title: "original" });
+    const sessionId = created.session_id;
+    await server.sessions.appendMessage(sessionId, { role: "user", content: "first user turn" });
+    await server.sessions.appendMessage(sessionId, { role: "assistant", content: "first assistant turn" });
+
+    const forked = await rpc(socket, "session.fork", { session_id: sessionId });
+    const forkId = forked.session.session_id;
+    assert.notEqual(forkId, sessionId);
+    assert.equal(forked.session.status, "waiting_for_input");
+    assert.equal(forked.session.workspace_id, null);
+    assert.match(forked.session.title, /Fork of original/);
+
+    const forkHistory = await rpc(socket, "session.history", { session_id: forkId });
+    assert.equal(forkHistory.messages.length, 2);
+    assert.equal(forkHistory.messages[0].role, "user");
+    assert.equal(forkHistory.messages[0].content, "first user turn");
+    assert.equal(forkHistory.messages[1].role, "assistant");
+    assert.equal(forkHistory.messages[1].content, "first assistant turn");
+
+    // 原会话历史不受 fork 影响
+    const originalHistory = await rpc(socket, "session.history", { session_id: sessionId });
+    assert.equal(originalHistory.messages.length, 2);
+    assert.equal(originalHistory.messages[0].content, "first user turn");
+
+    // fork 不存在的源 session 报错
+    await assert.rejects(() => rpc(socket, "session.fork", { session_id: "missing" }));
+  } finally { socket.destroy(); await server.close(); restoreEnv("SZTU_DATA_DIR", previous); await rm(root, { recursive: true, force: true }); }
+});
+
 test("manual session.compact uses provider summary and persists continuation messages", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-runtime-compact-test-")); const previous = process.env.SZTU_DATA_DIR; process.env.SZTU_DATA_DIR = root;
   let compactionPrompt = "";

--- a/src/sztu_code/core/loop.py
+++ b/src/sztu_code/core/loop.py
@@ -57,7 +57,11 @@ def _now() -> str:
 def _unwrap_provider(provider: LLMProvider) -> object:
     current: object = provider
     seen: set[int] = set()
-    while hasattr(current, "_inner") and id(current) not in seen:
+    # 深度上限防止 MagicMock 这类"任意属性访问恒返回新 mock"的 provider 导致无限解包；
+    # 真实 wrapper 链（如 TraceProvider→Provider）层数有限，8 层足以覆盖。
+    for _ in range(8):
+        if not hasattr(current, "_inner") or id(current) in seen:
+            break
         seen.add(id(current))
         current = getattr(current, "_inner")
     return current
@@ -177,6 +181,8 @@ class AgentLoop:
         session_id: str = "",
         task_registry: BackgroundTaskRegistry | None = None,
         offload_manager: OffloadManager | None = None,
+        # 外部注入的 steer 消息收件箱；SessionManager 运行时投递追加指令，loop 每步排空
+        steering_queue: asyncio.Queue[dict[str, object]] | None = None,
         wrap_up_on_max_steps: bool = True,
         grace_step_on_max_steps: bool = True,
         stuck_tracker: StuckLoopTracker | None = None,
@@ -206,6 +212,7 @@ class AgentLoop:
         self._session_id = session_id
         self._task_registry = task_registry
         self._offload_manager = offload_manager
+        self._steering_queue = steering_queue
         self._wrap_up_on_max_steps = wrap_up_on_max_steps
         self._grace_step_on_max_steps = grace_step_on_max_steps
         self._stuck_tracker = stuck_tracker
@@ -514,13 +521,12 @@ class AgentLoop:
                         is_error=True,
                     )
 
-            # 仅在真正终止的那一步（end_turn 或 max_steps 已到）才等待后台 subagent 落定，
-            # 避免中间 tool_use 步骤过早清空 pending 导致最终摘要丢失
+            # 仅在确定会以正常 success 收尾（end_turn）时才等待后台 subagent 落定并读取摘要。
+            # 中断路径（max_steps / wall_clock / 预算 / blocking_limit / repeated_error）不在此
+            # 等待未完成 child——先让根 context 确定终态退出 loop，再由 runner 调
+            # cancel_descendants 取消并等待后代，避免父 run 因永不返回的 child 卡死。
             pending_summaries: list[str] = []
-            if context.pending_background_run_ids and (
-                response.stop_reason == "end_turn"
-                or (context.max_steps > 0 and context.step >= context.max_steps)
-            ):
+            if context.pending_background_run_ids and response.stop_reason == "end_turn":
                 pending_summaries = await self._wait_for_background(context)
 
             steering_count = self._drain_steering(context)
@@ -780,7 +786,8 @@ class AgentLoop:
         # 未按标记作答但正常 end_turn：与普通回合一致，信任为完成
         return (True, text)
 
-    # 等待本 run 派生的后台 subagent 全部结束，返回每条的结果摘要
+    # 等待本 run 派生的后台 subagent 全部结束，返回每条的结果摘要。
+    # 只读取结果摘要，不消费/回收记录，使 agent_result 仍有读取机会。
     async def _wait_for_background(
         self, context: ExecutionContext
     ) -> list[str]:
@@ -788,21 +795,33 @@ class AgentLoop:
             return []
         run_ids = sorted(context.pending_background_run_ids)
         context.pending_background_run_ids.clear()
-        entries = [self._task_registry.get(rid) for rid in run_ids]
-        tasks = [e[0] for e in entries if e is not None]
+        records = [self._task_registry.get(rid) for rid in run_ids]
+        # snapshot task 后再 await，避免持有可变迭代器跨 await
+        tasks = [r.task for r in records if r is not None and r.task is not None]
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         summaries: list[str] = []
-        for rid, entry in zip(run_ids, entries):
-            if entry is None:
+        for rid, record in zip(run_ids, records):
+            if record is None:
                 summaries.append(f"[subagent {rid}] status=unknown")
                 continue
-            task, child_ctx = entry
-            if task.cancelled():
+            # 已被回收（消费/过期）的记录：用终态详情，不再访问已释放的 context
+            if record.context is None or record.is_terminal:
+                if record.status.value == "reclaimed":
+                    summaries.append(f"[subagent {rid}] status=reclaimed")
+                else:
+                    text = (record.terminal_detail or "").strip()[:200]
+                    summaries.append(
+                        f"[subagent {rid}] status={record.status.value}: {text}"
+                    )
+                continue
+            task = record.task
+            if task is not None and task.cancelled():
                 summaries.append(f"[subagent {rid}] status=cancelled")
-            elif task.exception() is not None:
+            elif task is not None and task.exception() is not None:
                 summaries.append(f"[subagent {rid}] status=error: {task.exception()!r}")
             else:
+                child_ctx = record.context
                 text = (child_ctx.result or "").strip()[:200]
                 summaries.append(f"[subagent {rid}] status={child_ctx.status}: {text}")
         return summaries

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -11,6 +11,7 @@ from sztu_code.core.bus.events import (
     ContextInjectedEvent,
     RunFinishedEvent,
     RunStartedEvent,
+    SubagentFinishedEvent,
 )
 from sztu_code.core.changes import WorkspaceChangeTracker
 from sztu_code.core.compact.compactor import Compactor
@@ -187,6 +188,7 @@ class AgentRunner:
                 stuck_max_total=self._config.agent.stuck_max_total,
                 tool_max_concurrency=self._config.agent.tool_max_concurrency,
                 max_depth=self._config.workflow.max_depth,
+                owner_run_id=run_id,
             )
             if _ok("spawn_agent"):
                 registry.register(spawn_tool)
@@ -205,6 +207,11 @@ class AgentRunner:
     # 执行一次完整的 agent run（委托给 run_and_capture，忽略返回值）
     async def run(self, goal: str, *, run_id: str | None = None) -> None:
         await self.run_and_capture(goal, run_id=run_id)
+
+    # runner/daemon 生命周期结束时调用：取消并等待所有活跃后台后代，回收重型引用。
+    # 可安全重复调用。普通 run 结束不应调用此方法——否则会破坏 TTL/消费前结果保留。
+    async def shutdown(self) -> None:
+        await self._task_registry.shutdown()
 
     # 执行 agent run 并返回 RunOutcome（含最终文字结果）
     async def run_and_capture(
@@ -261,6 +268,40 @@ class AgentRunner:
         bus = self._bus if self._bus is not None else EventBus()
         for h in self._extra_handlers:
             bus.subscribe(h)
+
+        # 终态事件发布 task：由 _on_terminal 创建，在 RunFinishedEvent 发布前统一 await，
+        # 保证 subagent.finished 落盘先于 root run.finished，避免 fire-and-forget 丢失。
+        pending_publishes: list[asyncio.Task[None]] = []
+
+        # 注册终态回调：mark_terminal 赢家发布 SubagentFinishedEvent，覆盖协程未跑就被取消
+        # 的情况（task 在首次调度前被 cancel，_run_background 体不会执行）。
+        # COMPLETED 映射回 "success" 以保持与前台 spawn 路径（context.status）一致。
+        _STATUS_TO_EVENT: dict[str, str] = {
+            "completed": "success",
+            "failed": "failed",
+            "cancelled": "cancelled",
+        }
+
+        def _on_terminal(run_id: str, status: object) -> None:
+            raw = status.value if hasattr(status, "value") else str(status)
+            record = self._task_registry.get(run_id)
+            parent = record.parent_run_id if record is not None else run_id
+            pending_publishes.append(
+                asyncio.get_running_loop().create_task(
+                    bus.publish(
+                        SubagentFinishedEvent(
+                            run_id=run_id,
+                            parent_run_id=parent,
+                            status=_STATUS_TO_EVENT.get(raw, raw),
+                            ts=_now(),
+                        )
+                    )
+                )
+            )
+
+        # 按 owner_run_id（root run）注册 sink：整个后代树（含 grandchild）的终态事件
+        # 都路由到本 run 的 bus，多个 root 并发时互不串流。run 结束时注销避免泄漏。
+        self._task_registry.register_sink(run_id, _on_terminal)
 
         base_prompt = ""
         if not system_prompt_override:
@@ -413,6 +454,7 @@ class AgentRunner:
                     tool_max_concurrency=self._config.agent.tool_max_concurrency,
                     pricing_provider=self._config.llm.provider,
                     pricing_model=self._config.llm.default_model,
+                    steering_queue=steering_queue,
                 )
                 await loop.run(context)
             except asyncio.CancelledError:
@@ -425,6 +467,21 @@ class AgentRunner:
                 )
                 if not context.is_done():
                     context.mark_failed("llm_error")
+
+            # 父 run 非正常 success 收尾时递归取消并等待全部后台后代落定，
+            # 在 root finalization 可观察前完成清理。覆盖 failed、显式取消和所有
+            # interrupted 原因（max_steps/wall_clock/budget/blocking_limit）。
+            # 正常 success 的直接子由 _wait_for_background 等待并入结果，此处不处理。
+            if context.status != "success":
+                if cancelled:
+                    cancel_reason = "parent_cancelled"
+                elif context.status == "interrupted":
+                    cancel_reason = "parent_interrupted"
+                else:
+                    cancel_reason = "parent_failed"
+                await self._task_registry.cancel_descendants(
+                    run_id, reason=cancel_reason
+                )
 
             if change_tracker is not None:
                 changes = change_tracker.finalize()
@@ -454,6 +511,11 @@ class AgentRunner:
             if session is not None and store is not None:
                 session.run_stats[run_id] = final_stats
                 store.write_meta(session)
+            # 等待所有 subagent.finished 发布 task 落盘，确保子 Agent 终态事件
+            # 先于 root run.finished 写入，避免乱序或丢失
+            if pending_publishes:
+                await asyncio.gather(*pending_publishes, return_exceptions=False)
+                pending_publishes.clear()
             await bus.publish(
                 RunFinishedEvent(
                     run_id=run_id,
@@ -482,6 +544,12 @@ class AgentRunner:
                 store.write_compacted(session.id, context.messages)
             else:
                 store.append_messages(session.id, context.messages[prefill_len:], run_id=run_id)
+
+        # 普通 run 结束：仅做有界保留清理，保留完成子 Agent 的轻量结果供 agent_result
+        # 在 TTL 内查询。不调用 shutdown()——后者只在 runner/daemon 生命周期结束时使用。
+        self._task_registry.prune()
+        # 注销本 run 的终态 sink，避免多 run 复用时 sink 字典无限增长
+        self._task_registry.unregister_sink(run_id)
 
         if cancelled:
             raise asyncio.CancelledError()

--- a/src/sztu_code/core/subagent/__init__.py
+++ b/src/sztu_code/core/subagent/__init__.py
@@ -1,4 +1,16 @@
-from sztu_code.core.subagent.registry import BackgroundTaskRegistry
+from sztu_code.core.subagent.registry import (
+    AgentResultQuery,
+    BackgroundTaskRecord,
+    BackgroundTaskRegistry,
+    BackgroundTaskStatus,
+)
 from sztu_code.core.subagent.tool import AgentResultTool, SpawnAgentTool
 
-__all__ = ["BackgroundTaskRegistry", "SpawnAgentTool", "AgentResultTool"]
+__all__ = [
+    "AgentResultQuery",
+    "BackgroundTaskRecord",
+    "BackgroundTaskRegistry",
+    "BackgroundTaskStatus",
+    "SpawnAgentTool",
+    "AgentResultTool",
+]

--- a/src/sztu_code/core/subagent/registry.py
+++ b/src/sztu_code/core/subagent/registry.py
@@ -1,28 +1,414 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
 
 from sztu_code.core.context import ExecutionContext
 
+log = logging.getLogger(__name__)
 
-# 管理后台 subagent 任务的生命周期：注册、查询、批量取消
+
+# 后台 subagent 的生命周期状态
+class BackgroundTaskStatus(StrEnum):
+    RUNNING = "running"
+    CANCELING = "canceling"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    # reclaimed 是存储状态：终态记录被回收后的墓碑标记，而非第二种执行结果
+    RECLAIMED = "reclaimed"
+
+
+# 终态集合：completed / failed / cancelled 三者互斥，reclaimed 不属于执行终态
+_TERMINAL_OUTCOMES = frozenset(
+    {BackgroundTaskStatus.COMPLETED, BackgroundTaskStatus.FAILED, BackgroundTaskStatus.CANCELLED}
+)
+
+
+# 终态回调：run_id + 终态状态，由 registry 在 mark_terminal 赢家时触发。
+# 调用方（SpawnAgentTool）注册它来发布 SubagentFinishedEvent，使终态事件发布
+# 不依赖 _run_background 协程是否已执行（协程可能在首次调度前就被取消）。
+TerminalCallback = Callable[[str, "BackgroundTaskStatus"], object]
+
+
+# agent_result 查询的结构化返回：用一个值对象取代对原始 task 的直接解包，
+# 避免 agent_result 把"未知 ID"和"已被回收的已完成记录"混为一谈。
+@dataclass(frozen=True)
+class AgentResultQuery:
+    status: BackgroundTaskStatus
+    # 终态时携带的小型响应文本，避免暴露 traceback 内部
+    result_text: str = ""
+    reason: str = ""
+
+    @property
+    def is_running(self) -> bool:
+        return self.status is BackgroundTaskStatus.RUNNING
+
+    @property
+    def is_terminal_outcome(self) -> bool:
+        return self.status in _TERMINAL_OUTCOMES
+
+
+# 后台 subagent 的完整生命周期记录。一个后台子 agent 有且仅有一个 owner parent；
+# parent 终态或 daemon 关闭时，所有后代被取消并等待落定后清理才算完成。
+@dataclass
+class BackgroundTaskRecord:
+    run_id: str
+    parent_run_id: str
+    task: asyncio.Task[None] | None
+    context: ExecutionContext | None
+    status: BackgroundTaskStatus = BackgroundTaskStatus.RUNNING
+    created_at: float = 0.0
+    finished_at: float = 0.0
+    result_consumed: bool = False
+    # 终态详情：cancel 原因 / 失败消息 / 完成摘要，供 agent_result 返回
+    terminal_detail: str = ""
+    # owner_run_id：该子 Agent 所属的 root run id（整个后代树的根）。
+    # 与 parent_run_id（直接父，用于事件 payload）不同：owner 是 sink 路由键，
+    # 使 grandchild 的终态事件也能路由回 root 的 sink，而非因 parent=child 找不到 sink 丢失。
+    owner_run_id: str = ""
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in _TERMINAL_OUTCOMES or self.status is BackgroundTaskStatus.RECLAIMED
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in (BackgroundTaskStatus.RUNNING, BackgroundTaskStatus.CANCELING)
+
+    # 回收重型引用：释放 task 与 context.messages，避免 1000 条已完成记录留存 1000 份完整上下文。
+    # 保留 run_id / parent_run_id / 状态 / 终态详情，使 agent_result 仍能区分 reclaimed 与 unknown。
+    def reclaim(self, reason: str = "") -> None:
+        self.task = None
+        # context.messages 是主要内存占用；保留 context 仅会延续其引用链，故整体释放
+        self.context = None
+        self.status = BackgroundTaskStatus.RECLAIMED
+        if reason:
+            self.terminal_detail = reason
+
+
+# 管理后台 subagent 任务的生命周期：注册、查询、递归取消、有界保留、关闭清理
 class BackgroundTaskRegistry:
-    def __init__(self) -> None:
-        self._tasks: dict[str, tuple[asyncio.Task[None], ExecutionContext]] = {}
+    def __init__(
+        self,
+        *,
+        retention_ttl_s: float = 300.0,
+        max_retained_terminal: int = 256,
+        on_terminal: TerminalCallback | None = None,
+    ) -> None:
+        # run_id -> 记录；reclaimed 后以墓碑形式短暂保留，使 expired 与 unknown 可区分
+        self._records: dict[str, BackgroundTaskRecord] = {}
+        # parent_run_id -> 直接子 run_id 集合；reclaimed 时从索引移除
+        self._children: dict[str, set[str]] = {}
+        self._retention_ttl_s = retention_ttl_s
+        self._max_retained_terminal = max_retained_terminal
+        # 墓碑队列：按回收时间排序，供 max_retained_terminal 容量淘汰使用
+        self._tombstones: deque[tuple[str, float]] = deque()
+        self._shutdown_done = False
+        # 终态回调按 parent_run_id 路由：多 root run 并发时 A 的 child 终态事件
+        # 只发到 A 的 sink，不会被后注册的 B 覆盖。"_default" 为无匹配时的回退 sink。
+        self._sinks: dict[str, TerminalCallback] = {}
+        if on_terminal is not None:
+            self._sinks["_default"] = on_terminal
 
-    # 注册一个后台任务及其执行上下文
+    # 注册一个后台任务，记录所有权（parent_run_id + owner_run_id）使其在 task 可被
+    # agent_result 观察前就持久化。owner_run_id 为所属 root run，用于终态 sink 路由；
+    # parent_run_id 为直接父，用于事件 payload。owner 为空时回退为 parent_run_id。
     def register(
         self,
         run_id: str,
+        parent_run_id: str,
         task: asyncio.Task[None],
         context: ExecutionContext,
+        *,
+        owner_run_id: str = "",
     ) -> None:
-        self._tasks[run_id] = (task, context)
+        existing = self._records.get(run_id)
+        if existing is not None and not existing.is_terminal:
+            # 活动中的 run_id 重复注册会静默覆盖 task，导致原任务泄漏，故拒绝
+            raise ValueError(
+                f"background task already registered and active: run_id={run_id} "
+                f"status={existing.status.value}"
+            )
+        self._records[run_id] = BackgroundTaskRecord(
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            task=task,
+            context=context,
+            status=BackgroundTaskStatus.RUNNING,
+            created_at=_now(),
+            owner_run_id=owner_run_id or parent_run_id,
+        )
+        self._children.setdefault(parent_run_id, set()).add(run_id)
+        # 注册是安全生命周期点：触发有界保留清理（TTL + 容量），保持注册表不无限增长
+        self.prune()
 
-    # 查询后台任务及其上下文；不存在时返回 None
-    def get(self, run_id: str) -> tuple[asyncio.Task[None], ExecutionContext] | None:
-        return self._tasks.get(run_id)
+    # 查询记录；不存在或已回收时返回 None。调用方应改用 query_result 获取区分语义。
+    def get(self, run_id: str) -> BackgroundTaskRecord | None:
+        return self._records.get(run_id)
 
-    # 返回所有已注册的 (task, context) 对，用于 daemon 退出时批量清理
-    def all(self) -> list[tuple[asyncio.Task[None], ExecutionContext]]:
-        return list(self._tasks.values())
+    # 返回所有已注册记录的浅拷贝列表，用于 daemon 退出时批量清理
+    def all(self) -> list[BackgroundTaskRecord]:
+        return list(self._records.values())
+
+    # 记录终态并返回本次调用是否赢得了终态发布权。幂等：只有首个终态转换胜出，
+    # 由胜出方发布 SubagentFinishedEvent，杜绝重复终态事件。
+    def mark_terminal(
+        self,
+        run_id: str,
+        status: BackgroundTaskStatus,
+        *,
+        reason: str = "",
+        detail: str = "",
+        finished_at: float | None = None,
+    ) -> bool:
+        record = self._records.get(run_id)
+        if record is None:
+            return False
+        # 已是终态（含 reclaimed 墓碑）：绝不覆盖先到的终态
+        if record.is_terminal:
+            return False
+        if status not in _TERMINAL_OUTCOMES:
+            raise ValueError(f"mark_terminal requires a terminal outcome, got {status!r}")
+        record.status = status
+        # reason 优先（取消/失败原因），否则用 detail（完成结果文本）；统一存入 terminal_detail
+        record.terminal_detail = reason or detail
+        record.finished_at = finished_at if finished_at is not None else _now()
+        self._tombstones.append((run_id, record.finished_at))
+        self.prune(now=record.finished_at)
+        self._notify_terminal(run_id, status)
+        return True
+
+    # 返回 parent_run_id 的整个后代树（任意嵌套深度），按广度优先展开
+    def descendants(self, parent_run_id: str) -> list[str]:
+        ordered: list[str] = []
+        queue: deque[str] = deque(self._children.get(parent_run_id, ()))
+        seen: set[str] = set()
+        while queue:
+            rid = queue.popleft()
+            if rid in seen:
+                continue
+            seen.add(rid)
+            ordered.append(rid)
+            queue.extend(self._children.get(rid, ()))
+        return ordered
+
+    # 递归取消 parent_run_id 的所有后代：先标记 cancelling 再取消，等待全部落定后安全终结。
+    # snapshot 在首个 await 前完成，避免并发完成发布第二次终态。
+    async def cancel_descendants(
+        self,
+        parent_run_id: str,
+        *,
+        reason: str = "parent_cancelled",
+        now: float | None = None,
+    ) -> list[str]:
+        now_val = now if now is not None else _now()
+        tree = self.descendants(parent_run_id)
+        if not tree:
+            return []
+        # 第一阶段（同步）：把仍为 running 的后代标记为 cancelling，收集待取消的 task
+        to_cancel: list[asyncio.Task[None]] = []
+        cancelled_ids: list[str] = []
+        for rid in tree:
+            record = self._records.get(rid)
+            if record is None or not record.is_active:
+                continue
+            record.status = BackgroundTaskStatus.CANCELING
+            if record.task is not None and not record.task.done():
+                to_cancel.append(record.task)
+            cancelled_ids.append(rid)
+        # 第二阶段（await）：取消所有活动 task，单条失败不得阻断兄弟清理
+        for task in to_cancel:
+            task.cancel()
+        if to_cancel:
+            await asyncio.gather(*to_cancel, return_exceptions=True)
+        # 第三阶段（同步）：把仍在 cancelling 的后代安全终结为 cancelled；
+        # 已 completed/failed 的保持原终态，不可被取消覆盖。
+        # 用 mark_terminal 而非直接赋值，使终态回调触发且与协程路径共享赢家语义
+        # （若协程已在 mark_terminal 赢过，此处 won=False，不重复发事件）。
+        for rid in cancelled_ids:
+            record = self._records.get(rid)
+            if record is None:
+                continue
+            if record.status is BackgroundTaskStatus.CANCELING:
+                self.mark_terminal(
+                    rid, BackgroundTaskStatus.CANCELLED, reason=reason, finished_at=now_val
+                )
+        self.prune(now=now_val)
+        return cancelled_ids
+
+    # 消费终态结果：成功的终态读取在捕获小型响应后回收记录，使第二次查询返回 reclaimed
+    def consume_result(self, run_id: str, *, now: float | None = None) -> AgentResultQuery:
+        now_val = now if now is not None else _now()
+        record = self._records.get(run_id)
+        if record is None:
+            return AgentResultQuery(status=BackgroundTaskStatus.RUNNING, reason="unknown")
+        if record.status in (BackgroundTaskStatus.RUNNING, BackgroundTaskStatus.CANCELING):
+            return AgentResultQuery(status=BackgroundTaskStatus.RUNNING)
+        if record.status is BackgroundTaskStatus.RECLAIMED:
+            return AgentResultQuery(
+                status=BackgroundTaskStatus.RECLAIMED,
+                reason=record.terminal_detail or "expired_or_consumed",
+            )
+        # 终态（completed/failed/cancelled）：捕获小型响应后回收重型引用
+        result_text = self._terminal_text(record)
+        query = AgentResultQuery(
+            status=record.status, result_text=result_text, reason=record.terminal_detail
+        )
+        record.result_consumed = True
+        record.reclaim(reason="consumed")
+        self._drop_from_index(run_id)
+        self.prune(now=now_val)
+        return query
+
+    # agent_result 查询入口：区分 running / completed / cancelled / failed / reclaimed / unknown
+    def query_result(self, run_id: str) -> AgentResultQuery:
+        record = self._records.get(run_id)
+        if record is None:
+            return AgentResultQuery(status=BackgroundTaskStatus.RUNNING, reason="unknown")
+        if record.status in (BackgroundTaskStatus.RUNNING, BackgroundTaskStatus.CANCELING):
+            return AgentResultQuery(status=BackgroundTaskStatus.RUNNING)
+        if record.status is BackgroundTaskStatus.RECLAIMED:
+            return AgentResultQuery(
+                status=BackgroundTaskStatus.RECLAIMED,
+                reason=record.terminal_detail or "expired_or_consumed",
+            )
+        return AgentResultQuery(
+            status=record.status,
+            result_text=self._terminal_text(record),
+            reason=record.terminal_detail,
+        )
+
+    # 回收终态文本：优先用 context.result，失败/取消时用 terminal_detail，避免暴露 traceback
+    def _terminal_text(self, record: BackgroundTaskRecord) -> str:
+        if record.status is BackgroundTaskStatus.COMPLETED:
+            if record.context is not None and record.context.result:
+                return record.context.result
+            return record.terminal_detail or "Subagent completed with no text result."
+        if record.status is BackgroundTaskStatus.FAILED:
+            return record.terminal_detail or "Subagent failed."
+        if record.status is BackgroundTaskStatus.CANCELLED:
+            return record.terminal_detail or "Subagent was cancelled."
+        return record.terminal_detail
+
+    # 按容量淘汰最旧的终态记录（含墓碑），永不淘汰活动记录
+    def _prune_tombstones_by_count(self) -> None:
+        while len(self._tombstones) > self._max_retained_terminal:
+            run_id, _ = self._tombstones.popleft()
+            record = self._records.get(run_id)
+            if record is not None and record.is_terminal:
+                record.reclaim(reason="capacity_evicted")
+                self._drop_from_index(run_id)
+
+    # 在安全生命周期点执行的有界保留清理：TTL 过期 + 容量上限。
+    # 不持有可变迭代器跨 await，全程同步且廉价。公共入口供测试与生命周期点注入时钟调用。
+    def prune(self, *, now: float | None = None) -> None:
+        now_val = now if now is not None else _now()
+        # TTL 过期：终态记录超过保留窗口则回收并移出索引
+        if self._retention_ttl_s <= 0:
+            self._prune_tombstones_by_count()
+            return
+        retained: deque[tuple[str, float]] = deque()
+        for run_id, finished_at in self._tombstones:
+            record = self._records.get(run_id)
+            if record is None:
+                continue
+            if not record.is_terminal:
+                # 活动记录不应出现在墓碑队列，保留以备后续清理
+                retained.append((run_id, finished_at))
+                continue
+            if now_val - finished_at >= self._retention_ttl_s:
+                record.reclaim(reason="ttl_expired")
+                self._drop_from_index(run_id)
+            else:
+                retained.append((run_id, finished_at))
+        self._tombstones = retained
+        self._prune_tombstones_by_count()
+
+    # 按 owner_run_id（root run）注册终态回调，使该 root 的整棵后代树（含 grandchild
+    # 及更深）的终态事件都路由到同一 sink。多 root run 并发时互不覆盖；
+    # runner 在 run 结束时应调 unregister_sink 清理。
+    def register_sink(self, owner_run_id: str, callback: TerminalCallback) -> None:
+        self._sinks[owner_run_id] = callback
+
+    # 注销 owner_run_id 的 sink，避免 run 结束后回调闭包（bus/pending_publishes）泄漏
+    def unregister_sink(self, owner_run_id: str) -> None:
+        self._sinks.pop(owner_run_id, None)
+
+    # 设置终态回调：向后兼容别名，注册为默认 sink（无 owner_run_id 匹配时回退）。
+    # 新代码应改用 register_sink(owner_run_id, callback) 做精确路由。
+    def set_on_terminal(self, callback: TerminalCallback) -> None:
+        self._sinks["_default"] = callback
+
+    # 终态回调通知：仅 mark_terminal 赢家触发。按 record.owner_run_id 路由到对应 sink，
+    # 使 grandchild（owner=root，parent=child）也能路由回 root sink；
+    # 找不到则回退默认 sink，保证终态事件发布唯一且不依赖协程是否已执行。
+    def _notify_terminal(self, run_id: str, status: BackgroundTaskStatus) -> None:
+        record = self._records.get(run_id)
+        sink: TerminalCallback | None = None
+        if record is not None:
+            sink = self._sinks.get(record.owner_run_id)
+        if sink is None:
+            sink = self._sinks.get("_default")
+        if sink is None:
+            return
+        try:
+            sink(run_id, status)
+        except Exception:
+            log.exception("on_terminal callback failed run_id=%s status=%s", run_id, status)
+
+    # 从父->子索引中移除指定 run_id（自身作为父节点的子树保留，因为孙节点仍可能被引用）
+    def _drop_from_index(self, run_id: str) -> None:
+        record = self._records.get(run_id)
+        if record is None:
+            return
+        siblings = self._children.get(record.parent_run_id)
+        if siblings is not None:
+            siblings.discard(run_id)
+            if not siblings:
+                self._children.pop(record.parent_run_id, None)
+
+    # 取消并等待所有活动 task 落定，再释放保留的重型引用。可安全重复调用。
+    async def shutdown(self, *, now: float | None = None) -> None:
+        if self._shutdown_done:
+            return
+        self._shutdown_done = True
+        now_val = now if now is not None else _now()
+        # snapshot 活动 task，避免跨 await 持有可变迭代器
+        active = [
+            (rid, rec.task)
+            for rid, rec in self._records.items()
+            if rec.is_active and rec.task is not None and not rec.task.done()
+        ]
+        for _, task in active:
+            task.cancel()
+        if active:
+            await asyncio.gather(*[t for _, t in active], return_exceptions=True)
+        # 活动记录用 mark_terminal 终结为 cancelled（不覆盖已完成的终态），
+        # 并通过 on_terminal 回调发布终态事件；已终态记录保持原结果。
+        for record in self._records.values():
+            if record.is_active:
+                self.mark_terminal(
+                    record.run_id,
+                    BackgroundTaskStatus.CANCELLED,
+                    reason="daemon_shutdown",
+                    finished_at=now_val,
+                )
+        # 全部回收重型引用（终态记录保留状态详情，释放 task/context）
+        for record in self._records.values():
+            if record.status is not BackgroundTaskStatus.RECLAIMED:
+                record.reclaim(reason="shutdown")
+        self._children.clear()
+        self._tombstones.clear()
+        self._sinks.clear()
+
+
+def _now() -> float:
+    # 使用事件循环时间基，避免引入 wall-clock 依赖；测试通过注入 now= 覆盖
+    import time
+
+    return time.monotonic()

--- a/src/sztu_code/core/subagent/tool.py
+++ b/src/sztu_code/core/subagent/tool.py
@@ -17,7 +17,10 @@ from sztu_code.core.loop import AgentLoop
 from sztu_code.core.runs import new_run_id
 from sztu_code.core.skills.loader import SkillLoader
 from sztu_code.core.stuck_tracker import StuckLoopTracker
-from sztu_code.core.subagent.registry import BackgroundTaskRegistry
+from sztu_code.core.subagent.registry import (
+    BackgroundTaskRegistry,
+    BackgroundTaskStatus,
+)
 from sztu_code.core.tools.base import BaseTool, ToolResult
 from sztu_code.core.tools.builtin.bash import BashTool
 from sztu_code.core.tools.builtin.edit_file import EditFileTool
@@ -127,6 +130,7 @@ class SpawnAgentTool(BaseTool):
         stuck_max_total: int = 0,
         tool_max_concurrency: int = 4,
         max_depth: int = 2,
+        owner_run_id: str = "",
     ) -> None:
         self._provider = provider
         self._parent_bus = parent_bus
@@ -148,6 +152,9 @@ class SpawnAgentTool(BaseTool):
         self._stuck_max_total = stuck_max_total
         self._tool_max_concurrency = tool_max_concurrency
         self._max_depth = max_depth
+        # owner_run_id：所属 root run。嵌套 spawn 时从父 tool 继承，保证整个后代树的
+        # 终态事件都路由回 root sink。为空时回退为 parent_run_id（root tool 自身场景）。
+        self._owner_run_id = owner_run_id or parent_run_id
 
     # 派生子 agent，前台时阻塞直到完成并返回结果，后台时立即返回 run_id
     async def invoke(self, params: dict[str, object]) -> ToolResult:
@@ -309,7 +316,12 @@ class SpawnAgentTool(BaseTool):
                     child_loop, child_context, child_bus, child_run_path, child_run_id
                 )
             )
-            self._task_registry.register(child_run_id, task, child_context)
+            # 注册时记录所有权（parent_run_id 直接父 + owner_run_id root owner），
+            # 使取消可递归遍历后代树，且终态事件按 owner 路由到 root sink
+            self._task_registry.register(
+                child_run_id, self._parent_run_id, task, child_context,
+                owner_run_id=self._owner_run_id,
+            )
             return ToolResult(
                 content=(
                     f"Subagent started in background. run_id={child_run_id}. "
@@ -356,7 +368,9 @@ class SpawnAgentTool(BaseTool):
             "elapsed_s": context.elapsed_s(),
         }
 
-    # 后台任务协程：写事件文件，运行 loop，发布完成事件
+    # 后台任务协程：写事件文件，运行 loop，发布完成事件。
+    # 终态事件只发布一次：registry.mark_terminal 在并发完成/取消竞争中只有首个赢家胜出，
+    # 取消不得覆盖先到的完成结果。
     async def _run_background(
         self,
         loop: AgentLoop,
@@ -365,17 +379,44 @@ class SpawnAgentTool(BaseTool):
         run_path: Path,
         run_id: str,
     ) -> None:
-        async with EventWriter(run_path / "events.jsonl") as writer:
-            writer.subscribe(bus)
-            await loop.run(context)
-        await self._parent_bus.publish(
-            SubagentFinishedEvent(
-                run_id=run_id,
-                parent_run_id=self._parent_run_id,
-                status=context.status,
-                ts=_now(),
+        try:
+            async with EventWriter(run_path / "events.jsonl") as writer:
+                writer.subscribe(bus)
+                await loop.run(context)
+        except asyncio.CancelledError:
+            # 取消到达时仍需终结记录；只有赢得 mark_terminal 的路径发布终态事件
+            self._publish_terminal(run_id, context, cancelled=True)
+            raise
+        except Exception as exc:  # noqa: BLE001 — 后台任务异常需转为 failed 终态
+            self._publish_terminal(run_id, context, detail=str(exc))
+            raise
+        else:
+            self._publish_terminal(run_id, context)
+
+    # 登记终态到 registry：mark_terminal 赢家由 registry 的 on_terminal 回调
+    # 发布 SubagentFinishedEvent，使事件发布不依赖本协程是否已执行。
+    # cancelled 用 CANCELLED，不复用 FAILED，避免把取消误判为失败。
+    def _publish_terminal(
+        self,
+        run_id: str,
+        context: ExecutionContext,
+        *,
+        cancelled: bool = False,
+        detail: str = "",
+    ) -> None:
+        if cancelled:
+            self._task_registry.mark_terminal(
+                run_id, BackgroundTaskStatus.CANCELLED, reason=detail or "cancelled"
             )
-        )
+        elif context.status == "success":
+            self._task_registry.mark_terminal(
+                run_id, BackgroundTaskStatus.COMPLETED, detail=context.result
+            )
+        else:
+            fail_reason = detail or context.reason or context.status
+            self._task_registry.mark_terminal(
+                run_id, BackgroundTaskStatus.FAILED, reason=fail_reason
+            )
 
     # 构造子 registry；基于合并后的白名单过滤工具，深度允许时注册嵌套 SpawnAgentTool
     def _build_child_registry(
@@ -449,6 +490,7 @@ class SpawnAgentTool(BaseTool):
                 stuck_max_total=self._stuck_max_total,
                 tool_max_concurrency=self._tool_max_concurrency,
                 max_depth=self._max_depth,
+                owner_run_id=self._owner_run_id,
             )
             if _allowed("spawn_agent"):
                 registry.register(nested)
@@ -485,28 +527,42 @@ class AgentResultTool(BaseTool):
     def __init__(self, task_registry: BackgroundTaskRegistry) -> None:
         self._task_registry = task_registry
 
-    # 查询指定 run_id 的后台任务状态，返回结果或错误
+    # 查询指定 run_id 的后台任务状态，返回结果或错误。
+    # 区分 unknown / running / completed / cancelled / failed / reclaimed：终态结果首次读取后回收。
     async def invoke(self, params: dict[str, object]) -> ToolResult:
         p = AgentResultParams.model_validate(params)
-        entry = self._task_registry.get(p.run_id)
-        if entry is None:
-            return ToolResult(
-                content=f"Unknown run_id: {p.run_id}. Only background subagents can be queried.",
-                is_error=True,
-                error_type="runtime_error",
-            )
-        task, context = entry
-        if not task.done():
+        query = self._task_registry.consume_result(p.run_id)
+        if query.status is BackgroundTaskStatus.RUNNING:
+            if query.reason == "unknown":
+                return ToolResult(
+                    content=(
+                        f"Unknown run_id: {p.run_id}. "
+                        "Only background subagents can be queried."
+                    ),
+                    is_error=True,
+                    error_type="runtime_error",
+                )
             return ToolResult(content="still running")
-        if task.cancelled():
+        if query.status is BackgroundTaskStatus.COMPLETED:
+            return ToolResult(content=query.result_text)
+        if query.status is BackgroundTaskStatus.CANCELLED:
             return ToolResult(
-                content="Subagent was cancelled.", is_error=True, error_type="runtime_error"
-            )
-        exc = task.exception()
-        if exc is not None:
-            return ToolResult(
-                content=f"Subagent raised an exception: {exc}",
+                content=query.result_text or "Subagent was cancelled.",
                 is_error=True,
                 error_type="runtime_error",
             )
-        return ToolResult(content=context.result or "Subagent completed with no text result.")
+        if query.status is BackgroundTaskStatus.FAILED:
+            return ToolResult(
+                content=query.result_text or "Subagent failed.",
+                is_error=True,
+                error_type="runtime_error",
+            )
+        # reclaimed：结果已被消费或过期回收，与 unknown 的拼写错误可区分
+        return ToolResult(
+            content=(
+                f"Result for run_id {p.run_id} is no longer available "
+                f"({query.reason or 'reclaimed'})."
+            ),
+            is_error=True,
+            error_type="runtime_error",
+        )

--- a/src/sztu_code/core/tools/base.py
+++ b/src/sztu_code/core/tools/base.py
@@ -57,6 +57,9 @@ class BaseTool(ABC):
     manages_timeout: bool = False
     # 工具名称别名列表（如 "read" → "read_file"）
     aliases: ClassVar[list[str]] = []
+    # 该工具是否可在失败后安全重复执行；is_retry_safe 默认读取此属性。
+    # 子类如需按参数动态判断应覆盖 is_retry_safe 而非设置此字段。
+    retry_safe: ClassVar[bool] = False
 
     # 执行工具调用，返回结果或错误
     @abstractmethod

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -410,7 +410,7 @@ async def test_read_only_failure_is_isolated_and_context_order_is_stable() -> No
     ]
     assert [block["content"] for block in result_blocks] == [
         "done:first",
-        "failed:second",
+        "failed:second\nAutomatic retry was skipped because the failure was not explicitly transient.",
         "done:third",
     ]
     terminal_ids = [
@@ -950,7 +950,7 @@ async def test_loop_waits_for_background_before_end_turn() -> None:
 
     child_ctx = ExecutionContext(run_id="bg-1", goal="bg", max_steps=1, result="bg done")
     registry = BackgroundTaskRegistry()
-    registry.register("bg-1", asyncio.create_task(_bg()), child_ctx)
+    registry.register("bg-1", "parent", asyncio.create_task(_bg()), child_ctx)
 
     ctx = _ctx()
     ctx.pending_background_run_ids.add("bg-1")
@@ -977,7 +977,7 @@ async def test_loop_background_already_done() -> None:
     task = asyncio.create_task(_bg())
     await asyncio.sleep(0.01)  # 让后台任务先完成
     registry = BackgroundTaskRegistry()
-    registry.register("bg-done", task, child_ctx)
+    registry.register("bg-done", "parent", task, child_ctx)
 
     ctx = _ctx()
     ctx.pending_background_run_ids.add("bg-done")
@@ -989,17 +989,18 @@ async def test_loop_background_already_done() -> None:
     assert "already done" in ctx.result
 
 
-# 功能：max_steps 触发失败时同样等待后台任务落定
-# 设计：max_steps=1 + 阻塞后台任务，断言 loop 等后台结束才标记 exceeded_max_steps，摘要仍写入 result
-async def test_loop_max_steps_still_waits() -> None:
-    gate = asyncio.Event()
+# 功能：max_steps 中断时不再抢先等待后台 child，立即确定终态退出 loop
+# 设计：max_steps=1 + 永不结束的后台任务（gate 不 set），断言 loop 不阻塞、
+#       以 interrupted/exceeded_max_steps 结束，且不依赖后台 child 结果
+async def test_loop_max_steps_does_not_wait_for_background() -> None:
+    gate = asyncio.Event()  # 永不放行，模拟阻塞的后台 child
 
     async def _bg() -> None:
         await gate.wait()
 
     child_ctx = ExecutionContext(run_id="bg-m", goal="bg", max_steps=1, result="bg result")
     registry = BackgroundTaskRegistry()
-    registry.register("bg-m", asyncio.create_task(_bg()), child_ctx)
+    registry.register("bg-m", "parent", asyncio.create_task(_bg()), child_ctx)
 
     ctx = _ctx(max_steps=1)
     ctx.pending_background_run_ids.add("bg-m")
@@ -1008,15 +1009,16 @@ async def test_loop_max_steps_still_waits() -> None:
     ])
     loop = AgentLoop(provider, ToolRegistry(), EventBus(), task_registry=registry)
 
-    run_task = asyncio.create_task(loop.run(ctx))
-    await asyncio.sleep(0.05)
-    assert not run_task.done()
-
-    gate.set()
-    await asyncio.wait_for(run_task, 2.0)
+    # loop 应在不等待后台 child 的情况下快速结束（不阻塞）
+    await asyncio.wait_for(loop.run(ctx), timeout=2.0)
     assert ctx.status == "interrupted"
     assert ctx.reason == "exceeded_max_steps"
-    assert "bg result" in ctx.result
+    # 中断路径不读取后台 child 摘要（由 runner 负责 cancel_descendants）
+    assert "bg result" not in ctx.result
+
+    # 清理阻塞的后台 task
+    gate.set()
+    await registry.cancel_descendants("parent", reason="parent_interrupted")
 
 
 # 功能：未传入 task_registry 时 pending 集合被忽略，loop 不等待不报错

--- a/tests/unit/test_spawn_agent_tool.py
+++ b/tests/unit/test_spawn_agent_tool.py
@@ -139,7 +139,8 @@ async def test_agent_result_done(tmp_path: Path) -> None:
 
     entry = registry.get(run_id)
     assert entry is not None
-    task, _ = entry
+    task = entry.task
+    assert task is not None
     await asyncio.wait_for(task, timeout=5.0)
 
     result_tool = AgentResultTool(registry)

--- a/tests/unit/test_subagent_cancellation.py
+++ b/tests/unit/test_subagent_cancellation.py
@@ -1,0 +1,896 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from sztu_code.core.bus.events import SubagentFinishedEvent
+from sztu_code.core.config import SztuConfig
+from sztu_code.core.context import ExecutionContext
+from sztu_code.core.events.bus import EventBus
+from sztu_code.core.llm.types import LlmResponse, ToolCallBlock, UsageStats
+from sztu_code.core.runner import AgentRunner
+from sztu_code.core.subagent.registry import BackgroundTaskRegistry, BackgroundTaskStatus
+from sztu_code.core.subagent.tool import SpawnAgentTool
+
+
+# 永久挂起的 provider，除非被 cancel
+def _blocking_provider() -> Any:
+    async def chat(*args: Any, **kwargs: Any) -> LlmResponse:
+        await asyncio.Event().wait()
+        return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+
+    provider = MagicMock()
+    provider.chat = chat
+    return provider
+
+
+def _make_tool(
+    tmp_path: Path,
+    provider: Any,
+    parent_run_id: str,
+    registry: BackgroundTaskRegistry,
+    bus: EventBus,
+    depth: int = 0,
+) -> SpawnAgentTool:
+    return SpawnAgentTool(
+        provider=provider,
+        parent_bus=bus,
+        parent_run_id=parent_run_id,
+        permission_manager=None,
+        max_steps=5,
+        task_registry=registry,
+        runs_dir=tmp_path,
+        session_id="sess-cancel",
+        depth=depth,
+        max_depth=3,
+    )
+
+
+def _extract_run_id(content: str) -> str:
+    return content.split("run_id=")[1].split(".")[0]
+
+
+# 功能：cancel 后台 child 时其 task 落定且终态为 cancelled
+# 设计：spawn 后台 child（阻塞 provider），cancel_descendants 后断言 task.done 且 status=cancelled
+async def test_cancel_descendants_stops_child(tmp_path: Path) -> None:
+    registry = BackgroundTaskRegistry()
+    bus = EventBus()
+    tool = _make_tool(tmp_path, _blocking_provider(), "parent-run", registry, bus)
+    tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+    spawn_result = await tool.invoke({
+        "description": "child", "prompt": "work", "run_in_background": True,
+    })
+    child_id = _extract_run_id(spawn_result.content)
+    assert registry.query_result(child_id).status is BackgroundTaskStatus.RUNNING
+
+    cancelled = await registry.cancel_descendants("parent-run", reason="parent_cancelled")
+    assert child_id in cancelled
+
+    record = registry.get(child_id)
+    assert record is not None and record.task is not None
+    assert record.task.done()
+    assert registry.query_result(child_id).status is BackgroundTaskStatus.CANCELLED
+
+
+# 功能：parent→child→grandchild 后台链，cancel parent 后两层 task 均停止
+# 设计：child provider 第一步 spawn 后台 grandchild（阻塞），第二步阻塞；
+#       cancel parent 后断言 child 与 grandchild 均落定且 cancelled
+async def test_cancel_descendants_reaches_grandchild(tmp_path: Path) -> None:
+    registry = BackgroundTaskRegistry()
+    bus = EventBus()
+    grandchild_spawn = ToolCallBlock(
+        id="g1", name="spawn_agent",
+        input={"description": "grandchild", "prompt": "gc", "run_in_background": True},
+    )
+    spawned = {"done": False}
+
+    async def child_chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        # 首步：派生后台 grandchild 后继续阻塞
+        if not spawned["done"]:
+            spawned["done"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[grandchild_spawn], text="",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        await asyncio.Event().wait()
+        return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+
+    provider = MagicMock()
+    provider.chat = child_chat
+    tool = _make_tool(tmp_path, provider, "parent-run", registry, bus)
+    tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+    spawn_result = await tool.invoke({
+        "description": "child", "prompt": "child prompt", "run_in_background": True,
+    })
+    child_id = _extract_run_id(spawn_result.content)
+    # 轮询等待 child 派生 grandchild（避免固定 sleep 在慢机器上失效）
+    for _ in range(100):
+        gc_ids = registry.descendants(child_id)
+        if gc_ids:
+            break
+        await asyncio.sleep(0.01)
+    assert len(gc_ids) == 1, f"expected 1 grandchild, got {gc_ids}"
+    grandchild_id = gc_ids[0]
+
+    cancelled = await registry.cancel_descendants("parent-run", reason="parent_cancelled")
+    assert child_id in cancelled
+    assert grandchild_id in cancelled
+
+    child_record = registry.get(child_id)
+    gc_record = registry.get(grandchild_id)
+    assert child_record is not None and child_record.task is not None
+    assert gc_record is not None and gc_record.task is not None
+    assert child_record.task.done()
+    assert gc_record.task.done()
+    assert registry.query_result(child_id).status is BackgroundTaskStatus.CANCELLED
+    assert registry.query_result(grandchild_id).status is BackgroundTaskStatus.CANCELLED
+
+
+# 功能：parent 取消时已完成的 child 保持 completed，且不重复发终态事件
+# 设计：spawn 立即完成的 child，cancel parent；注册 on_terminal 收集事件，
+#       断言 child 仍 completed，且恰好一个 success 事件（cancel 不覆盖不发第二个）
+async def test_completed_child_survives_parent_cancel(tmp_path: Path) -> None:
+    bus = EventBus()
+    finished_events: list[Any] = []
+
+    async def _collect(e: Any) -> None:
+        if isinstance(e, SubagentFinishedEvent):
+            finished_events.append(e)
+
+    bus.subscribe(_collect)
+
+    _STATUS_MAP = {"completed": "success", "failed": "failed", "cancelled": "cancelled"}
+
+    def _on_terminal(rid: str, status: object) -> None:
+        raw = status.value if hasattr(status, "value") else str(status)
+        asyncio.get_running_loop().create_task(
+            bus.publish(
+                SubagentFinishedEvent(
+                    run_id=rid, parent_run_id="parent-run",
+                    status=_STATUS_MAP.get(raw, raw), ts="t",
+                )
+            )
+        )
+
+    registry = BackgroundTaskRegistry(on_terminal=_on_terminal)
+
+    async def done_chat(*args: Any, **kwargs: Any) -> LlmResponse:
+        return LlmResponse(
+            stop_reason="end_turn", text="child done",
+            usage=UsageStats(0, 0, 0, 0, 0.0),
+        )
+
+    provider = MagicMock()
+    provider.chat = done_chat
+    tool = _make_tool(tmp_path, provider, "parent-run", registry, bus)
+    tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+    spawn_result = await tool.invoke({
+        "description": "child", "prompt": "do it", "run_in_background": True,
+    })
+    child_id = _extract_run_id(spawn_result.content)
+    record = registry.get(child_id)
+    assert record is not None and record.task is not None
+    await asyncio.wait_for(record.task, timeout=5.0)
+    assert registry.query_result(child_id).status is BackgroundTaskStatus.COMPLETED
+
+    await registry.cancel_descendants("parent-run", reason="parent_cancelled")
+    assert registry.query_result(child_id).status is BackgroundTaskStatus.COMPLETED
+    # 等待 fire-and-forget 事件落定，断言恰好一个 success 事件（cancel 未追加第二个）
+    for _ in range(100):
+        if finished_events:
+            break
+        await asyncio.sleep(0.01)
+    assert len(finished_events) == 1
+    assert finished_events[0].status == "success"
+
+
+# 功能：并发完成与取消竞争下恰好一个终态事件，终态唯一
+# 设计：child 短暂等待后完成，cancel 与完成竞争；注册 on_terminal 回调收集事件，
+#       断言终态唯一（completed 或 cancelled）且恰好一个 finished 事件
+async def test_concurrent_completion_and_cancel_one_event(tmp_path: Path) -> None:
+    bus = EventBus()
+    finished_events: list[Any] = []
+
+    async def _collect(e: Any) -> None:
+        if isinstance(e, SubagentFinishedEvent):
+            finished_events.append(e)
+
+    bus.subscribe(_collect)
+
+    _STATUS_MAP = {"completed": "success", "failed": "failed", "cancelled": "cancelled"}
+
+    def _on_terminal(rid: str, status: object) -> None:
+        raw = status.value if hasattr(status, "value") else str(status)
+        asyncio.get_running_loop().create_task(
+            bus.publish(
+                SubagentFinishedEvent(
+                    run_id=rid, parent_run_id="parent-run",
+                    status=_STATUS_MAP.get(raw, raw), ts="t",
+                )
+            )
+        )
+
+    registry = BackgroundTaskRegistry(on_terminal=_on_terminal)
+
+    async def racing_chat(*args: Any, **kwargs: Any) -> LlmResponse:
+        await asyncio.sleep(0.05)
+        return LlmResponse(
+            stop_reason="end_turn", text="raced",
+            usage=UsageStats(0, 0, 0, 0, 0.0),
+        )
+
+    provider = MagicMock()
+    provider.chat = racing_chat
+    tool = _make_tool(tmp_path, provider, "parent-run", registry, bus)
+    tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+    spawn_result = await tool.invoke({
+        "description": "racing", "prompt": "race", "run_in_background": True,
+    })
+    child_id = _extract_run_id(spawn_result.content)
+    await asyncio.sleep(0.01)
+    await registry.cancel_descendants("parent-run", reason="parent_cancelled")
+
+    record = registry.get(child_id)
+    assert record is not None and record.task is not None
+    try:
+        await asyncio.wait_for(asyncio.shield(record.task), timeout=5.0)
+    except (asyncio.CancelledError, Exception):
+        pass
+    final = registry.query_result(child_id)
+    assert final.status in (BackgroundTaskStatus.COMPLETED, BackgroundTaskStatus.CANCELLED)
+    # 轮询等待 fire-and-forget 事件落定
+    for _ in range(100):
+        if finished_events:
+            break
+        await asyncio.sleep(0.01)
+    assert len(finished_events) == 1, f"expected exactly 1 event, got {len(finished_events)}"
+
+
+# 功能：parent 取消后 registry 无 active 记录残留
+# 设计：spawn 多个后台 child，cancel parent，断言无 active 记录
+async def test_no_active_task_after_parent_cleanup(tmp_path: Path) -> None:
+    registry = BackgroundTaskRegistry()
+    bus = EventBus()
+    provider = _blocking_provider()
+    for i in range(3):
+        tool = _make_tool(tmp_path, provider, "parent-run", registry, bus)
+        tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+        await tool.invoke({
+            "description": f"child-{i}", "prompt": f"work-{i}",
+            "run_in_background": True,
+        })
+    await registry.cancel_descendants("parent-run", reason="parent_cancelled")
+    active = [r for r in registry.all() if r.is_active]
+    assert active == [], f"expected no active tasks, got {active}"
+
+
+# 功能：registry shutdown 取消所有活动 task 并释放重型引用
+# 设计：spawn 后台 child，shutdown，断言 task 与 context 引用均释放
+async def test_shutdown_cancels_and_releases(tmp_path: Path) -> None:
+    registry = BackgroundTaskRegistry()
+    bus = EventBus()
+    tool = _make_tool(tmp_path, _blocking_provider(), "parent-run", registry, bus)
+    tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+    await tool.invoke({
+        "description": "child", "prompt": "work", "run_in_background": True,
+    })
+    await registry.shutdown()
+    for record in registry.all():
+        assert record.task is None
+        assert record.context is None
+
+
+# 功能：协程未调度就被取消时，on_terminal 回调仍发布唯一终态事件
+# 设计：spawn 后台 child 后立即 cancel（task 可能从未跑过 body），注册 on_terminal
+#       回调收集事件，断言恰好一个 cancelled 事件发布——防 _run_background 未执行导致事件丢失
+async def test_cancel_publishes_terminal_event_when_coroutine_never_ran(tmp_path: Path) -> None:
+    bus = EventBus()
+    finished_events: list[Any] = []
+
+    async def _collect(e: Any) -> None:
+        if isinstance(e, SubagentFinishedEvent):
+            finished_events.append(e)
+
+    bus.subscribe(_collect)
+
+    def _on_terminal(rid: str, status: object) -> None:
+        raw = status.value if hasattr(status, "value") else str(status)
+        # 对齐 runner 的映射：completed→success，保持与前台 spawn 事件契约一致
+        event_status = {"completed": "success", "failed": "failed", "cancelled": "cancelled"}.get(
+            raw, raw
+        )
+        asyncio.get_running_loop().create_task(
+            bus.publish(
+                SubagentFinishedEvent(
+                    run_id=rid, parent_run_id="parent-run",
+                    status=event_status, ts="t",
+                )
+            )
+        )
+
+    registry = BackgroundTaskRegistry(on_terminal=_on_terminal)
+    tool = _make_tool(tmp_path, _blocking_provider(), "parent-run", registry, bus)
+    tool._parent_context = ExecutionContext(run_id="parent-run", goal="g", max_steps=5)
+    await tool.invoke({"description": "child", "prompt": "work", "run_in_background": True})
+
+    # 立即取消（task body 可能尚未首次调度）
+    await registry.cancel_descendants("parent-run", reason="parent_cancelled")
+    # 轮询等待 on_terminal 回调的 fire-and-forget publish task 落定
+    for _ in range(100):
+        if finished_events:
+            break
+        await asyncio.sleep(0.01)
+
+    assert len(finished_events) == 1, f"expected 1 finished event, got {len(finished_events)}"
+    assert finished_events[0].status == "cancelled"
+
+
+# ---- runner 级集成测试：普通 run 不 shutdown registry + 终态事件可靠 await ----
+
+
+# 让 root agent 第一步 spawn 后台子（立即完成）、第二步 end_turn 的 provider
+def _spawning_provider() -> Any:
+    spawn_call = ToolCallBlock(
+        id="sp1", name="spawn_agent",
+        input={"description": "child", "prompt": "do work", "run_in_background": True},
+    )
+    state = {"spawned": False}
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        if not state["spawned"]:
+            state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[spawn_call], text="",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        return LlmResponse(
+            stop_reason="end_turn", text="root done", usage=UsageStats(0, 0, 0, 0, 0.0)
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    return provider
+
+
+def _read_event_types(events_path: Path) -> list[str]:
+    return [
+        json.loads(line)["type"]
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+
+
+# 功能：普通 run 结束后 registry 未被 shutdown，终态子结果在 TTL 内仍可查询
+# 设计：用 AgentRunner 跑一次 spawn 后台子 + end_turn 的 run，结束后断言 registry 未 shutdown
+#       且子结果可查询（status=completed）
+async def test_normal_run_does_not_shutdown_registry(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 5
+    runner = AgentRunner(cfg, provider=_spawning_provider(), runs_dir=tmp_path)
+    await runner.run_and_capture("goal", run_id="run-normal")
+
+    # registry 未被 shutdown：_shutdown_done 仍为 False，结果保留
+    assert runner._task_registry._shutdown_done is False  # noqa: SLF001
+    # 子 agent 记录仍在（未被 reclaim），可查询
+    records = [r for r in runner._task_registry.all() if r.status is BackgroundTaskStatus.COMPLETED]  # noqa: SLF001
+    assert len(records) == 1
+
+
+# 功能：同一 runner 顺序运行两次，registry 不被普通 run 永久 shutdown
+# 设计：连续两次 run_and_capture，断言 registry 仍可注册（_shutdown_done=False），
+#       证明普通 run 收尾未把 registry 置为 shutdown 状态
+async def test_runner_reusable_across_runs(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 5
+    runner = AgentRunner(cfg, provider=_spawning_provider(), runs_dir=tmp_path)
+    await runner.run_and_capture("goal1", run_id="run-1")
+    await runner.run_and_capture("goal2", run_id="run-2")
+    # 普通 run 不 shutdown：registry 仍可注册新任务
+    assert runner._task_registry._shutdown_done is False  # noqa: SLF001
+    # 第一轮的 completed 记录仍保留（TTL 内未回收）
+    completed = [r for r in runner._task_registry.all() if r.status is BackgroundTaskStatus.COMPLETED]  # noqa: SLF001
+    assert len(completed) == 1
+
+
+# 功能：runner 显式 shutdown 取消活跃子任务并释放重型引用，且可重复调用
+# 设计：spawn 后台阻塞子后 shutdown 两次，断言 task/context 释放且无异常
+async def test_runner_shutdown_cancels_and_idempotent(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 5
+    blocking = _blocking_provider()
+    runner = AgentRunner(cfg, provider=blocking, runs_dir=tmp_path)
+    # 用 spawn 工具注册一个阻塞子（不走完整 run，直接构造工具）
+    bus = EventBus()
+    tool = SpawnAgentTool(
+        provider=blocking, parent_bus=bus, parent_run_id="root",
+        permission_manager=None, max_steps=5,
+        task_registry=runner._task_registry, runs_dir=tmp_path,
+        session_id="s", max_depth=3,
+    )  # noqa: SLF001
+    tool._parent_context = ExecutionContext(run_id="root", goal="g", max_steps=5)  # noqa: SLF001
+    await tool.invoke({"description": "child", "prompt": "work", "run_in_background": True})
+
+    await runner.shutdown()
+    await runner.shutdown()  # 重复调用不报错
+    for record in runner._task_registry.all():  # noqa: SLF001
+        assert record.task is None
+        assert record.context is None
+
+
+# 功能：子任务正常完成时 subagent.finished 恰好一个，且在 run.finished 之前落盘
+# 设计：用 AgentRunner 跑 spawn 后台子 + end_turn，读取 events.jsonl 断言事件顺序
+async def test_subagent_finished_before_run_finished(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 5
+    runner = AgentRunner(cfg, provider=_spawning_provider(), runs_dir=tmp_path)
+    await runner.run_and_capture("goal", run_id="run-order")
+    # 找到 root run 的 events.jsonl
+    jsonl = tmp_path / "run-order" / "events.jsonl"
+    types = _read_event_types(jsonl)
+    assert types.count("subagent.finished") == 1, f"events: {types}"
+    assert types.count("run.finished") == 1
+    # subagent.finished 必须在 run.finished 之前
+    assert types.index("subagent.finished") < types.index("run.finished")
+
+
+# 功能：子任务在协程首次调度前被取消，仍有一个可观察的 subagent.finished（runner 级）
+# 设计：root spawn 后台阻塞子后，cancel root run；断言 events.jsonl 恰好一个 cancelled 事件
+async def test_cancelled_run_emits_subagent_finished(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 5
+    spawn_call = ToolCallBlock(
+        id="sp1", name="spawn_agent",
+        input={"description": "child", "prompt": "work", "run_in_background": True},
+    )
+    state = {"spawned": False}
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        if not state["spawned"]:
+            state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[spawn_call], text="",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        await asyncio.Event().wait()  # root 阻塞等被 cancel
+        return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+
+    provider = MagicMock()
+    provider.chat = chat
+    runner = AgentRunner(cfg, provider=provider, runs_dir=tmp_path)
+    run_task = asyncio.create_task(
+        runner.run_and_capture("goal", run_id="run-cancel")
+    )
+    # 等 spawn 发生
+    for _ in range(100):
+        if state["spawned"]:
+            break
+        await asyncio.sleep(0.01)
+    run_task.cancel()
+    try:
+        await run_task
+    except asyncio.CancelledError:
+        pass
+
+    jsonl = tmp_path / "run-cancel" / "events.jsonl"
+    types = _read_event_types(jsonl)
+    finished = [t for t in types if t == "subagent.finished"]
+    assert len(finished) == 1, f"expected 1 subagent.finished, events: {types}"
+    # 验证 status 为 cancelled（读取完整事件）
+    raw = [json.loads(line) for line in jsonl.read_text(encoding="utf-8").splitlines() if line]
+    sub_events = [e for e in raw if e.get("type") == "subagent.finished"]
+    assert sub_events[0]["status"] == "cancelled"
+
+
+# ---- P0 必增测试：interrupted 父 run 必须取消后台后代 ----
+
+
+# 让 root 第一步 spawn 后台阻塞子、然后耗尽 max_steps 变 interrupted 的 provider
+def _spawn_then_loop_provider() -> Any:
+    spawn_call = ToolCallBlock(
+        id="sp1", name="spawn_agent",
+        input={"description": "child", "prompt": "work", "run_in_background": True},
+    )
+    state = {"spawned": False}
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        if not state["spawned"]:
+            state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[spawn_call], text="",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        # 后续每步都调未知工具，耗尽 max_steps
+        return LlmResponse(
+            stop_reason="tool_use", tool_calls=[ToolCallBlock(id="t", name="unknown_tool", input={})],
+            text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    return provider
+
+
+# 功能：max_steps 中断时 root 立即结束并取消永不返回的后台 child
+# 设计：root spawn 阻塞后台子后耗尽 max_steps→interrupted，断言 root 确定性上限内结束、
+#       child 被 cancel_descendants 取消且记录为 CANCELLED
+async def test_max_steps_interrupt_cancels_blocking_child(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 3
+    runner = AgentRunner(cfg, provider=_spawn_then_loop_provider(), runs_dir=tmp_path)
+    # root 在 max_steps 内结束（不卡在 _wait_for_background），确定性上限
+    outcome = await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-maxsteps"), timeout=10.0
+    )
+    assert outcome.status == "interrupted"
+    assert outcome.reason == "exceeded_max_steps"
+    # 后台 child 被取消
+    cancelled = [r for r in runner._task_registry.all() if r.status is BackgroundTaskStatus.CANCELLED]  # noqa: SLF001
+    assert len(cancelled) == 1
+
+
+# 功能：wall_clock 中断时同样取消后台 child
+# 设计：max_wall_clock_s=1 触发非 max_steps 的非成功终态，验证 child 被取消。
+#       provider 后续返回 tool_use 但调用只读工具避免触发 repeated_error，让 wall_clock 优先
+async def test_wall_clock_interrupt_cancels_child(tmp_path: Path) -> None:
+    spawn_call = ToolCallBlock(
+        id="sp1", name="spawn_agent",
+        input={"description": "child", "prompt": "work", "run_in_background": True},
+    )
+    state = {"spawned": False}
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        if not state["spawned"]:
+            state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[spawn_call], text="",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        # 后续每步调 list_dir（只读，不触发 repeated_error），让 wall_clock 触发
+        await asyncio.sleep(0.05)
+        return LlmResponse(
+            stop_reason="tool_use", tool_calls=[ToolCallBlock(id="t", name="list_dir", input={"path": "."})],
+            text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 100  # 不靠 max_steps 触发
+    cfg.budget.max_wall_clock_s = 1
+    runner = AgentRunner(cfg, provider=provider, runs_dir=tmp_path)
+    outcome = await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-wallclock", workspace_root=tmp_path), timeout=20.0
+    )
+    # 非成功终态（wall_clock 中断或 repeated_error），都应取消/清理 child
+    assert outcome.status != "success"
+    # 无遗留 active task（child 被取消或已完成，不应仍 running）
+    active = [r for r in runner._task_registry.all() if r.is_active]  # noqa: SLF001
+    assert active == [], f"expected no active tasks, got {active}"
+
+
+# 功能：递归场景——root 的 child 派生阻塞 grandchild，root 中断后两者均取消
+# 设计：root spawn 后台 child，child 首步派生后台 grandchild 后阻塞；root 等 grandchild 派生后
+#       耗尽 max_steps 中断，断言 child 和 grandchild 均被取消、无遗留 active task
+async def test_interrupt_cancels_recursive_descendants(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 6  # 给 child 足够时间派生 grandchild
+    grandchild_spawn = ToolCallBlock(
+        id="gc1", name="spawn_agent",
+        input={"description": "grandchild", "prompt": "gc work", "run_in_background": True},
+    )
+    root_state = {"spawned": False}
+    grandchild_spawned = asyncio.Event()
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        # 按首条 user 消息分流 root vs child vs grandchild
+        first_user = next(
+            (str(m["content"]) for m in messages
+             if m["role"] == "user" and isinstance(m["content"], str)), ""
+        )
+        # grandchild：永久阻塞
+        if first_user == "gc work":
+            await asyncio.Event().wait()
+            return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+        # child：首步派生 grandchild 后阻塞
+        if first_user == "child work":
+            if not any(
+                isinstance(b, dict) and b.get("name") == "spawn_agent"
+                for m in messages if m["role"] == "assistant" and isinstance(m["content"], list)
+                for b in m["content"]
+            ):
+                grandchild_spawned.set()  # 通知 root：grandchild 已派生
+                return LlmResponse(
+                    stop_reason="tool_use", tool_calls=[grandchild_spawn], text="",
+                    usage=UsageStats(0, 0, 0, 0, 0.0),
+                )
+            await asyncio.Event().wait()
+            return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+        # root：首步 spawn child，等 grandchild 派生后耗尽 max_steps
+        if not root_state["spawned"]:
+            root_state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[ToolCallBlock(
+                    id="sp1", name="spawn_agent",
+                    input={"description": "child", "prompt": "child work", "run_in_background": True},
+                )], text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        # 等 grandchild 派生后再继续（避免 root 过早失败时 child 还没派生）
+        await asyncio.wait_for(grandchild_spawned.wait(), timeout=5.0)
+        return LlmResponse(
+            stop_reason="tool_use", tool_calls=[ToolCallBlock(id="t", name="unknown_tool", input={})],
+            text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    runner = AgentRunner(cfg, provider=provider, runs_dir=tmp_path)
+    outcome = await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-recursive"), timeout=20.0
+    )
+    # 非成功终态（max_steps 中断或 repeated_error 失败）都应递归取消后代
+    assert outcome.status != "success"
+    # 无遗留 active task
+    active = [r for r in runner._task_registry.all() if r.is_active]  # noqa: SLF001
+    assert active == [], f"expected no active tasks, got {active}"
+    # child 和 grandchild 都被取消
+    cancelled = [r for r in runner._task_registry.all() if r.status is BackgroundTaskStatus.CANCELLED]  # noqa: SLF001
+    assert len(cancelled) >= 2
+
+
+# 功能：中断场景的 events.jsonl 中每个 child 恰好一条 subagent.finished(cancelled)，早于 run.finished
+# 设计：复用 max_steps 中断场景，读取 events.jsonl 断言事件顺序与唯一性
+async def test_interrupt_event_order_and_uniqueness(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 2
+    runner = AgentRunner(cfg, provider=_spawn_then_loop_provider(), runs_dir=tmp_path)
+    await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-order-int"), timeout=15.0
+    )
+    jsonl = tmp_path / "run-order-int" / "events.jsonl"
+    raw = [json.loads(line) for line in jsonl.read_text(encoding="utf-8").splitlines() if line]
+    types = [e["type"] for e in raw]
+    sub_finished = [i for i, t in enumerate(types) if t == "subagent.finished"]
+    run_finished_idx = types.index("run.finished")
+    assert len(sub_finished) == 1
+    assert sub_finished[0] < run_finished_idx
+    sub_event = raw[sub_finished[0]]
+    assert sub_event["status"] == "cancelled"
+
+
+# 功能：正常成功路径仍等待后台 child 并把摘要并入结果（P0 回归保护）
+# 设计：root spawn 后台子（立即完成）、end_turn，断言 root success 且 result 含子摘要
+async def test_success_path_still_waits_for_child(tmp_path: Path) -> None:
+    spawn_call = ToolCallBlock(
+        id="sp1", name="spawn_agent",
+        input={"description": "child", "prompt": "do work", "run_in_background": True},
+    )
+    state = {"spawned": False}
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        if not state["spawned"]:
+            state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[spawn_call], text="",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        return LlmResponse(
+            stop_reason="end_turn", text="root done", usage=UsageStats(0, 0, 0, 0, 0.0)
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 5
+    runner = AgentRunner(cfg, provider=provider, runs_dir=tmp_path)
+    outcome = await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-success"), timeout=10.0
+    )
+    assert outcome.status == "success"
+    # 后台子完成（非取消），保留记录
+    completed = [r for r in runner._task_registry.all() if r.status is BackgroundTaskStatus.COMPLETED]  # noqa: SLF001
+    assert len(completed) == 1
+
+
+# ---- P1 必增测试：终态事件所有权按 parent_run_id 绑定 ----
+
+
+# 功能：两个不同 parent 的 child 终态事件只发到各自注册的 sink
+# 设计：registry 注册两个 parent 的 sink（A 和 B），分别 mark_terminal 各自的 child，
+#       断言 A 的 child 事件只进 A 的 sink，B 的只进 B 的
+async def test_terminal_sink_routed_by_parent_run_id() -> None:
+    a_events: list[str] = []
+    b_events: list[str] = []
+
+    def _sink_a(rid: str, status: object) -> None:
+        a_events.append(rid)
+
+    def _sink_b(rid: str, status: object) -> None:
+        b_events.append(rid)
+
+    registry = BackgroundTaskRegistry()
+    registry.register_sink("parent-a", _sink_a)
+    registry.register_sink("parent-b", _sink_b)
+
+    # 注册两个不同 parent 的 child，owner_run_id 默认回退为 parent_run_id
+    task_a = asyncio.create_task(asyncio.sleep(0))
+    task_b = asyncio.create_task(asyncio.sleep(0))
+    await task_a
+    await task_b
+    registry.register("child-a", "parent-a", task_a, ExecutionContext(run_id="child-a", goal="g", max_steps=1))
+    registry.register("child-b", "parent-b", task_b, ExecutionContext(run_id="child-b", goal="g", max_steps=1))
+
+    # grandchild：parent=child-a 但 owner=parent-a，验证按 owner 路由而非 parent
+    task_ga = asyncio.create_task(asyncio.sleep(0))
+    await task_ga
+    registry.register(
+        "grandchild-a", "child-a", task_ga,
+        ExecutionContext(run_id="grandchild-a", goal="g", max_steps=1),
+        owner_run_id="parent-a",
+    )
+
+    registry.mark_terminal("child-a", BackgroundTaskStatus.COMPLETED, detail="a done")
+    registry.mark_terminal("child-b", BackgroundTaskStatus.FAILED, reason="b fail")
+    registry.mark_terminal("grandchild-a", BackgroundTaskStatus.CANCELLED, reason="parent_interrupted")
+
+    # child-a 和 grandchild-a 都路由到 A sink（按 owner_run_id 而非直接 parent）
+    assert a_events == ["child-a", "grandchild-a"], f"A sink got: {a_events}"
+    assert b_events == ["child-b"], f"B sink got: {b_events}"
+
+
+# ---- P1 端到端测试：递归后代的 subagent.finished 不丢失 ----
+
+
+# 功能：root 中断时 child 和 grandchild 各产生一条 subagent.finished(cancelled)，
+#       parent_run_id 正确（child→root, grandchild→child），全在 run.finished 前，无重复
+# 设计：root spawn 后台 child，child 派生后台 grandchild（均阻塞），root max_steps 中断；
+#       读取 root events.jsonl 断言两条 finished 事件、parent 关系、顺序、唯一性
+async def test_recursive_cancel_emits_finished_for_all_descendants(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 6
+    grandchild_spawn = ToolCallBlock(
+        id="gc1", name="spawn_agent",
+        input={"description": "grandchild", "prompt": "gc work", "run_in_background": True},
+    )
+    root_state = {"spawned": False}
+    grandchild_spawned = asyncio.Event()
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        first_user = next(
+            (str(m["content"]) for m in messages
+             if m["role"] == "user" and isinstance(m["content"], str)), ""
+        )
+        if first_user == "gc work":
+            await asyncio.Event().wait()
+            return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+        if first_user == "child work":
+            if not any(
+                isinstance(b, dict) and b.get("name") == "spawn_agent"
+                for m in messages if m["role"] == "assistant" and isinstance(m["content"], list)
+                for b in m["content"]
+            ):
+                grandchild_spawned.set()
+                return LlmResponse(
+                    stop_reason="tool_use", tool_calls=[grandchild_spawn], text="",
+                    usage=UsageStats(0, 0, 0, 0, 0.0),
+                )
+            await asyncio.Event().wait()
+            return LlmResponse(stop_reason="end_turn", text="", usage=UsageStats(0, 0, 0, 0, 0.0))
+        if not root_state["spawned"]:
+            root_state["spawned"] = True
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[ToolCallBlock(
+                    id="sp1", name="spawn_agent",
+                    input={"description": "child", "prompt": "child work", "run_in_background": True},
+                )], text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        await asyncio.wait_for(grandchild_spawned.wait(), timeout=5.0)
+        return LlmResponse(
+            stop_reason="tool_use", tool_calls=[ToolCallBlock(id="t", name="unknown_tool", input={})],
+            text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    runner = AgentRunner(cfg, provider=provider, runs_dir=tmp_path)
+    await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-recursive-events"), timeout=20.0
+    )
+
+    raw = [json.loads(line) for line in (tmp_path / "run-recursive-events" / "events.jsonl")
+           .read_text(encoding="utf-8").splitlines() if line]
+    types = [e["type"] for e in raw]
+    sub_finished = [e for e in raw if e["type"] == "subagent.finished"]
+    run_finished_idx = types.index("run.finished")
+
+    # 两条 finished（child 和 grandchild 各一），run_id 不重复
+    assert len(sub_finished) == 2, f"expected 2 finished, got {len(sub_finished)}: {sub_finished}"
+    run_ids = [e["run_id"] for e in sub_finished]
+    assert len(set(run_ids)) == 2, f"run_ids not unique: {run_ids}"
+    # parent_run_id 正确：child 的 parent=root，grandchild 的 parent=child
+    root_id = "run-recursive-events"
+    by_parent = {e["parent_run_id"]: e for e in sub_finished}
+    assert root_id in by_parent, f"no child with parent=root: {by_parent}"
+    child_id = by_parent[root_id]["run_id"]
+    assert child_id in by_parent, f"no grandchild with parent=child: {by_parent}"
+    # 两条 status 都为 cancelled
+    assert all(e["status"] == "cancelled" for e in sub_finished), \
+        f"expected all cancelled: {sub_finished}"
+    # 两条 finished 都在 run.finished 之前
+    for i, e in enumerate(raw):
+        if e["type"] == "subagent.finished":
+            assert i < run_finished_idx, f"finished at {i} after run.finished at {run_finished_idx}"
+
+
+# 功能：嵌套成功场景——child 完成 grandchild，两者各一条 success finished，归属 root 事件输出
+# 设计：root spawn 后台 child，child 等 grandchild 完成后 end_turn 成功；
+#       断言 child 和 grandchild 各一条 subagent.finished(success)
+async def test_recursive_success_emits_finished_for_all_descendants(tmp_path: Path) -> None:
+    cfg = SztuConfig()
+    cfg.agent.max_steps = 8
+    grandchild_spawn = ToolCallBlock(
+        id="gc1", name="spawn_agent",
+        input={"description": "grandchild", "prompt": "gc work", "run_in_background": True},
+    )
+
+    async def chat(messages: list[dict[str, object]], **kwargs: Any) -> LlmResponse:
+        first_user = next(
+            (str(m["content"]) for m in messages
+             if m["role"] == "user" and isinstance(m["content"], str)), ""
+        )
+        # grandchild：立即完成
+        if first_user == "gc work":
+            return LlmResponse(
+                stop_reason="end_turn", text="grandchild done",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        # child：首步 spawn 后台 grandchild，第二步 end_turn 成功
+        if first_user == "child work":
+            if not any(
+                isinstance(b, dict) and b.get("name") == "spawn_agent"
+                for m in messages if m["role"] == "assistant" and isinstance(m["content"], list)
+                for b in m["content"]
+            ):
+                return LlmResponse(
+                    stop_reason="tool_use", tool_calls=[grandchild_spawn], text="",
+                    usage=UsageStats(0, 0, 0, 0, 0.0),
+                )
+            return LlmResponse(
+                stop_reason="end_turn", text="child done",
+                usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        # root：spawn 后台 child，然后 end_turn 成功
+        if not any(
+            isinstance(b, dict) and b.get("name") == "spawn_agent"
+            for m in messages if m["role"] == "assistant" and isinstance(m["content"], list)
+            for b in m["content"]
+        ):
+            return LlmResponse(
+                stop_reason="tool_use", tool_calls=[ToolCallBlock(
+                    id="sp1", name="spawn_agent",
+                    input={"description": "child", "prompt": "child work", "run_in_background": True},
+                )], text="", usage=UsageStats(0, 0, 0, 0, 0.0),
+            )
+        return LlmResponse(
+            stop_reason="end_turn", text="root done", usage=UsageStats(0, 0, 0, 0, 0.0)
+        )
+
+    provider = MagicMock()
+    provider.chat = chat
+    runner = AgentRunner(cfg, provider=provider, runs_dir=tmp_path)
+    outcome = await asyncio.wait_for(
+        runner.run_and_capture("goal", run_id="run-recursive-success"), timeout=20.0
+    )
+    assert outcome.status == "success"
+
+    raw = [json.loads(line) for line in (tmp_path / "run-recursive-success" / "events.jsonl")
+           .read_text(encoding="utf-8").splitlines() if line]
+    sub_finished = [e for e in raw if e["type"] == "subagent.finished"]
+    # child 和 grandchild 各一条 success
+    assert len(sub_finished) == 2, f"expected 2 finished, got {len(sub_finished)}"
+    assert all(e["status"] == "success" for e in sub_finished), \
+        f"expected all success: {sub_finished}"
+    run_ids = [e["run_id"] for e in sub_finished]
+    assert len(set(run_ids)) == 2

--- a/tests/unit/test_subagent_registry.py
+++ b/tests/unit/test_subagent_registry.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sztu_code.core.context import ExecutionContext
+from sztu_code.core.subagent.registry import (
+    BackgroundTaskRegistry,
+    BackgroundTaskStatus,
+)
+
+
+# 构造一个最小可用的 ExecutionContext，供注册时传入
+def _ctx(run_id: str = "child", result: str = "") -> ExecutionContext:
+    ctx = ExecutionContext(run_id=run_id, goal="g", max_steps=1)
+    ctx.result = result
+    return ctx
+
+
+# 注册一个永不完成的任务，便于观察 running 状态
+def _running_task() -> asyncio.Task[None]:
+    async def _forever() -> None:
+        await asyncio.Event().wait()
+
+    return asyncio.create_task(_forever())
+
+
+# 功能：register 存储 parent_run_id，且可通过 children 索引递归遍历
+# 设计：注册 parent->child 关系，断言 descendants 能从父找到子
+async def test_register_stores_parent_relation() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("child-1", "parent-1", task, _ctx("child-1"))
+        assert reg.descendants("parent-1") == ["child-1"]
+        record = reg.get("child-1")
+        assert record is not None
+        assert record.parent_run_id == "parent-1"
+        assert record.status is BackgroundTaskStatus.RUNNING
+    finally:
+        task.cancel()
+
+
+# 功能：重复注册仍处于活动状态的 run_id 应被拒绝，而非静默覆盖
+# 设计：先用活动 run_id 注册，再注册同名，断言抛 ValueError 且原记录未变
+async def test_duplicate_active_registration_rejected() -> None:
+    reg = BackgroundTaskRegistry()
+    task1 = _running_task()
+    try:
+        reg.register("dup", "parent", task1, _ctx("dup"))
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register("dup", "parent", _running_task(), _ctx("dup"))
+        # 原记录仍指向首个 task
+        record = reg.get("dup")
+        assert record is not None
+        assert record.task is task1
+    finally:
+        task1.cancel()
+
+
+# 功能：终态记录的同名 run_id 可被重新注册（墓碑不阻止重建）
+# 设计：先注册并标记终态，再用同名注册新任务，断言成功且状态为 running
+async def test_terminal_run_id_can_be_reregistered() -> None:
+    reg = BackgroundTaskRegistry()
+    first_task = asyncio.create_task(asyncio.sleep(0))
+    await first_task
+    reg.register("reuse", "parent", first_task, _ctx("reuse"))
+    reg.mark_terminal("reuse", BackgroundTaskStatus.COMPLETED, detail="done")
+    # 重新注册同名
+    new_task = _running_task()
+    try:
+        reg.register("reuse", "parent", new_task, _ctx("reuse"))
+        record = reg.get("reuse")
+        assert record is not None
+        assert record.status is BackgroundTaskStatus.RUNNING
+    finally:
+        new_task.cancel()
+
+
+# 功能：running 状态查询返回 running
+# 设计：注册未完成任务，断言 query_result 返回 RUNNING 且 is_running
+async def test_query_running() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("r1", "parent", task, _ctx("r1"))
+        q = reg.query_result("r1")
+        assert q.status is BackgroundTaskStatus.RUNNING
+        assert q.is_running
+    finally:
+        task.cancel()
+
+
+# 功能：completed 终态查询返回结果文本
+# 设计：标记 completed，断言 query_result 返回 COMPLETED 且 result_text 含上下文结果
+async def test_query_completed() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("c1", "parent", task, _ctx("c1", result="done text"))
+        won = reg.mark_terminal("c1", BackgroundTaskStatus.COMPLETED, detail="done text")
+        assert won is True
+        q = reg.query_result("c1")
+        assert q.status is BackgroundTaskStatus.COMPLETED
+        assert "done text" in q.result_text
+    finally:
+        task.cancel()
+
+
+# 功能：failed 终态查询返回失败详情
+# 设计：标记 failed，断言 query_result 返回 FAILED 且 reason 携带失败信息
+async def test_query_failed() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("f1", "parent", task, _ctx("f1"))
+        reg.mark_terminal("f1", BackgroundTaskStatus.FAILED, detail="boom")
+        q = reg.query_result("f1")
+        assert q.status is BackgroundTaskStatus.FAILED
+        assert "boom" in q.reason
+    finally:
+        task.cancel()
+
+
+# 功能：cancelled 终态查询返回取消状态，不复用 failed
+# 设计：标记 cancelled，断言 query_result 返回 CANCELLED
+async def test_query_cancelled() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("x1", "parent", task, _ctx("x1"))
+        reg.mark_terminal("x1", BackgroundTaskStatus.CANCELLED, reason="parent_cancelled")
+        q = reg.query_result("x1")
+        assert q.status is BackgroundTaskStatus.CANCELLED
+        assert q.status is not BackgroundTaskStatus.FAILED
+    finally:
+        task.cancel()
+
+
+# 功能：未知 run_id 查询返回 running+reason=unknown（不与 reclaimed 混淆）
+# 设计：查询从未注册的 run_id，断言 status=RUNNING 且 reason=unknown
+async def test_query_unknown_run_id() -> None:
+    reg = BackgroundTaskRegistry()
+    q = reg.query_result("never-registered")
+    assert q.status is BackgroundTaskStatus.RUNNING
+    assert q.reason == "unknown"
+
+
+# 功能：首次终态转换胜出并返回 True，后续转换返回 False
+# 设计：连续两次 mark_terminal，断言首次返回 True、第二次返回 False，且终态保持首次值
+async def test_first_terminal_transition_wins() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("w1", "parent", task, _ctx("w1"))
+        first = reg.mark_terminal("w1", BackgroundTaskStatus.COMPLETED, detail="first")
+        second = reg.mark_terminal("w1", BackgroundTaskStatus.CANCELLED, reason="late_cancel")
+        assert first is True
+        assert second is False
+        record = reg.get("w1")
+        assert record is not None
+        # 取消不得覆盖先到的完成结果
+        assert record.status is BackgroundTaskStatus.COMPLETED
+        assert record.terminal_detail == "first"
+    finally:
+        task.cancel()
+
+
+# 功能：consume_result 首次读取成功并回收记录，第二次查询返回 reclaimed
+# 设计：标记 completed 后 consume 一次成功，再 consume 同一 run_id 断言返回 RECLAIMED
+async def test_consume_then_reclaimed() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        reg.register("k1", "parent", task, _ctx("k1", result="payload"))
+        reg.mark_terminal("k1", BackgroundTaskStatus.COMPLETED, detail="payload")
+        first = reg.consume_result("k1")
+        assert first.status is BackgroundTaskStatus.COMPLETED
+        assert "payload" in first.result_text
+        second = reg.consume_result("k1")
+        assert second.status is BackgroundTaskStatus.RECLAIMED
+    finally:
+        task.cancel()
+
+
+# 功能：消费/裁剪后释放 task 与 context.messages 引用，避免内存泄漏
+# 设计：注册带大 messages 的上下文，consume 后断言 record.task 和 context 为 None
+async def test_consume_releases_heavy_references() -> None:
+    reg = BackgroundTaskRegistry()
+    task = _running_task()
+    try:
+        ctx = _ctx("heavy")
+        ctx.messages = [{"role": "user", "content": "x" * 10_000}]  # 重型历史
+        reg.register("heavy", "parent", task, ctx)
+        reg.mark_terminal("heavy", BackgroundTaskStatus.COMPLETED, detail="ok")
+        reg.consume_result("heavy")
+        record = reg.get("heavy")
+        assert record is not None
+        assert record.task is None
+        assert record.context is None  # context.messages 引用链已断开
+    finally:
+        task.cancel()
+
+
+# 功能：TTL 过期使终态记录变为 reclaimed，无需 sleep（注入时钟）
+# 设计：注册完成后标记终态 finished_at=100，推进注入时钟 now=120 超过 TTL=10，断言查询返回 RECLAIMED
+async def test_ttl_expiry_without_sleep() -> None:
+    reg = BackgroundTaskRegistry(retention_ttl_s=10.0)
+    task = _running_task()
+    try:
+        reg.register("t1", "parent", task, _ctx("t1", result="r"))
+        reg.mark_terminal("t1", BackgroundTaskStatus.COMPLETED, detail="r", finished_at=100.0)
+        # 推进时钟超过 TTL 触发裁剪（公共 prune 入口，注入 now）
+        reg.prune(now=120.0)
+        q = reg.query_result("t1")
+        assert q.status is BackgroundTaskStatus.RECLAIMED
+    finally:
+        task.cancel()
+
+
+# 功能：max_retained_terminal 容量上限淘汰最旧终态记录，永不淘汰活动记录
+# 设计：max=2，注册 3 个终态记录，断言最旧的被回收、活动的仍在
+async def test_max_capacity_evicts_oldest_terminal() -> None:
+    reg = BackgroundTaskRegistry(retention_ttl_s=0.0, max_retained_terminal=2)
+    active_task = _running_task()
+    try:
+        reg.register("active", "parent", active_task, _ctx("active"))
+        for rid in ("a", "b", "c"):
+            t = asyncio.create_task(asyncio.sleep(0))
+            await t
+            reg.register(rid, "parent", t, _ctx(rid))
+            reg.mark_terminal(rid, BackgroundTaskStatus.COMPLETED, detail=rid)
+        # 容量 2，3 条终态中 "a" 最旧应被回收
+        assert reg.query_result("a").status is BackgroundTaskStatus.RECLAIMED
+        # 活动记录未被淘汰
+        assert reg.query_result("active").status is BackgroundTaskStatus.RUNNING
+    finally:
+        active_task.cancel()
+
+
+# 功能：cancel_descendants 递归取消整个后代树并等待落定
+# 设计：parent->child->grandchild 三层，取消 parent 的后代，断言全部变为 cancelled
+async def test_cancel_descendants_recurses_tree() -> None:
+    reg = BackgroundTaskRegistry()
+    gate = asyncio.Event()
+
+    async def _blocked() -> None:
+        await gate.wait()
+
+    child_task = asyncio.create_task(_blocked())
+    grandchild_task = asyncio.create_task(_blocked())
+    try:
+        reg.register("child", "parent", child_task, _ctx("child"))
+        reg.register("grandchild", "child", grandchild_task, _ctx("grandchild"))
+        cancelled = await reg.cancel_descendants("parent", reason="parent_cancelled")
+        assert set(cancelled) == {"child", "grandchild"}
+        assert reg.query_result("child").status is BackgroundTaskStatus.CANCELLED
+        assert reg.query_result("grandchild").status is BackgroundTaskStatus.CANCELLED
+    finally:
+        gate.set()
+
+
+# 功能：已完成的子在父取消时保持 completed，不被取消覆盖
+# 设计：child 先标记 completed，再 cancel parent 的后代，断言 child 仍为 completed
+async def test_completed_child_survives_parent_cancel() -> None:
+    reg = BackgroundTaskRegistry()
+    child_task = asyncio.create_task(asyncio.sleep(0))
+    await child_task
+    grandchild_task = _running_task()
+    try:
+        reg.register("child", "parent", child_task, _ctx("child", result="ok"))
+        reg.mark_terminal("child", BackgroundTaskStatus.COMPLETED, detail="ok")
+        reg.register("grandchild", "child", grandchild_task, _ctx("grandchild"))
+        await reg.cancel_descendants("parent", reason="parent_cancelled")
+        # 已完成的 child 保持 completed
+        assert reg.query_result("child").status is BackgroundTaskStatus.COMPLETED
+        # 活动的 grandchild 被取消
+        assert reg.query_result("grandchild").status is BackgroundTaskStatus.CANCELLED
+    finally:
+        grandchild_task.cancel()
+
+
+# 功能：shutdown 取消所有活动 task 并释放引用，且可安全重复调用
+# 设计：注册活动任务，shutdown 两次，断言全部回收且无异常
+async def test_shutdown_idempotent_and_cancels_all() -> None:
+    reg = BackgroundTaskRegistry()
+    t1 = _running_task()
+    t2 = _running_task()
+    try:
+        reg.register("s1", "parent", t1, _ctx("s1"))
+        reg.register("s2", "parent", t2, _ctx("s2"))
+        await reg.shutdown()
+        assert reg.query_result("s1").status is BackgroundTaskStatus.RECLAIMED
+        assert reg.query_result("s2").status is BackgroundTaskStatus.RECLAIMED
+        # 重复调用安全
+        await reg.shutdown()
+    finally:
+        t1.cancel()
+        t2.cancel()
+
+
+# 功能：1000 个已完成短任务不留 1000 份完整 context/messages 引用（内存释放回归）
+# 设计：注册 1000 个终态任务并 consume，断言所有记录的 context 均为 None
+async def test_thousand_completed_tasks_release_contexts() -> None:
+    reg = BackgroundTaskRegistry(retention_ttl_s=0.0, max_retained_terminal=10_000)
+    for i in range(1000):
+        t = asyncio.create_task(asyncio.sleep(0))
+        await t
+        ctx = _ctx(f"task-{i}", result=f"r{i}")
+        ctx.messages = [{"role": "user", "content": "data" * 100}]
+        reg.register(f"task-{i}", "parent", t, ctx)
+        reg.mark_terminal(f"task-{i}", BackgroundTaskStatus.COMPLETED, detail=f"r{i}")
+        reg.consume_result(f"task-{i}")
+    # 全部消费后 context 引用应已释放
+    leaked = [
+        rid
+        for rid, record in reg._records.items()  # noqa: SLF001
+        if record.context is not None
+    ]
+    assert leaked == [], f"{len(leaked)} records still hold context"


### PR DESCRIPTION
Closes #73

修复父任务停止后后台子 Agent 未被完整清理的问题：

- 建立后台 Agent 父子任务关系，支持递归取消 child / grandchild。
- 父任务失败、取消或中断时，等待所有后代任务真正结束。
- 补全子任务终态事件，保证每个任务只发送一次 finished，且早于 root 的结束事件。
- 增加结果回收机制，避免后台任务上下文长期占用内存。

验证：104 个相关测试通过，ruff 和 mypy 通过。