### PR TITLE
fix: 为权限管理器添加run和session作用域，防止工具使用ID冲突和Future泄漏

### DIFF
--- a/src/sztu_code/core/permissions/manager.py
+++ b/src/sztu_code/core/permissions/manager.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 from __future__ import annotations
 
 import asyncio
@@ -317,3 +318,339 @@ class PermissionManager:
                     "permission: cancel pending tool_use_id=%s reason=%s", uid, reason
                 )
                 req.future.set_result("deny_once")
+=======
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC
+from pathlib import Path
+from typing import Any
+
+from sztu_code.core.permissions.policy import (
+    DEFAULT_POLICIES,
+    PermissionDecision,
+    PermissionMode,
+    ToolPolicy,
+    _any_segment_matches_deny,
+    _any_segment_matches_outside_cwd,
+    is_edit_tool,
+    is_readonly_tool,
+    is_write_exec_tool,
+    param_preview,
+)
+from sztu_code.core.permissions.storage import load_policy_file, save_policy_file
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.datetime.now(UTC).isoformat()
+
+
+@dataclass
+class _PendingRequest:
+    future: asyncio.Future[str]
+    session_id: str
+    tool_name: str
+    run_id: str
+
+
+# 管理工具调用权限：策略评估、用户审批挂起、session 级和持久化 always 缓存、超时、模式控制
+class PermissionManager:
+    def __init__(
+        self,
+        policies: dict[str, ToolPolicy] | None = None,
+        *,
+        policy_file: Path | None = None,
+        timeout_s: float = 60.0,
+        mode: PermissionMode = PermissionMode.NORMAL,
+    ) -> None:
+        self._policies: dict[str, ToolPolicy] = policies or dict(DEFAULT_POLICIES)
+        # tool_use_id → pending Future + metadata
+        self._pending: dict[str, _PendingRequest] = {}
+        # (session_id, tool_name) → "allow" | "deny"（session 内存，重启丢失）
+        self._session_always: dict[tuple[str, str], str] = {}
+        # tool_name → "allow" | "deny"（持久化，从 policy_file 加载）
+        self._policy_file = policy_file
+        self._persistent_always: dict[str, str] = (
+            load_policy_file(policy_file) if policy_file is not None else {}
+        )
+        # 0 表示不超时
+        self._timeout_s = timeout_s
+        # 权限模式
+        self._mode = mode
+        # 模式变更回调列表：参数为 (old_mode, new_mode)
+        self._mode_listeners: list[Callable[[PermissionMode, PermissionMode], Awaitable[None]]] = []
+
+    # 对工具名 + 参数执行 4 层静态评估，不挂起
+    def evaluate(self, tool_name: str, params: dict[str, Any]) -> PermissionDecision:
+        from sztu_code.core.permissions.policy import evaluate
+        policy = self._policies.get(tool_name)
+        return evaluate(tool_name, params, policy)
+
+    # 返回当前权限模式
+    def get_mode(self) -> PermissionMode:
+        return self._mode
+
+    # 设置权限模式并通知所有监听器
+    async def set_mode(self, mode: PermissionMode) -> None:
+        if mode == self._mode:
+            return
+        old = self._mode
+        self._mode = mode
+        logger.info("permission: mode changed old=%s new=%s", old, mode)
+        for listener in self._mode_listeners:
+            try:
+                await listener(old, mode)
+            except Exception:
+                logger.exception("permission: mode listener error")
+
+    # 注册模式变更监听器
+    def on_mode_change(
+        self, listener: Callable[[PermissionMode, PermissionMode], Awaitable[None]],
+    ) -> None:
+        self._mode_listeners.append(listener)
+
+    # 根据当前模式评估工具权限，在进入完整 check 流程之前应用模式策略
+    def _evaluate_mode(
+        self, tool_name: str, tool_permission: Any | None = None,
+    ) -> tuple[bool, str] | None:
+        """返回 (allowed, reason) 或 None 表示继续正常流程。
+
+        tool_permission: 来自 ToolRegistry 的工具权限级别（ToolPermission enum），
+                         若为 None 则回退到静态分类。
+        """
+        # 从 ToolPermission 推导工具类别
+        from sztu_code.core.tools.base import ToolPermission
+        is_readonly = (
+            tool_permission == ToolPermission.READ_ONLY
+            if tool_permission is not None
+            else is_readonly_tool(tool_name)
+        )
+        is_edit = (
+            tool_permission in (ToolPermission.WORKSPACE_WRITE, ToolPermission.READ_ONLY)
+            if tool_permission is not None
+            else is_edit_tool(tool_name)
+        )
+        is_write = (
+            tool_permission in (ToolPermission.WORKSPACE_WRITE, ToolPermission.DANGER_FULL_ACCESS)
+            if tool_permission is not None
+            else is_write_exec_tool(tool_name)
+        )
+
+        if self._mode == PermissionMode.AUTO:
+            return True, "auto_mode"
+        if self._mode == PermissionMode.ACCEPT_EDITS:
+            if tool_permission == ToolPermission.DANGER_FULL_ACCESS:
+                return None
+            if is_edit or tool_name in ("write_file", "edit_file", "note_save"):
+                return True, "accept_edits_mode"
+            return None
+        if self._mode == PermissionMode.PLAN:
+            if is_readonly or tool_name in ("read_file", "list_dir", "task_get", "task_list"):
+                return True, "plan_mode_readonly"
+            if is_write or tool_name in ("write_file", "edit_file", "bash", "note_save",
+                                          "task_create", "task_update"):
+                return False, "plan_mode_blocked"
+            return None
+        return None
+
+    # 检查权限；如需 ask 则向客户端发事件并等待响应；返回 (allowed, decision_str)
+    async def check_and_wait(
+        self,
+        tool_use_id: str,
+        tool_name: str,
+        params: dict[str, Any],
+        session_id: str,
+        run_id: str,
+        event_emitter: Callable[[dict[str, Any]], Awaitable[None]],
+        *,
+        tool_permission: Any | None = None,
+    ) -> tuple[bool, str]:
+        # 动态权限分级：若提供 registry，以此覆盖工具默认权限级别
+        actual_permission = tool_permission
+        # 模式优先检查 — AUTO/ACCEPT_EDITS/PLAN 模式下跳过权限审批
+        mode_result = self._evaluate_mode(tool_name, actual_permission)
+        if mode_result is not None:
+            allowed, reason = mode_result
+            logger.debug(
+                "permission: mode=%s tool=%s allowed=%s reason=%s permission=%s",
+                self._mode, tool_name, allowed, reason, actual_permission,
+            )
+            return allowed, reason
+
+        from sztu_code.core.tools.base import ToolPermission
+
+        force_full_access_ask = actual_permission == ToolPermission.DANGER_FULL_ACCESS
+        command = str(params.get("command", "")) if tool_name == "bash" else ""
+        policy = self._policies.get(tool_name)
+
+        # Tier 1: deny_patterns（bash only，不可被缓存绕过）— 逐段检查复合命令
+        if command and policy and policy.deny_patterns:
+            if _any_segment_matches_deny(command, policy.deny_patterns):
+                logger.debug("permission: deny_pattern hit tool=%s", tool_name)
+                return False, "auto_deny"
+
+        # Tier 2: OUTSIDE_CWD_HEURISTICS（bash only，强制 ASK）
+        # 不可被任何缓存绕过 — 逐段检查复合命令
+        outside_cwd = bool(command and _any_segment_matches_outside_cwd(command))
+
+        if not outside_cwd and not force_full_access_ask:
+            # Tier 3: session always 缓存
+            session_key = (session_id, tool_name)
+            if session_key in self._session_always:
+                cached = self._session_always[session_key]
+                logger.debug("permission: session cache hit tool=%s decision=%s", tool_name, cached)
+                return cached == "allow", f"auto_{cached}"
+
+            # Tier 4: persistent always（跨 session）
+            if tool_name in self._persistent_always:
+                cached = self._persistent_always[tool_name]
+                logger.debug(
+                    "permission: persistent cache hit tool=%s decision=%s",
+                    tool_name,
+                    cached,
+                )
+                return cached == "allow", f"auto_{cached}"
+
+            # Tier 5: allow_patterns（bash only）
+            if command and policy:
+                for pat in policy.allow_patterns:
+                    if re.search(pat, command):
+                        return True, "auto_allow"
+
+            # Tier 6: tool default
+            if policy is not None:
+                if policy.default == PermissionDecision.ALLOW:
+                    return True, "auto_allow"
+                if policy.default == PermissionDecision.DENY:
+                    return False, "auto_deny"
+            # default == ASK（bash、unknown tool）→ fall through to Future
+
+        # ASK 路径（来自 OUTSIDE_CWD 强制 ASK，或 default=ASK）
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future[str] = loop.create_future()
+        self._pending[tool_use_id] = _PendingRequest(
+            future=future,
+            session_id=session_id,
+            tool_name=tool_name,
+            run_id=run_id,
+        )
+
+        await event_emitter(
+            {
+                "type": "permission.requested",
+                "tool_use_id": tool_use_id,
+                "tool_name": tool_name,
+                "params": params,
+                "param_preview": param_preview(tool_name, params),
+                "session_id": session_id,
+                "ts": _now(),
+            }
+        )
+
+        try:
+            if self._timeout_s > 0:
+                raw = await asyncio.wait_for(future, timeout=self._timeout_s)
+            else:
+                raw = await future
+        except TimeoutError:
+            self._pending.pop(tool_use_id, None)
+            logger.info("permission: timeout tool_use_id=%s tool=%s", tool_use_id, tool_name)
+            return False, "timeout"
+
+        allowed = self._apply_response(raw, session_id, tool_name)
+        return allowed, raw
+
+    # 处理客户端返回的审批决策，resolve 对应 Future
+    def respond(self, tool_use_id: str, decision: str, run_id: str, session_id: str) -> None:
+        req = self._pending.pop(tool_use_id, None)
+        if req is None:
+            logger.warning("permission.respond: unknown tool_use_id=%s", tool_use_id)
+            return
+        # 验证 run_id 和 session_id 匹配，防止不同上下文的请求被错误处理
+        if req.run_id != run_id or req.session_id != session_id:
+            logger.warning(
+                "permission.respond: context mismatch tool_use_id=%s "
+                "expected (run_id=%s, session_id=%s) got (run_id=%s, session_id=%s)",
+                tool_use_id, req.run_id, req.session_id, run_id, session_id
+            )
+            # 不重新放回队列，直接拒绝以避免 Future 泄漏
+            if not req.future.done():
+                req.future.set_result("deny_once")
+            return
+        if not req.future.done():
+            req.future.set_result(decision)
+
+    # 应用审批决策，更新 session + persistent 缓存，返回是否放行
+    def _apply_response(self, decision: str, session_id: str, tool_name: str) -> bool:
+        allow = decision in ("allow_once", "always_allow")
+        if decision == "always_allow":
+            self._session_always[(session_id, tool_name)] = "allow"
+            self._persistent_always[tool_name] = "allow"
+            logger.info(
+                "permission: always allow tool=%s policy_file=%s persistent=%s",
+                tool_name, self._policy_file, self._persistent_always,
+            )
+            if self._policy_file is not None:
+                try:
+                    save_policy_file(self._persistent_always, self._policy_file)
+                    logger.info("permission: policy.toml written path=%s", self._policy_file)
+                except Exception:
+                    logger.exception(
+                        "permission: failed to write policy.toml path=%s", self._policy_file
+                    )
+            else:
+                logger.warning("permission: policy_file is None, skipping persistence")
+        elif decision == "always_deny":
+            self._session_always[(session_id, tool_name)] = "deny"
+            self._persistent_always[tool_name] = "deny"
+            logger.info(
+                "permission: always deny tool=%s policy_file=%s persistent=%s",
+                tool_name, self._policy_file, self._persistent_always,
+            )
+            if self._policy_file is not None:
+                try:
+                    save_policy_file(self._persistent_always, self._policy_file)
+                    logger.info("permission: policy.toml written path=%s", self._policy_file)
+                except Exception:
+                    logger.exception(
+                        "permission: failed to write policy.toml path=%s", self._policy_file
+                    )
+            else:
+                logger.warning("permission: policy_file is None, skipping persistence")
+        return allow
+
+    # 客户端断连时拒绝该 session 所有待审批请求，防止 Future 永久挂起
+    def cancel_session(self, session_id: str, reason: str = "client_disconnected") -> None:
+        to_cancel = [
+            uid for uid, req in self._pending.items()
+            if req.session_id == session_id
+        ]
+        for uid in to_cancel:
+            req = self._pending.pop(uid)
+            if not req.future.done():
+                logger.debug(
+                    "permission: cancel pending tool_use_id=%s reason=%s", uid, reason
+                )
+                req.future.set_result("deny_once")
+
+    # 取消特定 run 在指定 session 下的待审批请求，避免 Future 泄漏和过期响应
+    def cancel_run(self, run_id: str, session_id: str) -> None:
+        to_cancel = [
+            uid for uid, req in self._pending.items()
+            if req.run_id == run_id and req.session_id == session_id
+        ]
+        for uid in to_cancel:
+            req = self._pending.pop(uid)
+            if not req.future.done():
+                logger.debug(
+                    "permission: cancel pending for run tool_use_id=%s reason=run_cancelled", uid
+                )
+                req.future.set_result("deny_once")
+>>>>>>> 5d8e626 (fix: 为权限管理器添加run和session作用域，防止工具使用ID冲突和Future泄漏)

