### PR TITLE
fix(py-runtime): 修复 usage_estimator 改造后的套件损坏，测试 mock 全量对齐新签名

### DIFF
--- a/py-runtime/src/sztu_code/core/compact/context_usage.py
+++ b/py-runtime/src/sztu_code/core/compact/context_usage.py
@@ -57,7 +57,8 @@ def _accumulate_message(
             if isinstance(block, dict) and block.get("type") in {"tool_use", "tool_result"}
         ]
         raw["tools"] += _count(counter, tool_blocks)
-        raw["conversation"] += _count(counter, [block for block in content if block not in tool_blocks])
+        non_tool_blocks = [block for block in content if block not in tool_blocks]
+        raw["conversation"] += _count(counter, non_tool_blocks)
     else:
         raw["conversation"] += _count(counter, content)
 

--- a/py-runtime/tests/integration/test_multi_agent_workflow_e2e.py
+++ b/py-runtime/tests/integration/test_multi_agent_workflow_e2e.py
@@ -177,7 +177,8 @@ class _DeterministicEvaluationProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+    
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         del tool_schemas, bus, run_id, step, system
         goal = _initial_goal(messages)

--- a/py-runtime/tests/integration/test_phase12_e2e.py
+++ b/py-runtime/tests/integration/test_phase12_e2e.py
@@ -50,7 +50,8 @@ class _CodingScenarioProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+    
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._step += 1
 

--- a/py-runtime/tests/integration/test_s5_permission_flow.py
+++ b/py-runtime/tests/integration/test_s5_permission_flow.py
@@ -36,7 +36,8 @@ class _SingleBashProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+    
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._step += 1
         if self._step == 1:
@@ -60,7 +61,8 @@ class _TwoBashProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+    
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._step += 1
         if self._step == 1:

--- a/py-runtime/tests/test_long_compaction.py
+++ b/py-runtime/tests/test_long_compaction.py
@@ -143,7 +143,8 @@ persist compaction before returning
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+    
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._calls += 1
         if self._calls == 1:

--- a/py-runtime/tests/unit/test_deep_integration.py
+++ b/py-runtime/tests/unit/test_deep_integration.py
@@ -100,7 +100,7 @@ class _MockProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self.call_count += 1
         self.last_messages = [dict(m) for m in messages]

--- a/py-runtime/tests/unit/test_loop.py
+++ b/py-runtime/tests/unit/test_loop.py
@@ -46,7 +46,7 @@ class _MockProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         if self._exc is not None:
             raise self._exc
@@ -76,7 +76,8 @@ class _CompactingProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    )usage_estimator: object | None = None,
+    
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._calls += 1
         if self._calls == 1:
@@ -307,7 +308,7 @@ async def test_steering_received_at_end_turn_continues_loop() -> None:
             *,
             step: int = 0,
             system: str | None = None,
-        )usage_estimator: object | None = None,
+            usage_estimator: object | None = None,
         ) -> LlmResponse:
             self.calls.append([dict(message) for message in messages])
             if len(self.calls) == 1:

--- a/py-runtime/tests/unit/test_runner.py
+++ b/py-runtime/tests/unit/test_runner.py
@@ -30,6 +30,7 @@ class _EndTurnProvider:
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         return LlmResponse(stop_reason="end_turn", text="done")
 
@@ -49,6 +50,7 @@ class _LoopingProvider:
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._call += 1
         tc = ToolCallBlock(id=f"t{self._call}", name="unknown_tool", input={})
@@ -72,6 +74,7 @@ class _CapturingProvider:
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self.messages = [dict(m) for m in messages]
         self.system = system
@@ -107,6 +110,7 @@ new goal
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self._calls += 1
         if self._calls == 1:
@@ -147,6 +151,7 @@ class _CancelableCompactingProvider:
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         if run_id == "compact":
             self.compact_started.set()
@@ -200,6 +205,7 @@ finish without session
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         if run_id == "compact":
             self.compact_started.set()
