### PR TITLE
fix(desktop): prepare-runtime 写入 type:module 声明，修复安装版 daemon 无法自启动

### DIFF
--- a/desktop/scripts/prepare-runtime.js
+++ b/desktop/scripts/prepare-runtime.js
@@ -51,6 +51,10 @@ const esbuildCommand = await import("node:fs").then(({ existsSync }) => existsSy
 const esbuildIsScript = esbuildCommand === esbuild && readFileSync(esbuild).subarray(0, 2).toString() === "#!/";
 const result = spawnSync(esbuildIsScript ? process.execPath : esbuildCommand, esbuildIsScript ? [esbuildCommand, ...esbuildArgs] : esbuildArgs, { cwd: repositoryRoot, stdio: "inherit", windowsHide: true });
 if (result.status !== 0) throw new Error(`Failed to bundle the TypeScript runtime (exit code ${result.status ?? 1})`);
+// esbuild 以 --format=esm 输出 .js，而 Node 对 .js 默认按 CommonJS 解析；
+// 必须在 runtime 目录声明 "type": "module"，否则安装版 daemon 启动即报
+// "Cannot use import statement outside a module"（issue #152）
+await writeFile(path.join(runtimeRoot, "package.json"), `${JSON.stringify({ type: "module" }, null, 2)}\n`);
 await prepareSkillAssets(path.join(repositoryRoot, "packages", "runtime-ts", "skills"), path.join(runtimeRoot, "skills"), repositoryRoot);
 for (const directory of ["prompts", "agents"]) await cp(path.join(repositoryRoot, "packages", "runtime-ts", directory), path.join(runtimeRoot, directory), { recursive: true });
 } finally {


### PR DESCRIPTION
## 关联 Issue

Closes #152

## 问题

Release 安装包（v0.1.1 Windows 实测，逻辑上影响所有平台产物）的桌面端 daemon 无法自启动：`resources/runtime/main.js` 是 esbuild `--format=esm` 产物，但 runtime 目录没有 `"type": "module"` 的 package.json，Node 默认按 CommonJS 解析，启动即抛 `SyntaxError: Cannot use import statement outside a module` 并无限重试（`~/.sztu/logs/desktop-daemon.log` 证据见 issue）。开发模式不受影响（debug 构建回退到仓库内 `packages/runtime-ts/dist/main.js`，其上层 package.json 已声明 module），因此此前未被察觉。

## 修复

`prepare-runtime.js` 在 esbuild 完成后向 `runtimeRoot` 写入 `{"type": "module"}` 的 package.json（`writeFile` 已在现有导入中，无新依赖）。

## 验证

- `node scripts/prepare-runtime.js` 产物包含 `package.json`；
- 用产物内置的 `node.exe` 加载 `main.js`，正常监听 `SZTU_TS_PORT` 指定端口；
- 本机已安装的 v0.1.1 手动补入该文件后，daemon 立即恢复自启动（`SztuCode TypeScript runtime listening on 127.0.0.1:7438`）。

## 备注

备选方案（`--format=cjs` 或输出 `main.mjs`）效果等价，本 PR 选择改动最小的方案；如果后续 runtime 产物需要被非 Node 工具消费，可以再考虑 `.mjs` 后缀。