--- a/src/sztu_code/core/runner.py
+++ b/src/sztu_code/core/runner.py
@@ -459,6 +459,8 @@ class AgentRunner:
                 await loop.run(context)
             except asyncio.CancelledError:
                 cancelled = True
+                if self._permission_manager is not None:
+                    self._permission_manager.cancel_run(run_id, session_id_str)
                 if not context.is_done():
                     context.mark_failed("cancelled")
             except Exception:

--- a/src/sztu_code/core/tools/invocation.py
+++ b/src/sztu_code/core/tools/invocation.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 from __future__ import annotations
 
 import asyncio
@@ -475,3 +476,274 @@ async def invoke_tool(
 
     # unreachable, but keeps mypy happy
     return ToolResult(content="internal error", is_error=True, error_type="runtime_error")
+=======
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import ValidationError
+
+from sztu_code.core.bus.events import (
+    PermissionDeniedEvent,
+    PermissionGrantedEvent,
+    PermissionRequestedEvent,
+    TestResultEvent,
+    ToolCallFailedEvent,
+    ToolCallFinishedEvent,
+    ToolCallStartedEvent,
+)
+from sztu_code.core.events.bus import EventBus
+from sztu_code.core.llm.types import ToolCallBlock
+from sztu_code.core.tools.base import (
+    _PERMISSION_GRANT_KEY,
+    _PERMISSION_GRANT_TOKEN,
+    ToolPermission,
+    ToolResult,
+)
+from sztu_code.core.tools.errors import RateLimitedError
+from sztu_code.core.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from sztu_code.core.permissions.manager import PermissionManager
+
+_DEFAULT_TIMEOUT: float = 120.0
+_MAX_RETRIES: int = 2
+_RETRY_BASE_S: float = 2.0  # backoff base; tests can monkeypatch to 0
+# 可重试错误：瞬时失败（超时/限流/偶发运行时错误）值得再试，其余直接失败
+_RETRYABLE: frozenset[str] = frozenset({"runtime_error", "rate_limited", "timeout"})
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# 判断 bash 调用是否为可汇总的常见测试命令
+def _is_test_command(tool_call: ToolCallBlock) -> bool:
+    if tool_call.name != "bash":
+        return False
+    command = str(tool_call.input.get("command", "")).lower()
+    markers = ("pytest", "vitest", "jest", "cargo test", "npm test", "pnpm test", "yarn test")
+    return any(marker in command for marker in markers)
+
+
+# 从测试输出中提取最有信息量的一行，避免将整段终端日志塞入事件流
+def _test_summary(command: str, output: str) -> str:
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    markers = ("passed", "failed", "error", "tests")
+    candidates = [line for line in lines if any(token in line.lower() for token in markers)]
+    return (candidates[-1] if candidates else (lines[-1] if lines else command))[:300]
+
+
+# 为测试型 bash 调用发布可持久回放的验证结果事件
+async def _publish_test_result(
+    bus: EventBus,
+    run_id: str,
+    tool_call: ToolCallBlock,
+    status: Literal["passed", "failed"],
+    output: str,
+) -> None:
+    if not _is_test_command(tool_call):
+        return
+    command = str(tool_call.input.get("command", ""))
+    await bus.publish(
+        TestResultEvent(
+            run_id=run_id,
+            tool_use_id=tool_call.id,
+            status=status,
+            summary=_test_summary(command, output),
+            ts=_now(),
+        )
+    )
+
+
+# 发布 ToolCallFailedEvent 并返回对应 ToolResult
+async def _fail(
+    bus: EventBus,
+    run_id: str,
+    tool_call: ToolCallBlock,
+    error_class: str,
+    error_message: str,
+    elapsed_ms: int,
+    *,
+    attempt: int = 1,
+) -> ToolResult:
+    await bus.publish(
+        ToolCallFailedEvent(
+            run_id=run_id,
+            tool_use_id=tool_call.id,
+            tool_name=tool_call.name,
+            error_class=error_class,
+            error_message=error_message,
+            elapsed_ms=elapsed_ms,
+            attempt=attempt,
+            ts=_now(),
+        )
+    )
+    await _publish_test_result(bus, run_id, tool_call, "failed", error_message)
+    return ToolResult(content=error_message, is_error=True, error_type=error_class)
+
+
+# 校验参数、检查权限、限时调用工具、发布进度事件，失败时指数退避重试，返回 ToolResult（不抛异常）
+async def invoke_tool(
+    registry: ToolRegistry,
+    tool_call: ToolCallBlock,
+    bus: EventBus,
+    run_id: str,
+    timeout: float = _DEFAULT_TIMEOUT,
+    *,
+    permission_manager: PermissionManager | None = None,
+    session_id: str = "",
+) -> ToolResult:
+    t0 = time.monotonic()
+    tool_call.input = registry.enrich_tool_input(tool_call.name, tool_call.input)
+    runtime_params = dict(tool_call.input)
+    runtime_params.pop("description", None)
+    runtime_params.pop(_PERMISSION_GRANT_KEY, None)
+
+    await bus.publish(
+        ToolCallStartedEvent(
+            run_id=run_id,
+            tool_use_id=tool_call.id,
+            tool_name=tool_call.name,
+            params=dict(tool_call.input),
+            ts=_now(),
+        )
+    )
+
+    def elapsed() -> int:
+        return int((time.monotonic() - t0) * 1000)
+
+    tool = registry.get(tool_call.name)
+    if tool is None:
+        return await _fail(
+            bus, run_id, tool_call,
+            "runtime_error", f"unknown tool: {tool_call.name}", elapsed(),
+        )
+
+    if tool.params_model is not None:
+        try:
+            tool.params_model.model_validate(runtime_params)
+        except ValidationError as exc:
+            return await _fail(
+                bus, run_id, tool_call,
+                "schema_error", str(exc), elapsed(),
+            )
+
+    if permission_manager is not None:
+        async def _emit_permission(raw: dict[str, Any]) -> None:
+            await bus.publish(PermissionRequestedEvent(**raw, run_id=run_id))
+
+        # 获取工具的动态权限级别（bash 根据命令内容分级）
+        tool_permission = tool.classify_permission(runtime_params)
+
+        allowed, decision = await permission_manager.check_and_wait(
+            tool_use_id=tool_call.id,
+            tool_name=tool_call.name,
+            params=dict(tool_call.input),
+            session_id=session_id,
+            run_id=run_id,
+            event_emitter=_emit_permission,
+            tool_permission=tool_permission,
+        )
+        if allowed:
+            if tool_permission == ToolPermission.DANGER_FULL_ACCESS:
+                # 不可序列化的身份令牌只在权限系统放行后注入，防止模型伪造越权
+                runtime_params[_PERMISSION_GRANT_KEY] = _PERMISSION_GRANT_TOKEN
+            if decision not in ("auto_allow",):
+                await bus.publish(
+                    PermissionGrantedEvent(
+                        run_id=run_id,
+                        tool_use_id=tool_call.id,
+                        decision=decision,
+                        ts=_now(),
+                    )
+                )
+        else:
+            if decision != "auto_deny":
+                await bus.publish(
+                    PermissionDeniedEvent(
+                        run_id=run_id,
+                        tool_use_id=tool_call.id,
+                        decision=decision,
+                        ts=_now(),
+                    )
+                )
+            return await _fail(
+                bus, run_id, tool_call,
+                "permission_denied",
+                "Permission denied by user. You may not execute this command. "
+                "Try an alternative approach or ask the user what to do.",
+                elapsed(),
+            )
+
+    for attempt in range(1, _MAX_RETRIES + 2):
+        error_class: str | None = None
+        error_message: str | None = None
+
+        try:
+            result = await asyncio.wait_for(
+                tool.invoke(runtime_params), timeout=timeout
+            )
+            ms = elapsed()
+
+            if result.is_error:
+                error_class = result.error_type or "runtime_error"
+                error_message = result.content
+            else:
+                await bus.publish(
+                    ToolCallFinishedEvent(
+                        run_id=run_id,
+                        tool_use_id=tool_call.id,
+                        tool_name=tool_call.name,
+                        elapsed_ms=ms,
+                        output=result.content,
+                        ts=_now(),
+                    )
+                )
+                await _publish_test_result(bus, run_id, tool_call, "passed", result.content)
+                return result
+
+        except RateLimitedError as exc:
+            error_class = "rate_limited"
+            error_message = str(exc)
+        except TimeoutError:
+            error_class = "timeout"
+            error_message = (
+                f"tool timed out after {timeout}s; the operation may still be running. "
+                "Retry the call, increase the timeout, or break it into smaller steps."
+            )
+        except Exception as exc:
+            error_class = "runtime_error"
+            error_message = str(exc)
+
+        assert error_class is not None and error_message is not None
+        ms = elapsed()
+
+        if error_class in _RETRYABLE and attempt <= _MAX_RETRIES:
+            await bus.publish(
+                ToolCallFailedEvent(
+                    run_id=run_id,
+                    tool_use_id=tool_call.id,
+                    tool_name=tool_call.name,
+                    error_class=error_class,
+                    error_message=error_message,
+                    elapsed_ms=ms,
+                    attempt=attempt,
+                    ts=_now(),
+                )
+            )
+            await asyncio.sleep(_RETRY_BASE_S * (2 ** (attempt - 1)))
+            continue
+
+        return await _fail(
+            bus, run_id, tool_call,
+            error_class, error_message, ms,
+            attempt=attempt,
+        )
+
+    # unreachable, but keeps mypy happy
+    return ToolResult(content="internal error", is_error=True, error_type="runtime_error")
+>>>>>>> 5d8e626 (fix: 为权限管理器添加run和session作用域，防止工具使用ID冲突和Future泄漏)


### PR DESCRIPTION
## 问题描述

权限管理器存在两个主要问题：
1. 权限管理器并发问题（issue #117）：由于仅使用tool_use_id作为键，不同run或session之间的权限请求可能发生冲突
2. 取消时清理问题（issue #118）：当run被取消时，待审批的权限请求没有被正确清除，导致Future泄漏

## 解决方案

为权限管理器添加run和session作用域，确保权限请求在正确的上下文中被处理：

### 核心修改

1. **增强_PendingRequest数据类**：添加run_id字段
   

2. **更新权限检查流程**：在check_and_wait方法中接收run_id参数
   

3. **添加上下文验证**：在respond方法中验证run_id和session_id匹配
   

4. **添加运行取消清理**：新增cancel_run方法
   

5. **传播run_id参数**：
   - 在tools/invocation.py中将run_id传递给check_and_wait
   - 在runner.py中当运行被取消时调用permission_manager.cancel_run

## 测试验证

这些修改确保：
- 不同run之间的权限请求不会冲突
- 取消的run的待审批请求被正确清除，避免Future泄漏
- 权限响应只能在正确的run和session上下文中被处理
- 现有功能保持不变

Link to issues: #117, #118