### PR TITLE
fix(inspector): 加号菜单层级低于文件标签栏，提升 workspace-tab-strip 至 130

### DIFF
--- a/desktop/src/file-rail.css
+++ b/desktop/src/file-rail.css
@@ -26,7 +26,9 @@
 
 .workspace-tab-strip {
   position: relative;
-  z-index: 20;
+  /* 需高于 .file-tabs-bar（120）/ .file-tabs-actions（122）：二者所在 main 不创建 stacking context，
+     会在同一祖先层与 strip 比较，否则加号下拉菜单（受限于本层 z-index 100）会被文件标签栏盖住 */
+  z-index: 130;
   display: flex;
   min-width: 0;
   align-items: center;


### PR DESCRIPTION
## 修复

右侧栏文件功能区顶部加号菜单被文件标签栏遮挡。

- 根因：`.file-tabs-bar`（z-index 120）与 `.workspace-tab-strip`（z-index 20）在同一个祖先 stacking context 比较（main 不创建 SC），标签栏盖住了受限于 strip 层级的加号菜单（z-index 100）
- 修复：`.workspace-tab-strip` 提升至 z-index 130，高于 `.file-tabs-bar`（120）与 `.file-tabs-actions`（122）
