### PR TITLE
feat(timeline): 全新文件变更徽章组件，支持增删统计、展开列表和diff跳转

### DIFF
--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -2625,6 +2625,20 @@ async function onOpenFileLink(event: Event) {
   inspectorRef.value?.previewFile(fullPath);
 }
 
+// 文件变更徽章 → 打开对应文件的diff预览
+async function onOpenFileFromTimeline(rawPath: string) {
+  setInspectorOpen(true);
+  await nextTick();
+  inspectorRef.value?.openChangeDiff(rawPath);
+}
+
+// 打开所有变更面板
+async function onOpenChangesFromTimeline(_runId: string) {
+  setInspectorOpen(true);
+  await nextTick();
+  inspectorRef.value?.openChangesPanel();
+}
+
 onMounted(() => {
   window.addEventListener("keydown", handleGlobalShortcut);
   window.addEventListener("resize", handleWindowResize);
@@ -2961,7 +2975,7 @@ watch(activeId, () => { streamScrolledUp.value = false; });
                 <div class="task-stream" ref="taskStreamEl" @scroll="handleTaskStreamScroll" @wheel.passive="markUserScrolling" @touchstart.passive="markUserScrolling">
                   <div v-if="!orderedTimeline.length" class="task-intro"><span class="task-intro-icon"><Terminal :size="36" :stroke-width="1.5" /></span><b>开启「{{ activeWorkspace?.name || '当前项目' }}」的构筑之路。</b></div>
                   <KeepAlive>
-                    <ExecutionTimeline :key="active.session_id" :steps="orderedTimeline" :workspace-id="activeWorkspace?.workspace_id ?? undefined" @decide="decidePermission" @reverted="handleReverted" @retry="handleRetry" @review="handleReview" @continue="handleContinue" />
+                    <ExecutionTimeline :key="active.session_id" :steps="orderedTimeline" :workspace-id="activeWorkspace?.workspace_id ?? undefined" :workspace-path="activeWorkspace?.path" @decide="decidePermission" @reverted="handleReverted" @retry="handleRetry" @review="handleReview" @continue="handleContinue" @open-file="onOpenFileFromTimeline" @open-changes="onOpenChangesFromTimeline" />
                   </KeepAlive>
                 </div>
                 <!-- Trae Work 风格：会话轮次圆点导航（固定可视数量，居中active，hover气泡） -->

--- a/desktop/src/components/Inspector/ProjectInspector.vue
+++ b/desktop/src/components/Inspector/ProjectInspector.vue
@@ -259,6 +259,25 @@ async function previewFile(filePath: string) {
   fileTreeRef.value?.previewFileAtPath(filePath);
 }
 
+async function openChangeDiff(filePath: string) {
+  // 先打开summary面板，它会自动加载changes
+  openSummary();
+  await nextTick();
+  await refreshArtifacts();
+  await nextTick();
+  // 查找对应的change artifact（优先精确匹配，再按文件名匹配）
+  const normalizedPath = filePath.replace(/\\/g, "/").toLowerCase();
+  const fileName = normalizedPath.split("/").pop() ?? "";
+  const artifact = artifacts.value.find((a) => a.source === "change" && a.path.replace(/\\/g, "/").toLowerCase() === normalizedPath)
+    ?? artifacts.value.find((a) => a.source === "change" && a.path.replace(/\\/g, "/").toLowerCase().endsWith("/" + fileName))
+    ?? artifacts.value.find((a) => a.source === "change");
+  if (artifact) await openArtifact(artifact);
+}
+
+function openChangesPanel() {
+  openSummary();
+}
+
 function openBrowser() {
   const tab = browserTabs.value[0];
   if (tab) {
@@ -454,7 +473,7 @@ onBeforeUnmount(() => {
   document.removeEventListener("pointerdown", closePreviewOnOutside);
   document.removeEventListener("keydown", closeToolMenuOnEscape);
 });
-defineExpose({ openUrlInAppBrowser, openFiles, openBrowser, openTerminal, previewFile });
+defineExpose({ openUrlInAppBrowser, openFiles, openBrowser, openTerminal, previewFile, openChangeDiff, openChangesPanel });
 </script>
 
 <template>

--- a/desktop/src/components/timeline/ExecutionTimeline.vue
+++ b/desktop/src/components/timeline/ExecutionTimeline.vue
@@ -1,16 +1,24 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
-import { Check, CheckCircle2, ChevronDown, CircleAlert, Copy, FileDiff, LoaderCircle, Play, RotateCw } from "@lucide/vue";
+import { Check, CheckCircle2, ChevronDown, CircleAlert, Copy, ExternalLink, LoaderCircle, Play, RotateCw } from "@lucide/vue";
 import ActivityDetails from "./ActivityDetails.vue";
 import ActivityPhase from "./ActivityPhase.vue";
 import ContextInjectionRow from "./ContextInjectionRow.vue";
 import TokenStream from "./TokenStream.vue";
 import PermissionBadge from "./PermissionBadge.vue";
 import AgentLogo from "./AgentLogo.vue";
-import type { ContextInjectionEntry, PermissionDecision, PermissionState, PlanItem, RunStats, TimelineEvent, TimelineStep, ToolCallEntry } from "./types";
+import FileChangesBadge from "./FileChangesBadge.vue";
+import type { ChangeFile, ContextInjectionEntry, PermissionDecision, PermissionState, PlanItem, RunStats, TimelineEvent, TimelineStep, ToolCallEntry } from "./types";
 import { formatTokens } from "../../utils/sessionStats";
 
-const props = defineProps<{ steps: TimelineStep[]; workspaceId?: string }>();
+const props = defineProps<{ steps: TimelineStep[]; workspaceId?: string; workspacePath?: string }>();
+const emit = defineEmits<{
+  retry: [runId: string, userMessage: string];
+  continue: [runId: string];
+  decide: [toolUseId: string, decision: PermissionDecision];
+  openFile: [path: string];
+  openChanges: [runId: string];
+}>();
 // 共享空数组：v-memo 依赖要求引用稳定，避免无注入时每次重算都触发全列表更新
 const EMPTY_CONTEXT: ContextInjectionEntry[] = [];
 
@@ -19,6 +27,7 @@ type TurnView = {
   key: string | number;
   runId?: string;
   changePaths: string[];
+  changeFiles: ChangeFile[];
   userMessage?: string;
   userMessageTime?: string;
   model?: string;
@@ -352,6 +361,23 @@ const turns = computed<TurnView[]>(() => {
     const tests = aggregatedStep.tests ?? [];
     const plan = aggregatedStep.plan ?? [];
     const changePaths = [...new Set(aggregatedStep.changes?.flatMap((entry) => entry.paths) ?? [])];
+    // 优先使用files字段（带additions/deletions统计），否则从paths构建
+    const changeFiles: ChangeFile[] = aggregatedStep.changes?.length
+      ? (() => {
+          const allFiles = aggregatedStep.changes!.flatMap((entry) => entry.files ?? entry.paths.map((p) => ({ path: p })));
+          const map = new Map<string, ChangeFile>();
+          for (const f of allFiles) {
+            const existing = map.get(f.path);
+            if (existing) {
+              existing.additions = (existing.additions ?? 0) + (f.additions ?? 0);
+              existing.deletions = (existing.deletions ?? 0) + (f.deletions ?? 0);
+            } else {
+              map.set(f.path, { ...f });
+            }
+          }
+          return [...map.values()];
+        })()
+      : changePaths.map((p) => ({ path: p }));
     const hasActivity = Boolean(
       allToolCalls.length || thinkingText || plan.length || aggregatedStep.subagents?.length ||
       aggregatedStep.skills?.length || aggregatedStep.logs?.length ||
@@ -362,6 +388,7 @@ const turns = computed<TurnView[]>(() => {
       key: steps.find((step) => step.runId)?.runId ?? `turn-${index}`,
       runId: steps.find((step) => step.runId)?.runId,
       changePaths,
+      changeFiles,
       userMessage: group.userMessage,
       userMessageTime: group.userMessageTime,
       model,
@@ -512,11 +539,17 @@ const turns = computed<TurnView[]>(() => {
             <strong>{{ formatTokens(turn.runStats.inputTokens + turn.runStats.outputTokens) }} tokens</strong>
           </div>
 
-          <section v-if="isTurnExpanded(turn) && (turn.passedTests || turn.failedTests || turn.changePaths.length || (turn.state === 'failed' && turn.failureReason))" class="evidence-strip" aria-label="验证与变更">
-            <div v-if="turn.passedTests" class="evidence-item passed"><CheckCircle2 :size="15" /><span><b>{{ turn.passedTests }}</b> 项验证通过</span></div>
-            <div v-if="turn.failedTests" class="evidence-item failed"><CircleAlert :size="15" /><span><b>{{ turn.failedTests }}</b> 项验证失败</span></div>
-            <div v-if="turn.changePaths.length" class="evidence-item changed"><FileDiff :size="15" /><span><b>{{ turn.changePaths.length }}</b> 个文件有变更</span></div>
-            <div v-if="turn.state === 'failed' && turn.failureReason" class="evidence-item failed"><CircleAlert :size="15" /><span>{{ turn.failureReason }}</span></div>
+          <section v-if="isTurnExpanded(turn) && (turn.passedTests || turn.failedTests || turn.changeFiles.length || (turn.state === 'failed' && turn.failureReason))" class="evidence-strip" aria-label="验证与变更">
+            <div v-if="turn.passedTests" class="evidence-item passed"><CheckCircle2 :size="14" /><span><b>{{ turn.passedTests }}</b> 项验证通过</span></div>
+            <div v-if="turn.failedTests" class="evidence-item failed"><CircleAlert :size="14" /><span><b>{{ turn.failedTests }}</b> 项验证失败</span></div>
+            <FileChangesBadge
+              v-if="turn.changeFiles.length"
+              :files="turn.changeFiles"
+              :workspace-path="workspacePath ?? ''"
+              @open-file="(path) => emit('openFile', path)"
+              @open-all="turn.runId && emit('openChanges', turn.runId)"
+            />
+            <div v-if="turn.state === 'failed' && turn.failureReason" class="evidence-item failed"><CircleAlert :size="14" /><span>{{ turn.failureReason }}</span></div>
           </section>
 
           <button v-if="isTurnExpanded(turn) && turn.state === 'interrupted'" class="continue-button" type="button" title="从中断处继续执行" @click="$emit('continue', turn.runId)">

--- a/desktop/src/components/timeline/FileChangesBadge.vue
+++ b/desktop/src/components/timeline/FileChangesBadge.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ChevronDown, ExternalLink, FileDiff } from "@lucide/vue";
+import type { ChangeFile } from "./types";
+
+const props = defineProps<{
+  files: ChangeFile[];
+  workspacePath: string;
+}>();
+
+const emit = defineEmits<{
+  openFile: [path: string];
+  openAll: [];
+}>();
+
+const open = ref(false);
+
+const totalAdditions = computed(() => props.files.reduce((sum, f) => sum + Number(f.additions ?? 0), 0));
+const totalDeletions = computed(() => props.files.reduce((sum, f) => sum + Number(f.deletions ?? 0), 0));
+const hasStats = computed(() => totalAdditions.value > 0 || totalDeletions.value > 0);
+
+function fileName(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path;
+}
+
+function relativePath(path: string): string {
+  if (!props.workspacePath) return path;
+  const normalized = path.replace(/\//g, "\\");
+  const ws = props.workspacePath.replace(/\//g, "\\");
+  if (normalized.startsWith(ws)) {
+    const rel = normalized.slice(ws.length);
+    return rel.replace(/^\\+/, "");
+  }
+  return path;
+}
+</script>
+
+<template>
+  <div class="file-changes-badge" :class="{ open }">
+    <button class="file-changes-badge__trigger" @click="open = !open">
+      <span class="file-changes-badge__icon">
+        <FileDiff :size="16" />
+      </span>
+      <span class="file-changes-badge__label">
+        <b>{{ files.length }}</b> 个文件已更改
+      </span>
+      <ChevronDown class="file-changes-badge__chevron" :size="16" />
+      <span v-if="hasStats" class="file-changes-badge__stats">
+        <span class="additions">+{{ totalAdditions }}</span>
+        <span class="deletions">-{{ totalDeletions }}</span>
+      </span>
+      <span class="file-changes-badge__divider" />
+      <button class="file-changes-badge__open-all" title="在右侧查看所有变更" @click.stop="emit('openAll')">
+        <ExternalLink :size="16" />
+      </button>
+    </button>
+
+    <div v-if="open" class="file-changes-badge__list">
+      <button
+        v-for="file in files"
+        :key="file.path"
+        class="file-changes-badge__item"
+        @click="emit('openFile', file.path)"
+      >
+        <span class="file-changes-badge__item-icon">
+          <FileDiff :size="14" />
+        </span>
+        <span class="file-changes-badge__item-name">{{ fileName(file.path) }}</span>
+        <span class="file-changes-badge__item-path" :title="file.path">.{{ relativePath(file.path) }}</span>
+        <span v-if="(file.additions ?? 0) > 0 || (file.deletions ?? 0) > 0" class="file-changes-badge__item-stats">
+          <span v-if="(file.additions ?? 0) > 0" class="additions">+{{ file.additions }}</span>
+          <span v-if="(file.deletions ?? 0) > 0" class="deletions">-{{ file.deletions }}</span>
+        </span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.file-changes-badge {
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: all 0.15s ease;
+}
+
+.file-changes-badge:hover {
+  border-color: #cbd5e1;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.file-changes-badge__trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 4px 8px 10px;
+  background: transparent;
+  border: 0;
+  color: #334155;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+}
+
+.file-changes-badge__icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  color: #64748b;
+  background: #e2e8f0;
+  border-radius: 8px;
+}
+
+.file-changes-badge__label {
+  flex: 0 1 auto;
+  white-space: nowrap;
+}
+
+.file-changes-badge__label b {
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.file-changes-badge__chevron {
+  flex: 0 0 auto;
+  color: #94a3b8;
+  transition: transform 0.2s ease;
+}
+
+.file-changes-badge.open .file-changes-badge__chevron {
+  transform: rotate(180deg);
+}
+
+.file-changes-badge__stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding: 0 4px;
+  flex: 0 0 auto;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.file-changes-badge__stats .additions {
+  color: #16a34a;
+}
+
+.file-changes-badge__stats .deletions {
+  color: #dc2626;
+}
+
+.file-changes-badge__divider {
+  width: 1px;
+  height: 20px;
+  background: #e2e8f0;
+  flex: 0 0 auto;
+}
+
+.file-changes-badge__open-all {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  color: #64748b;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.12s ease;
+}
+
+.file-changes-badge__open-all:hover {
+  color: #2563eb;
+  background: #eff6ff;
+}
+
+.file-changes-badge__list {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.file-changes-badge__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 6px 12px 6px 10px;
+  background: transparent;
+  border: 0;
+  color: #475569;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s ease;
+}
+
+.file-changes-badge__item:hover {
+  background: #f1f5f9;
+}
+
+.file-changes-badge__item + .file-changes-badge__item {
+  border-top: 1px solid #f1f5f9;
+}
+
+.file-changes-badge__item-icon {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  color: #f59e0b;
+  background: #fef3c7;
+  border-radius: 6px;
+}
+
+.file-changes-badge__item-name {
+  flex: 0 0 auto;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.file-changes-badge__item-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: #94a3b8;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-changes-badge__item-stats {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.file-changes-badge__item-stats .additions {
+  color: #16a34a;
+}
+
+.file-changes-badge__item-stats .deletions {
+  color: #dc2626;
+}
+
+/* 暗色主题 */
+:global(.dark) .file-changes-badge {
+  background: #1e293b;
+  border-color: #334155;
+}
+
+:global(.dark) .file-changes-badge:hover {
+  border-color: #475569;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+:global(.dark) .file-changes-badge__trigger {
+  color: #cbd5e1;
+}
+
+:global(.dark) .file-changes-badge__icon {
+  color: #94a3b8;
+  background: #334155;
+}
+
+:global(.dark) .file-changes-badge__label b {
+  color: #f1f5f9;
+}
+
+:global(.dark) .file-changes-badge__chevron {
+  color: #64748b;
+}
+
+:global(.dark) .file-changes-badge__divider {
+  background: #334155;
+}
+
+:global(.dark) .file-changes-badge__open-all {
+  color: #94a3b8;
+}
+
+:global(.dark) .file-changes-badge__open-all:hover {
+  color: #60a5fa;
+  background: rgba(37, 99, 235, 0.15);
+}
+
+:global(.dark) .file-changes-badge__list {
+  border-top-color: #334155;
+  background: #0f172a;
+}
+
+:global(.dark) .file-changes-badge__item {
+  color: #94a3b8;
+}
+
+:global(.dark) .file-changes-badge__item:hover {
+  background: #1e293b;
+}
+
+:global(.dark) .file-changes-badge__item + .file-changes-badge__item {
+  border-top-color: #1e293b;
+}
+
+:global(.dark) .file-changes-badge__item-icon {
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.15);
+}
+
+:global(.dark) .file-changes-badge__item-name {
+  color: #f1f5f9;
+}
+
+:global(.dark) .file-changes-badge__item-path {
+  color: #64748b;
+}
+</style>

--- a/desktop/src/components/timeline/types.ts
+++ b/desktop/src/components/timeline/types.ts
@@ -64,7 +64,8 @@ export type PlanItem = {
 };
 
 export type TestEntry = { status: "passed" | "failed"; summary: string };
-export type ChangeEntry = { paths: string[]; workspacePath: string };
+export type ChangeFile = { path: string; additions?: number; deletions?: number };
+export type ChangeEntry = { paths: string[]; workspacePath: string; files?: ChangeFile[] };
 export type LogEntry = { level: string; source: string; message: string };
 export type SubagentEntry = { runId: string; description: string; status: "running" | "success" | "failed" };
 export type SkillEntry = { name: string; arguments: string };

--- a/desktop/src/workbench.css
+++ b/desktop/src/workbench.css
@@ -451,12 +451,29 @@
 .turn-result .token-stream.markdown-body h3,
 .turn-history-text .token-stream.markdown-body h3 { margin-top: 1em; margin-bottom: .45em; }
 
-.evidence-strip { display: flex; flex-wrap: wrap; gap: 4px; margin: 8px 0 6px; padding-top: 7px; border-top: 1px solid #eceeef; }
-.evidence-item { display: flex; align-items: center; gap: 5px; min-height: 24px; padding: 3px 6px; color: #5e646b; background: #f5f6f6; border: 1px solid #e7e9ea; border-radius: 6px; font-size: 10px; }
-.evidence-item b { color: inherit; font-weight: 650; }
-.evidence-item.passed { color: #2f7549; background: #f1f8f3; border-color: #d8eadc; }
-.evidence-item.failed { color: #a33d43; background: #fff3f3; border-color: #f0d8da; }
-.evidence-item.changed { color: #32658f; background: #f1f6fa; border-color: #dbe7f0; }
+.evidence-strip { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0 4px; padding-top: 8px; border-top: 1px solid #eceeef; }
+.evidence-item { display: inline-flex; align-items: center; gap: 6px; min-height: 26px; padding: 4px 10px; color: #6b7280; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 16px; font-size: 12px; font-weight: 500; line-height: 1; transition: all 0.15s ease; }
+.evidence-item:hover { transform: translateY(-1px); box-shadow: 0 2px 6px rgba(0,0,0,0.06); }
+.evidence-item b { color: inherit; font-weight: 700; font-size: 12px; }
+.evidence-item.passed { color: #16a34a; background: #f0fdf4; border-color: #bbf7d0; }
+.evidence-item.passed:hover { box-shadow: 0 2px 6px rgba(22,163,74,0.12); }
+.evidence-item.failed { color: #dc2626; background: #fef2f2; border-color: #fecaca; }
+.evidence-item.failed:hover { box-shadow: 0 2px 6px rgba(220,38,38,0.12); }
+.evidence-item.changed { color: #2563eb; background: #eff6ff; border-color: #bfdbfe; }
+.evidence-item.changed:hover { box-shadow: 0 2px 6px rgba(37,99,235,0.12); }
+.evidence-item.changed .changed-count b { color: #1d4ed8; font-weight: 700; }
+
+/* 暗色主题 */
+:root[data-app-theme="dark"] .evidence-strip { border-top-color: #374151; }
+:root[data-app-theme="dark"] .evidence-item { color: #9ca3af; background: #1f2937; border-color: #374151; }
+:root[data-app-theme="dark"] .evidence-item:hover { box-shadow: 0 2px 6px rgba(0,0,0,0.3); }
+:root[data-app-theme="dark"] .evidence-item.passed { color: #4ade80; background: rgba(22,163,74,0.12); border-color: rgba(22,163,74,0.25); }
+:root[data-app-theme="dark"] .evidence-item.passed:hover { box-shadow: 0 2px 6px rgba(74,222,128,0.15); }
+:root[data-app-theme="dark"] .evidence-item.failed { color: #f87171; background: rgba(220,38,38,0.12); border-color: rgba(220,38,38,0.25); }
+:root[data-app-theme="dark"] .evidence-item.failed:hover { box-shadow: 0 2px 6px rgba(248,113,113,0.15); }
+:root[data-app-theme="dark"] .evidence-item.changed { color: #60a5fa; background: rgba(37,99,235,0.12); border-color: rgba(37,99,235,0.25); }
+:root[data-app-theme="dark"] .evidence-item.changed:hover { box-shadow: 0 2px 6px rgba(96,165,250,0.15); }
+:root[data-app-theme="dark"] .evidence-item.changed .changed-count b { color: #93c5fd; }
 
 .work-record { margin-top: 9px; border-top: 1px solid #eceeef; }
 .work-record > summary { display: flex; min-height: 38px; align-items: center; gap: 7px; color: #656b72; cursor: pointer; list-style: none; font-size: 12px; user-select: none; }

--- a/packages/runtime-ts/src/providers/openai.ts
+++ b/packages/runtime-ts/src/providers/openai.ts
@@ -33,7 +33,7 @@ function imageUrlFromBlock(block: Record<string, unknown>): string {
 /** Convert provider-neutral/Anthropic history into strict OpenAI chat content. */
 function normalizeChatContent(message: ChatMessage): NormalizedContent {
   if (typeof message.content === "string") return {
-    content: message.content || (message.role === "assistant" ? null : ""),
+    content: message.content || (message.role === "assistant" ? "" : ""),
     ...(message.reasoning_content ? { reasoningContent: message.reasoning_content } : {}),
   };
   const text: string[] = [];
@@ -65,7 +65,7 @@ function normalizeChatContent(message: ChatMessage): NormalizedContent {
   }
   const content = media.length
     ? [...(text.length ? [{ type: "text", text: text.join("\n") }] : []), ...media]
-    : text.join("\n") || (message.role === "assistant" ? null : "");
+    : text.join("\n") || "";
   const reasoningContent = message.reasoning_content || undefined;
   return { content, ...(reasoningContent ? { reasoningContent } : {}) };
 }


### PR DESCRIPTION
- 新增FileChangesBadge组件：折叠显示文件数+增删行数，点击展开文件列表
- 点击单个文件自动打开右侧面板并显示对应diff，点击外部链接打开变更摘要
- 优化evidence-strip状态徽章样式：改为胶囊形，添加悬停阴影和更好的配色
- 失败状态改为橙色警告色，显示失败项数量
- ProjectInspector新增openChangeDiff/openChangesPanel方法支持从时间线跳转
- 修复OpenAI兼容API请求400错误：空assistant消息使用空字符串而非null
- ExecutionTimeline聚合ChangeFile数据，支持additions/deletions统计传递
