### PR TITLE
fix(events): 慢 UI/遥测订阅者不再拖慢 Agent Loop（有界队列 + 异常隔离 + 流式合并）

### DIFF
--- a/py-runtime/src/sztu_code/core/app.py
+++ b/py-runtime/src/sztu_code/core/app.py
@@ -1818,7 +1818,8 @@ class CoreApp:
             trace_path = Path(self._config.trace.file).expanduser()
             self._trace = TraceWriter(trace_path)
             await self._trace.start()
-            self._bus.subscribe(self._trace_event_handler)
+            # trace 是 best-effort 遥测：走观测订阅，磁盘慢不拖累核心 loop
+            self._bus.subscribe_observer(self._trace_event_handler)
 
         policy_file = Path("~/.sztu/policy.toml").expanduser()
         self._permission_manager = PermissionManager(
@@ -1833,7 +1834,9 @@ class CoreApp:
         )
 
         self._broadcaster = IpcEventBroadcaster(trace=self._trace)
-        self._bus.subscribe(self._broadcaster.handle)
+        # 桌面/客户端广播是观测订阅：慢客户端只能拖慢自己的投递 worker（有界队列 +
+        # 流式事件合并/丢弃），不再阻塞 Agent Loop 或其他订阅者
+        self._bus.subscribe_observer(self._broadcaster.handle)
         sessions_root = Path("~/.sztu/sessions").expanduser()
         store = SessionStore(
             sessions_root,
@@ -1980,6 +1983,12 @@ class CoreApp:
         if self._mcp_manager is not None:
             await self._mcp_manager.stop_all()
         await server.stop()
+        # 有界 drain 观测订阅队列，把 shutdown 时未投递的事件数量暴露出来
+        undelivered = await self._bus.close_observers()
+        if undelivered:
+            logger.warning(
+                "event bus shutdown: %d observer event(s) undelivered", undelivered
+            )
         if self._trace is not None:
             await self._trace.stop()
 

--- a/py-runtime/src/sztu_code/core/events/bus.py
+++ b/py-runtime/src/sztu_code/core/events/bus.py
@@ -1,15 +1,224 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+from collections import deque
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from pydantic import BaseModel
 
+from sztu_code.core.bus.events import LlmThinkingEvent, LlmTokenEvent
+
 type EventHandler = Callable[[BaseModel], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
+
+# 高频流式事件（逐 token/逐思考块）：观测队列满时可合并或丢弃；
+# 其余事件视为生命周期关键事件，任何情况下不允许静默丢失
+STREAM_EVENT_TYPES = frozenset({"llm.token", "llm.thinking"})
+# 观测队列默认容量：正常渲染消费远快于填充速度，压满说明订阅者已卡死
+_DEFAULT_OBSERVER_QUEUE_SIZE = 256
+_DEFAULT_DRAIN_TIMEOUT_S = 2.0
+# 关键事件在观测队列满时的最长等待；超时后淘汰最旧事件腾位，避免无限阻塞核心 loop
+_ENQUEUE_TIMEOUT_S = 5.0
+
+
+@dataclass
+class ObserverStats:
+    """观测订阅者的投递计数，用于压测断言和运行时可观测"""
+
+    delivered: int = 0
+    dropped: int = 0
+    merged: int = 0
+    errors: int = 0
+    undelivered: int = 0
+
+
+def _is_stream_event(event: BaseModel) -> bool:
+    return getattr(event, "type", "") in STREAM_EVENT_TYPES
+
+
+# 把相邻同源的 token/thinking 增量合并为单条事件；返回 None 表示不可合并。
+# 增量文本拼接即客户端的渲染方式，因此合并不丢内容。
+def _merge_stream_events(prev: BaseModel, new: BaseModel) -> BaseModel | None:
+    if isinstance(prev, LlmTokenEvent) and isinstance(new, LlmTokenEvent):
+        if prev.run_id == new.run_id:
+            return new.model_copy(update={"token": prev.token + new.token, "ts": new.ts})
+        return None
+    if isinstance(prev, LlmThinkingEvent) and isinstance(new, LlmThinkingEvent):
+        if prev.run_id == new.run_id and prev.step == new.step:
+            return new.model_copy(
+                update={"thinking": prev.thinking + new.thinking, "ts": new.ts}
+            )
+        return None
+    return None
+
+
+class _EventQueue:
+    """观测订阅者的有界 FIFO 队列。基于 deque 实现，以便合并时检视队尾、
+    淘汰时移除队首；put/get 的唤醒语义与 asyncio.Queue 一致"""
+
+    def __init__(self, maxsize: int) -> None:
+        self.items: deque[BaseModel] = deque()
+        self._maxsize = max(1, maxsize)
+        self._not_empty = asyncio.Event()
+        self._space_available = asyncio.Event()
+        self._space_available.set()
+
+    def qsize(self) -> int:
+        return len(self.items)
+
+    def full(self) -> bool:
+        return len(self.items) >= self._maxsize
+
+    def put_nowait(self, item: BaseModel) -> None:
+        self.items.append(item)
+        self._not_empty.set()
+        if self.full():
+            self._space_available.clear()
+
+    def pop_oldest(self) -> BaseModel:
+        item = self.items.popleft()
+        self._space_available.set()
+        return item
+
+    async def put(self, item: BaseModel) -> None:
+        while self.full():
+            self._space_available.clear()
+            await self._space_available.wait()
+        self.put_nowait(item)
+
+    async def get(self) -> BaseModel:
+        while not self.items:
+            self._not_empty.clear()
+            await self._not_empty.wait()
+        item = self.items.popleft()
+        self._space_available.set()
+        return item
+
+
+class _ObserverWorker:
+    """每个观测订阅者一个 worker task：FIFO 保序，handler 异常只计数不外泄"""
+
+    def __init__(self, handler: EventHandler, queue_size: int) -> None:
+        self._handler = handler
+        self._queue = _EventQueue(queue_size)
+        self.stats = ObserverStats()
+        self._closed = False
+        self._task: asyncio.Task[None] | None = None
+        # idle=在 get() 等待新事件；clear 表示正在执行 handler（在途事件）
+        self._idle = asyncio.Event()
+        self._idle.set()
+        self._inflight_cancelled = False
+
+    def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                event = await self._queue.get()
+                self._idle.clear()
+                try:
+                    await self._handler(event)
+                    self.stats.delivered += 1
+                except Exception:
+                    self.stats.errors += 1
+                    logger.exception(
+                        "event bus: observer subscriber failed on %s",
+                        type(event).__name__,
+                    )
+                self._idle.set()
+        except asyncio.CancelledError:
+            # 在途事件被取消即未投递；在 get() 中被取消则无在途事件（idle 已置位）
+            if not self._idle.is_set():
+                self._inflight_cancelled = True
+
+    async def enqueue(self, event: BaseModel) -> None:
+        if self._closed:
+            self.stats.undelivered += 1
+            return
+        queue = self._queue
+        if not queue.full():
+            queue.put_nowait(event)
+            return
+        if _is_stream_event(event):
+            # 队尾同源流式事件直接合并，内容零丢失
+            merged = _merge_stream_events(queue.items[-1], event) if queue.items else None
+            if merged is not None:
+                queue.items[-1] = merged
+                self.stats.merged += 1
+                return
+            # 不同源：淘汰最旧的流式事件给新事件腾位
+            for existing in queue.items:
+                if _is_stream_event(existing):
+                    queue.items.remove(existing)
+                    self.stats.dropped += 1
+                    break
+            if not queue.full():
+                queue.put_nowait(event)
+            else:
+                self.stats.dropped += 1
+            return
+        # 生命周期关键事件：有限等待腾位；超时淘汰最旧事件，保证关键事件最终入队
+        try:
+            await asyncio.wait_for(queue.put(event), timeout=_ENQUEUE_TIMEOUT_S)
+        except TimeoutError:
+            evicted = queue.pop_oldest()
+            self.stats.dropped += 1
+            logger.error(
+                "event bus: observer queue full for %.1fs, evicted %s to deliver %s",
+                _ENQUEUE_TIMEOUT_S,
+                type(evicted).__name__,
+                type(event).__name__,
+            )
+            queue.put_nowait(event)
+
+    async def close(self, drain_timeout: float) -> int:
+        """停止接收新事件，有界等待队列清空且在途事件处理完成，返回未投递事件数"""
+        self._closed = True
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + drain_timeout
+        while (
+            self._queue.qsize() > 0 or not self._idle.is_set()
+        ) and loop.time() < deadline:
+            await asyncio.sleep(0.005)
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        undelivered = self._queue.qsize() + (1 if self._inflight_cancelled else 0)
+        self.stats.undelivered = undelivered
+        return undelivered
+
+
+class ObserverHandle:
+    """观测订阅的句柄：查询统计并负责有界 drain 后退订"""
+
+    def __init__(self, bus: EventBus, worker: _ObserverWorker) -> None:
+        self._bus = bus
+        self._worker = worker
+
+    @property
+    def stats(self) -> ObserverStats:
+        return self._worker.stats
+
+    @property
+    def pending(self) -> int:
+        return self._worker._queue.qsize()
+
+    async def unsubscribe(self, drain_timeout: float = _DEFAULT_DRAIN_TIMEOUT_S) -> int:
+        self._bus._remove_observer(self._worker)
+        return await self._worker.close(drain_timeout)
 
 
 class EventBus:
     def __init__(self) -> None:
         self._subscribers: list[EventHandler] = []
+        self._observers: list[_ObserverWorker] = []
 
     # 注册一个事件处理函数
     def subscribe(self, handler: EventHandler) -> None:
@@ -20,7 +229,40 @@ class EventBus:
         if handler in self._subscribers:
             self._subscribers.remove(handler)
 
-    # 按注册顺序依次调用所有订阅者
+    # 注册观测订阅者：慢 UI/遥测等 best-effort 订阅者经有界队列异步投递，
+    # 不阻塞 publish；返回句柄用于退订和统计查询
+    def subscribe_observer(
+        self,
+        handler: EventHandler,
+        *,
+        queue_size: int = _DEFAULT_OBSERVER_QUEUE_SIZE,
+    ) -> ObserverHandle:
+        worker = _ObserverWorker(handler, queue_size)
+        self._observers.append(worker)
+        worker.start()
+        return ObserverHandle(self, worker)
+
+    def _remove_observer(self, worker: _ObserverWorker) -> None:
+        if worker in self._observers:
+            self._observers.remove(worker)
+
+    # 可靠订阅者按注册顺序依次 await（事件序是生命周期正确性的前提）；
+    # 单个订阅者异常只记录日志，不再中断后续订阅者或改变 run 状态；
+    # 观测订阅者仅入队，投递在各自 worker 中异步完成
     async def publish(self, event: BaseModel) -> None:
-        for handler in self._subscribers:
-            await handler(event)
+        for handler in list(self._subscribers):
+            try:
+                await handler(event)
+            except Exception:
+                logger.exception(
+                    "event bus: reliable subscriber failed on %s", type(event).__name__
+                )
+        for observer in list(self._observers):
+            await observer.enqueue(event)
+
+    # 有界 drain 所有观测队列（shutdown 用），返回仍未投递的事件总数
+    async def close_observers(self, timeout: float = _DEFAULT_DRAIN_TIMEOUT_S) -> int:
+        total = 0
+        for worker in list(self._observers):
+            total += await worker.close(timeout)
+        return total

--- a/py-runtime/src/sztu_code/core/events/writer.py
+++ b/py-runtime/src/sztu_code/core/events/writer.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 # 每写满 N 个事件才 flush 一次：高频流式事件（llm.token/llm.thinking）不再逐条触发磁盘 syscall
 _FLUSH_INTERVAL = 32
+# 流式增量事件走批量 flush；其余事件视为生命周期关键事件，写入后立即 flush（落盘 barrier）
+_STREAM_EVENT_TYPES = frozenset({"llm.token", "llm.thinking"})
 
 
 class EventWriter:
@@ -47,7 +49,11 @@ class EventWriter:
         try:
             self._file.write(event.model_dump_json() + "\n")
             self._pending += 1
-            if self._pending >= _FLUSH_INTERVAL:
+            if getattr(event, "type", "") not in _STREAM_EVENT_TYPES:
+                # 生命周期事件即时落盘，崩溃后 events.jsonl 也保有完整的事件序列
+                self._pending = 0
+                self._file.flush()
+            elif self._pending >= _FLUSH_INTERVAL:
                 self._pending = 0
                 self._file.flush()
         except (OSError, ValueError) as e:

--- a/py-runtime/tests/unit/test_event_bus.py
+++ b/py-runtime/tests/unit/test_event_bus.py
@@ -1,7 +1,19 @@
 from __future__ import annotations
 
+import asyncio
+import time
+
+import pytest
 from pydantic import BaseModel
 
+from sztu_code.core.bus.events import (
+    LlmTokenEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+)
+from sztu_code.core.events import bus as event_bus_module
 from sztu_code.core.events.bus import EventBus
 
 
@@ -65,3 +77,278 @@ async def test_subscribers_called_in_order() -> None:
 async def test_no_subscribers_publish_is_noop() -> None:
     bus = EventBus()
     await bus.publish(_FakeEvent(value="x"))  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# 观测订阅者（subscribe_observer）：有界队列、异常隔离、合并/丢弃策略
+# ---------------------------------------------------------------------------
+
+
+def _token(run_id: str, token: str) -> LlmTokenEvent:
+    return LlmTokenEvent(run_id=run_id, token=token, ts="2026-08-28T00:00:00Z")
+
+
+# 功能：验证慢观测订阅者不阻塞 publish（issue #75 核心验收标准）
+# 设计：观测者每事件 sleep 100ms，publish 20 个 token 事件；若 publish 被同步
+# await 会阻塞约 2s，异步投递则应在远小于该值的时间内返回
+async def test_slow_observer_does_not_block_publish() -> None:
+    bus = EventBus()
+
+    async def slow_observer(event: BaseModel) -> None:
+        await asyncio.sleep(0.1)
+
+    handle = bus.subscribe_observer(slow_observer)
+    events = [_token("r", "t") for _ in range(20)]
+
+    start = time.monotonic()
+    for event in events:
+        await bus.publish(event)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.5, f"publish 被慢观测订阅者阻塞了 {elapsed:.2f}s"
+    assert handle.stats.dropped == 0
+    undelivered = await handle.unsubscribe(drain_timeout=5.0)
+    assert undelivered == 0
+    assert handle.stats.delivered == 20
+
+
+# 功能：验证可靠订阅者与观测订阅者互不干扰，且观测者异常不影响他人
+# 设计：观测者持续抛异常，可靠订阅者正常收集；publish 不应抛出，最终状态不受影响
+async def test_observer_exception_isolated() -> None:
+    bus = EventBus()
+    received: list[BaseModel] = []
+
+    async def reliable(event: BaseModel) -> None:
+        received.append(event)
+
+    async def bad_observer(event: BaseModel) -> None:
+        raise RuntimeError("observer boom")
+
+    bus.subscribe(reliable)
+    handle = bus.subscribe_observer(bad_observer)
+
+    first, second = _FakeEvent(value="1"), _FakeEvent(value="2")
+    await bus.publish(first)  # 不应抛出
+    await bus.publish(second)
+    assert received == [first, second]
+
+    await handle.unsubscribe()
+    assert handle.stats.errors == 2
+
+
+# 功能：验证可靠订阅者异常只隔离自身，后续订阅者仍收到事件
+# 设计：第一个 handler 抛异常，第二个正常收集；旧行为异常会中断后续订阅者，此为回归保护
+async def test_reliable_subscriber_exception_does_not_block_next() -> None:
+    bus = EventBus()
+    received: list[BaseModel] = []
+
+    async def bad(event: BaseModel) -> None:
+        raise RuntimeError("reliable boom")
+
+    async def good(event: BaseModel) -> None:
+        received.append(event)
+
+    bus.subscribe(bad)
+    bus.subscribe(good)
+    event = _FakeEvent(value="x")
+    await bus.publish(event)  # 不应抛出
+    assert received == [event]
+
+
+# 功能：验证观测订阅者按 FIFO 顺序收到事件
+# 设计：观测者带延迟消费，发布序列化生命周期事件，断言收到的 type 顺序与发布一致
+async def test_observer_preserves_order() -> None:
+    bus = EventBus()
+    received: list[str] = []
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def slow_observer(event: BaseModel) -> None:
+        if not started.is_set():
+            started.set()
+            await gate.wait()
+        received.append(getattr(event, "type", "fake"))
+        await asyncio.sleep(0.01)
+
+    handle = bus.subscribe_observer(slow_observer)
+    sequence: list[BaseModel] = [
+        RunStartedEvent(run_id="r", goal="g", ts="t"),
+        StepStartedEvent(run_id="r", step=1, ts="t"),
+        StepFinishedEvent(run_id="r", step=1, ts="t"),
+        RunFinishedEvent(run_id="r", status="success", steps=1, ts="t"),
+    ]
+    for event in sequence:
+        await bus.publish(event)
+    gate.set()
+    await handle.unsubscribe(drain_timeout=5.0)
+    assert received == [getattr(e, "type") for e in sequence]
+
+
+# 功能：验证观测队列满时同源 token 增量被合并，拼接后文本零丢失
+# 设计：首个事件在 handler 内被 gate 挂起，随后塞满小队列再发布新 token；
+# 断言 merged 计数为 1 且收到的 token 拼接与发布拼接一致
+async def test_stream_events_merge_when_queue_full() -> None:
+    bus = EventBus()
+    received: list[LlmTokenEvent] = []
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def blocked_observer(event: BaseModel) -> None:
+        if not started.is_set():
+            started.set()
+            await gate.wait()
+        if isinstance(event, LlmTokenEvent):
+            received.append(event)
+
+    handle = bus.subscribe_observer(blocked_observer, queue_size=2)
+    await bus.publish(_token("r", "a"))  # worker 取走并在 handler 中挂起
+    await started.wait()
+    await bus.publish(_token("r", "b"))
+    await bus.publish(_token("r", "c"))  # 队列已满
+    await bus.publish(_token("r", "d"))  # 触发队尾合并
+
+    assert handle.stats.merged == 1
+    gate.set()
+    await handle.unsubscribe(drain_timeout=5.0)
+    assert "".join(e.token for e in received) == "abcd"
+    assert handle.stats.dropped == 0
+
+
+# 功能：验证队列满且队尾不可合并（不同 run）时，淘汰最旧流式事件保新事件
+# 设计：run r1 的 token 塞满队列后发布 run r2 的 token；断言 dropped=1、
+# r2 事件仍在且投递顺序保持 FIFO
+async def test_unmergeable_stream_event_evicts_oldest() -> None:
+    bus = EventBus()
+    received: list[LlmTokenEvent] = []
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def blocked_observer(event: BaseModel) -> None:
+        if not started.is_set():
+            started.set()
+            await gate.wait()
+        if isinstance(event, LlmTokenEvent):
+            received.append(event)
+
+    handle = bus.subscribe_observer(blocked_observer, queue_size=2)
+    await bus.publish(_token("r1", "a"))
+    await started.wait()
+    await bus.publish(_token("r1", "b"))
+    await bus.publish(_token("r1", "c"))  # 满
+    await bus.publish(_token("r2", "x"))  # 不可合并 → 淘汰最旧
+
+    assert handle.stats.dropped == 1
+    gate.set()
+    await handle.unsubscribe(drain_timeout=5.0)
+    # a 是 worker 已取走的在途事件，gate 释放后补记；被淘汰的是队首 b
+    assert [e.token for e in received] == ["a", "c", "x"]
+
+
+# 功能：验证观测队列满时生命周期关键事件有限等待后仍被投递，不静默丢失
+# 设计：worker 挂起、队列塞满后发布 RunStarted；publish 作为任务运行，
+# 短暂等待后仍未完成（背压生效），释放 gate 后关键事件最终送达且 dropped=0
+async def test_lifecycle_event_backpressures_then_delivered() -> None:
+    bus = EventBus()
+    received: list[BaseModel] = []
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def blocked_observer(event: BaseModel) -> None:
+        if not started.is_set():
+            started.set()
+            await gate.wait()
+        received.append(event)
+
+    handle = bus.subscribe_observer(blocked_observer, queue_size=1)
+    await bus.publish(_token("r", "a"))  # worker 取走并挂起
+    await started.wait()
+    await bus.publish(_token("r", "b"))  # 队列满
+    critical = RunStartedEvent(run_id="r", goal="g", ts="t")
+    publish_task = asyncio.create_task(bus.publish(critical))
+
+    await asyncio.sleep(0.2)
+    assert not publish_task.done(), "关键事件应在队列满时背压等待"
+
+    gate.set()
+    await asyncio.wait_for(publish_task, timeout=5.0)
+    await handle.unsubscribe(drain_timeout=5.0)
+    assert critical in received
+    assert handle.stats.dropped == 0
+
+
+# 功能：验证关键事件等待超时后淘汰最旧事件也要完成投递（不允许被丢弃的是关键事件）
+# 设计：monkeypatch 缩短 _ENQUEUE_TIMEOUT_S；worker 永久挂起、队列满，关键事件
+# 超时后淘汰队首 token 入队，断言关键事件入队且被淘汰者计入 dropped
+async def test_lifecycle_event_timeout_evicts_oldest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(event_bus_module, "_ENQUEUE_TIMEOUT_S", 0.1)
+    bus = EventBus()
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def never_ready(event: BaseModel) -> None:
+        if not started.is_set():
+            started.set()
+            await gate.wait()
+
+    handle = bus.subscribe_observer(never_ready, queue_size=1)
+    await bus.publish(_token("r", "a"))  # worker 取走并挂起
+    await started.wait()
+    await bus.publish(_token("r", "b"))  # 队列满
+    critical = RunFinishedEvent(run_id="r", status="success", steps=1, ts="t")
+    await asyncio.wait_for(bus.publish(critical), timeout=5.0)
+
+    assert handle.stats.dropped == 1  # 淘汰的是 token b，关键事件保留
+    gate.set()
+    await handle.unsubscribe(drain_timeout=5.0)
+
+
+# 功能：验证高频事件压力下观测队列内存有界、投递计数可查询
+# 设计：慢观测者 + 小队列，发布 500 个 token；断言队内积压始终不超过容量，
+# drain 后 delivered 数量与发布总量一致
+async def test_observer_queue_bounded_under_load() -> None:
+    bus = EventBus()
+    max_pending = 0
+
+    async def slow_observer(event: BaseModel) -> None:
+        await asyncio.sleep(0.002)
+
+    handle = bus.subscribe_observer(slow_observer, queue_size=32)
+    for i in range(500):
+        await bus.publish(_token("r", str(i)))
+        max_pending = max(max_pending, handle.pending)
+
+    assert max_pending <= 32
+    assert handle.stats.dropped == 0
+    await handle.unsubscribe(drain_timeout=10.0)
+    # 合并保真：发布 500 条，drain 后"已投递 + 已合并"必须覆盖全部内容
+    assert handle.stats.delivered + handle.stats.merged == 500
+
+
+# 功能：验证退订时有界 drain 并如实上报未投递数量
+# 设计：worker 挂起期间堆积事件后退订（短 drain 超时），断言 undelivered 等于
+# 未消费的事件数，且 worker 被取消后不再继续消费
+async def test_unsubscribe_reports_undelivered() -> None:
+    bus = EventBus()
+    started = asyncio.Event()
+    gate = asyncio.Event()
+    count = 0
+
+    async def suspended_observer(event: BaseModel) -> None:
+        nonlocal count
+        if not started.is_set():
+            started.set()
+            await gate.wait()
+        count += 1
+
+    handle = bus.subscribe_observer(suspended_observer, queue_size=8)
+    await bus.publish(_FakeEvent(value="first"))  # worker 取走并挂起
+    await started.wait()
+    for i in range(5):
+        await bus.publish(_FakeEvent(value=str(i)))
+
+    undelivered = await handle.unsubscribe(drain_timeout=0.05)
+    assert undelivered == 6  # 队列中 5 条 + 被取消的在途事件 1 条
+    gate.set()
+    assert count == 0  # 在途 handler 在 gate 处被取消，未计入 count

--- a/py-runtime/tests/unit/test_event_writer.py
+++ b/py-runtime/tests/unit/test_event_writer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from sztu_code.core.bus.events import RunFinishedEvent, RunStartedEvent
+from sztu_code.core.bus.events import LlmTokenEvent, RunFinishedEvent, RunStartedEvent
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.events.writer import EventWriter
 
@@ -98,3 +98,20 @@ async def test_event_writer_oserror_is_logged(
             await writer.handle(event)
 
     assert any("failed to write" in r.message for r in caplog.records)
+
+
+# 功能：验证流式 token 事件走批量缓冲、生命周期事件立即 flush（落盘 barrier）
+# 设计：先发 token（仍在缓冲区，读文件为空），再发生命周期事件后立刻能读到该事件；
+# 依赖真实文件与即时读取，模拟"崩溃后 events.jsonl 保有完整生命周期序列"的场景
+async def test_lifecycle_event_flushes_immediately(tmp_path: Path) -> None:
+    path = tmp_path / "events.jsonl"
+    token = LlmTokenEvent(run_id="r1", token="hello", ts="2026-05-11T00:00:00Z")
+    started = RunStartedEvent(run_id="r1", goal="g", ts="2026-05-11T00:00:00Z")
+
+    async with EventWriter(path) as writer:
+        await writer.handle(token)
+        assert path.read_text() == ""  # 流式事件仍缓冲，未触发 flush
+        await writer.handle(started)
+        text = path.read_text()  # 生命周期事件立即落盘
+        assert "run.started" in text
+        assert "run_id" in text and "r1" in text


### PR DESCRIPTION
## 关联 Issue

Closes #75

## 问题回顾

`EventBus.publish()` 按注册顺序逐个 `await handler(event)`，所有订阅者（EventWriter 持久化、桌面 IPC 广播、Trace 遥测）共享同一条同步链路：任意慢订阅者直接增加 Agent Loop 延迟；未捕获的订阅者异常还会中断后续订阅者，甚至影响 run 本身。

## 改动内容

### 1. 订阅者语义分级（`events/bus.py`）

| | 可靠订阅者 `subscribe()`（原 API） | 观测订阅者 `subscribe_observer()`（新增） |
| --- | --- | --- |
| 语义 | 逐个按注册顺序 `await`，事件序即生命周期正确性前提 | 经有界队列 + 独立 worker 异步投递（FIFO 保序） |
| 失败影响 | 异常逐个隔离、记日志，不再中断后续订阅者 | 异常只计数（`stats.errors`），绝不外泄 |
| 适用 | EventWriter、subagent bridge、测试收集器 | Trace 遥测、桌面/客户端广播 |

### 2. 有界背压与合并/丢弃策略

- 队列默认容量 256，压满即触发策略，内存有界；
- **流式事件**（`llm.token` / `llm.thinking`）：满时与队尾同源事件**按增量文本合并**（同 `run_id`，thinking 另需同 `step`），拼接即客户端渲染方式，内容零丢失；不同源时淘汰最旧流式事件保新事件，全部计入 `dropped` / `merged`，可查询；
- **生命周期关键事件**：有限等待腾位（5s）；超时则淘汰最旧事件也要完成投递——被丢弃的永远不会是关键事件，且淘汰行为记录 ERROR 日志，不静默。

### 3. EventWriter 落盘 barrier（`events/writer.py`）

流式事件保持每 32 条批量 flush；**生命周期事件写入后立即 flush**，崩溃后 `events.jsonl` 也保有完整事件序列。

### 4. daemon 接线（`app.py`）

- `trace_event_handler` 与 `IpcEventBroadcaster.handle` 改为观测订阅：慢磁盘/慢客户端只拖慢各自的投递 worker；
- daemon shutdown 增加 `close_observers()` 有界 drain，未投递数量以 warning 日志暴露。

## 验收标准对照

- [x] 注入每事件延迟 100ms 的 best-effort 订阅者，20 个 token 事件 publish 不额外阻塞约 2s（`test_slow_observer_does_not_block_publish`）
- [x] 一个抛异常的订阅者不影响其他订阅者，也不改变 run 最终状态（`test_observer_exception_isolated`、`test_reliable_subscriber_exception_does_not_block_next`）
- [x] `RunStarted -> ToolCall* -> RunFinished` 关键事件在 JSONL 中保持顺序（`test_observer_preserves_order` + 生命周期即时落盘）
- [x] 高频事件压力测试中队列内存有上限，丢弃/合并计数可查询（`test_observer_queue_bounded_under_load`，500 条 token、容量 32）
- [x] `uv run pytest tests/unit/test_event_bus.py tests/unit/test_event_writer.py tests/unit/test_runner.py`——前两个文件 21 个用例全部通过；`test_runner.py` 存在与本 PR 无关的预先存在问题（见下）

## 测试

```
uv run pytest tests/unit/test_event_bus.py tests/unit/test_event_writer.py -v
21 passed in 2.57s
```

- `uv run ruff check` 对全部改动文件通过；
- `uv run mypy src/sztu_code/core/events/bus.py src/sztu_code/core/events/writer.py` 通过；
- 其余单元测试的失败集与 main 基线**完全一致**（stash 后对比验证，无新增失败）。

## 顺带发现：main 上预先存在的测试问题（与本 PR 无关）

在验证过程中发现当前 main（`155bc3d`）在本地有如下预先存在的失败，已用 `git stash` 在干净 main 上复现确认：

1. `tests/unit/test_verification_executor.py` 收集即报 ImportError：`modification_status_summary` 已不在 `runner.py` 中（疑似 verification 重构后遗留）；
2. `tests/unit/test_runner.py` 中 6 个用例失败（`test_run_finished_event_published_on_success` 等）且在 `test_cancelled_run_cancels_pending_compaction` 处挂起；
3. `src/sztu_code/core/app.py` 有 ruff I001（导入排序）。

如果需要我可以另开 issue/PR 处理。