@@ -261,6 +267,7 @@ survive failure
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         if run_id == "compact":
             self.compact_started.set()
@@ -907,6 +914,7 @@ async def test_session_registers_note_save_tool(tmp_path: Path) -> None:
             *,
             step: int = 0,
             system: str | None = None,
+            usage_estimator: object | None = None,
         ) -> LlmResponse:
             self.calls += 1
             if self.calls == 1:

--- a/py-runtime/tests/unit/test_session_manager.py
+++ b/py-runtime/tests/unit/test_session_manager.py
@@ -96,6 +96,7 @@ class _SummaryProvider:
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         return LlmResponse(
             stop_reason="end_turn",

--- a/py-runtime/tests/unit/test_verification_repair.py
+++ b/py-runtime/tests/unit/test_verification_repair.py
@@ -119,6 +119,7 @@ class _EndTurnProvider:
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         self.calls += 1
         last = messages[-1]
@@ -142,6 +143,7 @@ class _WritingProvider(_EndTurnProvider):
         *,
         step: int = 0,
         system: str | None = None,
+        usage_estimator: object | None = None,
     ) -> LlmResponse:
         response = await super().chat(
             messages, tool_schemas, bus, run_id, step=step, system=system


### PR DESCRIPTION
## 关联 Issue

Closes #135

## 问题回顾

PR #134 的执行阶段编排功能给 `LLMProvider.chat()` 新增了 keyword-only 参数 `usage_estimator`（`loop.py` 全部调用点都会传递），配套测试更新存在两类问题，导致单元测试套件**完全无法运行**（`pytest tests/unit` 在收集阶段即报 2 个 SyntaxError 中断）：

1. **7 处参数插入位置错误**：`a70b06c` 在 mock 签名中插入参数时贴在了闭括号外面（`system: str | None = None,` 之后的 `) -> LlmResponse:` 之前），涉及 `test_loop.py`（3）、`test_deep_integration.py`（1）、`test_s5_permission_flow.py`（2）、`test_multi_agent_workflow_e2e.py`/`test_phase12_e2e.py`/`test_long_compaction.py`（各 1）；
2. **其余 11 个 provider mock 未同步**：`test_runner.py`（8）、`test_session_manager.py`（1）、`test_verification_repair.py`（2）的 `chat()` 未接受该参数，语法修复后所有经过它们的 run 在 `provider.chat()` 处抛 `TypeError`，造成 8+ 个用例失败与挂起；
3. **ruff 46 个错误**：45 个在新功能配套测试，1 个在 `src/compact/context_usage.py`。

## 修复内容

- 7 处参数移回签名内（统一放在 `system` 之后、闭括号之前）；
- 其余 11 个 mock 的 `chat()` 签名统一补 `usage_estimator: object | None = None,`，与 `llm/base.py:20` 的协议签名一致；
- ruff `--fix` 处理可自动修复项，`context_usage.py:60` 的 E501 手工换行，`ruff check src tests` 清零。

## 修复前后对比

| 指标 | 修复前（`dfaced0`） | 修复后 |
| --- | --- | --- |
| `pytest tests/unit` | 收集中断（2 SyntaxError），实际 17+ 失败与挂起 | **1076 passed + 6 xfailed，35s，无挂起** |
| `pytest tests/integration` | 同样无法收集 | 37 passed + 5 failed（5 个为 #133 已记录的预存 e2e 失败，与本次无关） |
| `ruff check src tests` | 46 errors | **All checks passed** |
| `mypy src` | — | 通过（203 文件） |

> 附注：本 PR 总计 +28/-10，无行尾符噪声（`test_runner.py` 等文件在仓库中以 CRLF 存储，提交时已保持原样）。

## 遗留事项

`tests/integration/test_multi_agent_workflow_e2e.py` 的 5 个参数化用例失败延续自 #133 中记录的预存问题（workflow 工具返回 error 结果），与本次语法/签名修复无关，建议按 #92/#94 范围单独处理。