### PR TITLE
[Feature] #145: Add local semantic search foundation

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
-        "@rollup/rollup-win32-x64-msvc": "^4.63.1",
         "@tauri-apps/api": "^2.9.1",
         "@tauri-apps/plugin-dialog": "^2.4.0",
         "@tauri-apps/plugin-opener": "^2.5.4",
@@ -897,18 +896,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.63.1",
-      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
-      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
       "os": [
         "win32"
       ]

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@lobehub/icons-static-svg": "^1.94.0",
-    "@rollup/rollup-win32-x64-msvc": "^4.63.1",
     "@tauri-apps/api": "^2.9.1",
     "@tauri-apps/plugin-dialog": "^2.4.0",
     "@tauri-apps/plugin-opener": "^2.5.4",

--- a/desktop/scripts/prepare-runtime.js
+++ b/desktop/scripts/prepare-runtime.js
@@ -12,6 +12,8 @@ const runtimeRoot = path.dirname(output);
 const lockPath = path.join(path.dirname(runtimeRoot), ".runtime-prep.lock");
 
 async function acquireLock() {
+  // resources 目录被 .gitignore 忽略，干净 CI 中可能尚不存在。
+  await mkdir(path.dirname(lockPath), { recursive: true });
   const deadline = Date.now() + 120_000;
   for (;;) {
     try {
@@ -43,7 +45,7 @@ const bundledNode = path.join(runtimeRoot, process.platform === "win32" ? "node.
 await cp(process.execPath, bundledNode);
 if (process.platform !== "win32") await chmod(bundledNode, 0o755);
 const esbuild = path.join(repositoryRoot, "node_modules", "esbuild", "bin", "esbuild");
-const esbuildArgs = [path.join(repositoryRoot, "packages", "runtime-ts", "src", "main.ts"), "--bundle", "--platform=node", "--format=esm", `--outfile=${output}`,
+const esbuildArgs = [path.join(repositoryRoot, "packages", "runtime-ts", "src", "main.ts"), "--bundle", "--platform=node", "--format=esm", "--loader:.node=file", `--outfile=${output}`,
   // ESM 产物中 CJS 依赖的动态 require 会落入 esbuild 抛错 shim，注入真实 require
   `--banner:js=import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);`];
 const nativeEsbuild = process.platform === "win32"

--- a/npm/sztucode-tui/package.json
+++ b/npm/sztucode-tui/package.json
@@ -25,6 +25,9 @@
   "engines": {
     "node": ">=20"
   },
+  "dependencies": {
+    "@xenova/transformers": "^2.17.2"
+  },
   "os": [
     "darwin",
     "linux",

--- a/npm/sztucode-tui/scripts/install.js
+++ b/npm/sztucode-tui/scripts/install.js
@@ -23,7 +23,16 @@ const runtimeSource = resolve(repositoryRoot, "packages/runtime-ts/src/main.ts")
 // ESM 产物中 CJS 依赖（如 mammoth/xlsx）的 require("fs") 会落入 esbuild 的抛错 shim；
 // 注入 createRequire 提供真实 require，保证捆绑的 Node 内置模块解析正常
 const requireBanner = { js: "import { createRequire } from 'node:module'; const require = createRequire(import.meta.url);" };
-const sharedBuildOptions = { bundle: true, platform: "node", format: "esm", absWorkingDir: repositoryRoot, banner: requireBanner };
+// transformers.js 会在运行时加载平台相关的 ONNX 原生模块，不能把所有平台的 .node 文件捆进单一产物。
+// 将它保留为外部依赖，由发布包在目标平台安装对应版本。
+const sharedBuildOptions = {
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  absWorkingDir: repositoryRoot,
+  banner: requireBanner,
+  external: ["@xenova/transformers"],
+};
 await build({ ...sharedBuildOptions, entryPoints: [cliSource], outfile: resolve(cliTarget, "main.js") });
 await build({ ...sharedBuildOptions, entryPoints: [runtimeSource], outfile: resolve(runtimeTarget, "main.js") });
 console.log("Bundled the TypeScript runtime and CLI for npm publishing.");

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,6 +470,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
@@ -654,6 +663,69 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@sztucode/agent-core": {
       "resolved": "packages/agent-core",
       "link": true
@@ -698,14 +770,33 @@
       "resolved": "packages/telemetry",
       "link": true
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -735,6 +826,100 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+      "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
+      "integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
+      "integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
@@ -755,11 +940,60 @@
       ],
       "license": "MIT"
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
       "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -774,6 +1008,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -781,6 +1021,47 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "node_modules/core-util-is": {
@@ -801,6 +1082,39 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dingbat-to-unicode": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
@@ -814,6 +1128,15 @@
       "license": "BSD",
       "dependencies": {
         "underscore": "^1.13.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/esbuild": {
@@ -858,12 +1181,42 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.8.3",
       "resolved": "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/frac": {
       "version": "1.1.2",
@@ -873,6 +1226,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -889,6 +1248,38 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -900,6 +1291,18 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -937,6 +1340,12 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lop": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
@@ -970,6 +1379,110 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
       }
     },
     "node_modules/option": {
@@ -1025,11 +1538,137 @@
         "@napi-rs/canvas": "^0.1.80"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -1052,11 +1691,100 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -1076,6 +1804,17 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+      "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1083,6 +1822,59 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
+      "integrity": "sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tsx": {
@@ -1102,6 +1894,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/typescript": {
@@ -1128,7 +1932,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {
@@ -1154,6 +1957,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/xlsx": {
       "version": "0.18.5",
@@ -1273,6 +2082,7 @@
         "@sztucode/session": "file:../session",
         "@sztucode/session-fs": "file:../session-fs",
         "@sztucode/telemetry": "file:../telemetry",
+        "@xenova/transformers": "^2.17.2",
         "js-tiktoken": "^1.0.21",
         "mammoth": "^1.12.2",
         "pdf-parse": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cli:ts": "tsx packages/cli/src/main.ts",
     "cli:py": "uv run --project py-runtime --offline python -m sztu_code.cli",
     "eval": "tsx packages/evaluation/src/main.ts",
+    "eval:semantic": "tsx scripts/eval-semantic-search.ts",
     "bench:tbench": "node scripts/run-tbench.mjs",
     "bench:tbench:ts": "node scripts/run-tbench.mjs --ts",
     "docs:protocol": "tsx scripts/gen_protocol_doc.ts",

--- a/packages/runtime-ts/package.json
+++ b/packages/runtime-ts/package.json
@@ -16,6 +16,7 @@
     "@sztucode/session": "file:../session",
     "@sztucode/session-fs": "file:../session-fs",
     "@sztucode/telemetry": "file:../telemetry",
+    "@xenova/transformers": "^2.17.2",
     "js-tiktoken": "^1.0.21",
     "mammoth": "^1.12.2",
     "pdf-parse": "^2.4.5",

--- a/packages/runtime-ts/package.json
+++ b/packages/runtime-ts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/main.ts",
-    "build": "npm run build --prefix ../ai && npm run build --prefix ../agent-core && npm run build --prefix ../protocol && npm run build --prefix ../telemetry && tsc -p tsconfig.json",
+    "build": "npm run build --prefix ../ai && npm run build --prefix ../session && npm run build --prefix ../session-fs && npm run build --prefix ../telemetry && npm run build --prefix ../agent-core && npm run build --prefix ../protocol && npm run build --prefix ../server && tsc -p tsconfig.json",
     "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {

--- a/packages/runtime-ts/src/chunking/code-splitter.ts
+++ b/packages/runtime-ts/src/chunking/code-splitter.ts
@@ -1,0 +1,37 @@
+import { makeChunk, requireSource, splitLineWindow, validateSplitterOptions, type Chunk, type Chunker, type SplitterOptions } from "./splitter.js";
+
+const DECLARATION = /^\s*(?:(?:export|default|public|private|protected|async|static|abstract|final)\s+)*(?:function|class|interface|type|enum|namespace|struct|trait|impl|fn|def)\b/;
+const GO_FUNCTION = /^\s*func\s+(?:\([^)]*\)\s*)?[A-Za-z_][\w]*\s*\(/;
+
+function isBoundary(line: string, index: number): boolean {
+  return index > 0 && (DECLARATION.test(line) || GO_FUNCTION.test(line));
+}
+
+export class CodeSplitter implements Chunker {
+  private readonly options: Required<SplitterOptions>;
+  private readonly language?: string;
+
+  constructor(options: SplitterOptions = {}, language?: string) {
+    this.options = validateSplitterOptions(options);
+    this.language = language;
+  }
+
+  split(content: string, metadata: Record<string, string>): Chunk[] {
+    requireSource(metadata);
+    if (!content.trim()) return [];
+    return splitLineWindow(content, metadata, "code", this.options, this.language, isBoundary);
+  }
+}
+
+/** 只在需要保留单个声明整体时使用的简单声明分块辅助函数。 */
+export function splitDeclarations(content: string, metadata: Record<string, string>, language?: string): Chunk[] {
+  const lines = content.replace(/\r\n?/g, "\n").split("\n");
+  const starts = [0];
+  lines.forEach((line, index) => { if (isBoundary(line, index)) starts.push(index); });
+  const chunks: Chunk[] = [];
+  for (let index = 0; index < starts.length; index += 1) {
+    const chunk = makeChunk(lines, starts[index]!, starts[index + 1] ?? lines.length, metadata, "code", language, index);
+    if (chunk) chunks.push(chunk);
+  }
+  return chunks;
+}

--- a/packages/runtime-ts/src/chunking/code-splitter.ts
+++ b/packages/runtime-ts/src/chunking/code-splitter.ts
@@ -3,6 +3,44 @@ import { makeChunk, requireSource, splitLineWindow, validateSplitterOptions, typ
 const DECLARATION = /^\s*(?:(?:export|default|public|private|protected|async|static|abstract|final)\s+)*(?:function|class|interface|type|enum|namespace|struct|trait|impl|fn|def)\b/;
 const GO_FUNCTION = /^\s*func\s+(?:\([^)]*\)\s*)?[A-Za-z_][\w]*\s*\(/;
 
+export interface CodeSymbol {
+  name: string;
+  kind: string;
+}
+
+const SYMBOL_PATTERNS: Array<{ kind: string; pattern: RegExp }> = [
+  { kind: "function", pattern: /^\s*(?:(?:export|default|public|private|protected|async|static)\s+)*(?:function)\s+([A-Za-z_$][\w$]*)/ },
+  { kind: "class", pattern: /^\s*(?:(?:export|default|public|private|protected|abstract)\s+)*class\s+([A-Za-z_$][\w$]*)/ },
+  { kind: "interface", pattern: /^\s*(?:(?:export|declare)\s+)*interface\s+([A-Za-z_$][\w$]*)/ },
+  { kind: "type", pattern: /^\s*(?:(?:export|declare)\s+)*type\s+([A-Za-z_$][\w$]*)/ },
+  { kind: "enum", pattern: /^\s*(?:(?:export|declare)\s+)*enum\s+([A-Za-z_$][\w$]*)/ },
+  { kind: "namespace", pattern: /^\s*(?:(?:export|declare)\s+)*namespace\s+([A-Za-z_$][\w$]*)/ },
+  { kind: "python_function", pattern: /^\s*def\s+([A-Za-z_]\w*)\s*\(/ },
+  { kind: "go_function", pattern: /^\s*func\s+(?:\([^)]*\)\s*)?([A-Za-z_]\w*)\s*\(/ },
+  { kind: "rust_function", pattern: /^\s*(?:(?:pub|async|unsafe|const)\s+)*fn\s+([A-Za-z_]\w*)\s*[<(]/ },
+  { kind: "struct", pattern: /^\s*(?:(?:pub|export)\s+)*(?:struct|trait|impl)\s+([A-Za-z_]\w*)/ },
+];
+
+/** 从代码块开头的声明中提取可用于检索的符号名称。 */
+export function extractSymbols(content: string): CodeSymbol[] {
+  const symbols: CodeSymbol[] = [];
+  const seen = new Set<string>();
+  for (const line of content.replace(/\r\n?/g, "\n").split("\n")) {
+    for (const { kind, pattern } of SYMBOL_PATTERNS) {
+      const match = pattern.exec(line);
+      const name = match?.[1];
+      if (!name) continue;
+      const key = `${kind}:${name}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        symbols.push({ name, kind });
+      }
+      break;
+    }
+  }
+  return symbols;
+}
+
 function isBoundary(line: string, index: number): boolean {
   return index > 0 && (DECLARATION.test(line) || GO_FUNCTION.test(line));
 }
@@ -19,7 +57,14 @@ export class CodeSplitter implements Chunker {
   split(content: string, metadata: Record<string, string>): Chunk[] {
     requireSource(metadata);
     if (!content.trim()) return [];
-    return splitLineWindow(content, metadata, "code", this.options, this.language, isBoundary);
+    return splitLineWindow(content, metadata, "code", this.options, this.language, isBoundary).map((chunk) => {
+      const symbols = extractSymbols(chunk.text);
+      if (symbols.length > 0) {
+        chunk.metadata.symbol = symbols.map((symbol) => symbol.name).join(", ");
+        chunk.metadata.symbol_kind = symbols[0]!.kind;
+      }
+      return chunk;
+    });
   }
 }
 

--- a/packages/runtime-ts/src/chunking/index.ts
+++ b/packages/runtime-ts/src/chunking/index.ts
@@ -1,0 +1,20 @@
+export * from "./splitter.js";
+export * from "./code-splitter.js";
+export * from "./markdown-splitter.js";
+
+import { CodeSplitter } from "./code-splitter.js";
+import { MarkdownSplitter, TextSplitter } from "./markdown-splitter.js";
+import type { Chunker, SplitterOptions } from "./splitter.js";
+
+const CODE_EXTENSIONS = new Map([
+  [".ts", "typescript"], [".tsx", "typescript"], [".js", "javascript"], [".jsx", "javascript"],
+  [".py", "python"], [".go", "go"], [".rs", "rust"], [".java", "java"], [".c", "c"],
+  [".cc", "cpp"], [".cpp", "cpp"], [".h", "c"], [".hpp", "cpp"],
+]);
+
+export function createChunker(fileName: string, options: SplitterOptions = {}): Chunker {
+  const extension = fileName.slice(fileName.lastIndexOf(".")).toLowerCase();
+  if (CODE_EXTENSIONS.has(extension)) return new CodeSplitter(options, CODE_EXTENSIONS.get(extension));
+  if (extension === ".md" || extension === ".markdown") return new MarkdownSplitter(options);
+  return new TextSplitter(options);
+}

--- a/packages/runtime-ts/src/chunking/markdown-splitter.ts
+++ b/packages/runtime-ts/src/chunking/markdown-splitter.ts
@@ -1,0 +1,87 @@
+import { makeChunk, requireSource, validateSplitterOptions, type Chunk, type Chunker, type SplitterOptions } from "./splitter.js";
+
+const HEADING = /^#{1,6}\s+\S/;
+
+export class MarkdownSplitter implements Chunker {
+  private readonly options: Required<SplitterOptions>;
+
+  constructor(options: SplitterOptions = {}) {
+    this.options = validateSplitterOptions(options);
+  }
+
+  split(content: string, metadata: Record<string, string>): Chunk[] {
+    requireSource(metadata);
+    const lines = content.replace(/\r\n?/g, "\n").split("\n");
+    if (!content.trim()) return [];
+    const starts = [0];
+    let inFence = false;
+    lines.forEach((line, index) => {
+      if (/^\s*```/.test(line)) inFence = !inFence;
+      else if (!inFence && HEADING.test(line) && index > 0) starts.push(index);
+    });
+
+    const chunks: Chunk[] = [];
+    for (let section = 0; section < starts.length; section += 1) {
+      const start = starts[section]!;
+      const end = starts[section + 1] ?? lines.length;
+      const sectionText = lines.slice(start, end).join("\n").trim();
+      if (sectionText.length <= this.options.maxChars) {
+        const chunk = makeChunk(lines, start, end, metadata, "markdown", "markdown", chunks.length);
+        if (chunk) chunks.push(chunk);
+        continue;
+      }
+      const sectionChunks = this.splitLongSection(lines, start, end, metadata, chunks.length);
+      chunks.push(...sectionChunks);
+    }
+    return chunks;
+  }
+
+  private splitLongSection(lines: string[], start: number, end: number, metadata: Record<string, string>, index: number): Chunk[] {
+    const chunks: Chunk[] = [];
+    let cursor = start;
+    while (cursor < end) {
+      let next = cursor;
+      let length = 0;
+      while (next < end && (next === cursor || length + lines[next]!.length + 1 <= this.options.maxChars)) {
+        length += lines[next]!.length + 1;
+        next += 1;
+      }
+      if (next < end) {
+        let paragraph = next;
+        while (paragraph > cursor + 1 && lines[paragraph - 1]!.trim()) paragraph -= 1;
+        if (paragraph > cursor + 1) next = paragraph;
+      }
+      const chunk = makeChunk(lines, cursor, next, metadata, "markdown", "markdown", index + chunks.length);
+      if (chunk) chunks.push(chunk);
+      if (next >= end) break;
+      const overlap = Math.min(this.options.overlapLines, Math.floor(Math.max(0, next - cursor) / 2));
+      cursor = Math.max(cursor + 1, next - overlap);
+    }
+    return chunks;
+  }
+}
+
+export class TextSplitter implements Chunker {
+  private readonly options: Required<SplitterOptions>;
+
+  constructor(options: SplitterOptions = {}) {
+    this.options = validateSplitterOptions(options);
+  }
+
+  split(content: string, metadata: Record<string, string>): Chunk[] {
+    requireSource(metadata);
+    const paragraphs = content.replace(/\r\n?/g, "\n").split(/\n\s*\n/).map((item) => item.trim()).filter(Boolean);
+    if (paragraphs.length === 0) return [];
+    const chunks: Chunk[] = [];
+    let current = "";
+    for (const paragraph of paragraphs) {
+      if (current && current.length + paragraph.length + 2 > this.options.maxChars) {
+        chunks.push({ text: current, metadata: { ...metadata, source: requireSource(metadata), type: "text", start_line: undefined, end_line: undefined, chunk_index: chunks.length } });
+        current = "";
+      }
+      current = current ? `${current}\n\n${paragraph}` : paragraph;
+    }
+    if (current) chunks.push({ text: current, metadata: { ...metadata, source: requireSource(metadata), type: "text", chunk_index: chunks.length } });
+    return chunks;
+  }
+}

--- a/packages/runtime-ts/src/chunking/splitter.ts
+++ b/packages/runtime-ts/src/chunking/splitter.ts
@@ -1,0 +1,100 @@
+export type ChunkType = "code" | "markdown" | "text" | "document";
+
+export interface ChunkMetadata {
+  source: string;
+  start_line?: number;
+  end_line?: number;
+  type: ChunkType;
+  language?: string;
+  [key: string]: string | number | boolean | undefined;
+}
+
+export interface Chunk {
+  text: string;
+  metadata: ChunkMetadata;
+}
+
+export interface Chunker {
+  split(content: string, metadata: Record<string, string>): Chunk[];
+}
+
+export interface SplitterOptions {
+  maxChars?: number;
+  overlapLines?: number;
+}
+
+export function validateSplitterOptions(options: SplitterOptions): Required<SplitterOptions> {
+  const maxChars = options.maxChars ?? 3_500;
+  const overlapLines = options.overlapLines ?? 20;
+  if (!Number.isInteger(maxChars) || maxChars < 1) throw new Error("分块 maxChars 必须是正整数");
+  if (!Number.isInteger(overlapLines) || overlapLines < 0) throw new Error("分块 overlapLines 必须是非负整数");
+  return { maxChars, overlapLines };
+}
+
+export function requireSource(metadata: Record<string, string>): string {
+  const source = metadata.source?.trim();
+  if (!source) throw new Error("分块 metadata.source 不能为空");
+  return source;
+}
+
+export function makeChunk(
+  lines: readonly string[],
+  start: number,
+  end: number,
+  metadata: Record<string, string>,
+  type: ChunkType,
+  language?: string,
+  chunkIndex = 0,
+): Chunk | null {
+  const text = lines.slice(start, end).join("\n").trim();
+  if (!text) return null;
+  return {
+    text,
+    metadata: {
+      ...metadata,
+      source: requireSource(metadata),
+      type,
+      ...(language ? { language } : {}),
+      start_line: start + 1,
+      end_line: end,
+      chunk_index: chunkIndex,
+    },
+  };
+}
+
+export function splitLineWindow(
+  content: string,
+  metadata: Record<string, string>,
+  type: ChunkType,
+  options: SplitterOptions,
+  language?: string,
+  boundary?: (line: string, index: number) => boolean,
+): Chunk[] {
+  requireSource(metadata);
+  const { maxChars, overlapLines } = validateSplitterOptions(options);
+  const lines = content.replace(/\r\n?/g, "\n").split("\n");
+  if (lines.length === 1 && !lines[0]!.trim()) return [];
+  const chunks: Chunk[] = [];
+  let start = 0;
+  while (start < lines.length) {
+    let end = start;
+    let length = 0;
+    while (end < lines.length && (end === start || length + lines[end]!.length + 1 <= maxChars)) {
+      length += lines[end]!.length + 1;
+      end += 1;
+    }
+    if (end <= start) end = start + 1;
+    if (end < lines.length && boundary) {
+      let candidate = end;
+      const minimumBoundaryDistance = Math.min(20, Math.max(2, Math.floor((end - start) / 3)));
+      while (candidate > start + minimumBoundaryDistance && !boundary(lines[candidate - 1]!, candidate - 1)) candidate -= 1;
+      if (candidate > start + minimumBoundaryDistance) end = candidate;
+    }
+    const chunk = makeChunk(lines, start, end, metadata, type, language, chunks.length);
+    if (chunk) chunks.push(chunk);
+    if (end >= lines.length) break;
+    const overlap = Math.min(overlapLines, Math.floor(Math.max(0, end - start) / 2));
+    start = Math.max(start + 1, end - overlap);
+  }
+  return chunks;
+}

--- a/packages/runtime-ts/src/embedding/index.ts
+++ b/packages/runtime-ts/src/embedding/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./local-embedder.js";

--- a/packages/runtime-ts/src/embedding/local-embedder.ts
+++ b/packages/runtime-ts/src/embedding/local-embedder.ts
@@ -1,0 +1,122 @@
+import type { Embedder, EmbeddingModel, LocalEmbedderOptions } from "./types.js";
+
+const DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2";
+const DEFAULT_DIMENSIONS = 384;
+const DEFAULT_MAX_TOKENS = 512;
+
+interface FeatureExtractionResult {
+  data: ArrayLike<number>;
+  dims?: readonly number[];
+}
+
+interface FeatureExtractionPipeline {
+  (texts: string[], options: { pooling: "mean"; normalize: true }): Promise<FeatureExtractionResult>;
+}
+
+/**
+ * 对本地嵌入模型的轻量适配器。
+ * 模型只在第一次真正嵌入时加载，并且并发的第一次调用共享同一个加载 Promise。
+ */
+export class LocalEmbedder implements Embedder {
+  readonly name: string;
+  readonly dimensions: number;
+  readonly maxTokens: number;
+
+  private readonly loadModel: () => Promise<EmbeddingModel>;
+  private modelPromise: Promise<EmbeddingModel> | undefined;
+
+  constructor(options: LocalEmbedderOptions) {
+    if (!options.name.trim()) throw new Error("嵌入模型名称不能为空");
+    if (!Number.isInteger(options.dimensions) || options.dimensions < 1) throw new Error("嵌入向量维度必须是正整数");
+    if (!Number.isInteger(options.maxTokens) || options.maxTokens < 1) throw new Error("嵌入模型 maxTokens 必须是正整数");
+    this.name = options.name;
+    this.dimensions = options.dimensions;
+    this.maxTokens = options.maxTokens;
+    this.loadModel = options.loadModel;
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (!Array.isArray(texts)) throw new TypeError("texts 必须是数组");
+    if (texts.length === 0) return [];
+    for (const text of texts) {
+      if (typeof text !== "string" || text.trim().length === 0) throw new Error("嵌入文本不能为空");
+    }
+
+    const model = await this.getModel();
+    const vectors = await model.embed(texts);
+    if (!Array.isArray(vectors) || vectors.length !== texts.length) {
+      throw new Error(`嵌入模型返回 ${vectors?.length ?? "非数组"} 个向量，期望 ${texts.length} 个`);
+    }
+    return vectors.map((vector, index) => this.validateVector(vector, index));
+  }
+
+  async embedQuery(text: string): Promise<number[]> {
+    const vectors = await this.embed([text]);
+    return vectors[0]!;
+  }
+
+  private getModel(): Promise<EmbeddingModel> {
+    if (!this.modelPromise) {
+      const promise = Promise.resolve().then(() => this.loadModel());
+      this.modelPromise = promise;
+      void promise.catch(() => {
+        if (this.modelPromise === promise) this.modelPromise = undefined;
+      });
+    }
+    return this.modelPromise;
+  }
+
+  private validateVector(vector: number[], index: number): number[] {
+    if (!Array.isArray(vector) || vector.length !== this.dimensions) {
+      throw new Error(`第 ${index + 1} 个嵌入向量维度错误：期望 ${this.dimensions}，实际 ${vector?.length ?? "非数组"}`);
+    }
+    if (!vector.every((value) => typeof value === "number" && Number.isFinite(value))) {
+      throw new Error(`第 ${index + 1} 个嵌入向量包含非有限数值`);
+    }
+    return [...vector];
+  }
+}
+
+export interface TransformersEmbedderOptions {
+  model?: string;
+  dimensions?: number;
+  maxTokens?: number;
+  batchSize?: number;
+}
+
+/** 使用 transformers.js 的默认本地嵌入模型。模型在第一次调用时才下载和加载。 */
+export function createTransformersEmbedder(options: TransformersEmbedderOptions = {}): LocalEmbedder {
+  const modelName = options.model ?? DEFAULT_MODEL;
+  const dimensions = options.dimensions ?? DEFAULT_DIMENSIONS;
+  const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const batchSize = options.batchSize ?? 8;
+  if (!Number.isInteger(batchSize) || batchSize < 1) throw new Error("嵌入批大小必须是正整数");
+
+  return new LocalEmbedder({
+    name: modelName,
+    dimensions,
+    maxTokens,
+    loadModel: async () => {
+      const module = await import("@xenova/transformers");
+      const pipeline = await module.pipeline("feature-extraction", modelName) as unknown as FeatureExtractionPipeline;
+      return {
+        embed: async (texts: string[]) => {
+          const vectors: number[][] = [];
+          for (let start = 0; start < texts.length; start += batchSize) {
+            const batch = texts.slice(start, start + batchSize);
+            const output = await pipeline(batch, { pooling: "mean", normalize: true });
+            const data = Array.from(output.data);
+            const expectedLength = batch.length * dimensions;
+            if (data.length !== expectedLength) {
+              throw new Error(`transformers.js 返回 ${data.length} 个数值，期望 ${expectedLength} 个`);
+            }
+            for (let index = 0; index < batch.length; index += 1) {
+              vectors.push(data.slice(index * dimensions, (index + 1) * dimensions));
+            }
+          }
+          return vectors;
+        },
+      };
+    },
+  });
+}

--- a/packages/runtime-ts/src/embedding/types.ts
+++ b/packages/runtime-ts/src/embedding/types.ts
@@ -1,0 +1,20 @@
+/** 将文本转换为向量的最小抽象。 */
+export interface Embedder {
+  readonly name: string;
+  readonly dimensions: number;
+  readonly maxTokens: number;
+  embed(texts: string[]): Promise<number[][]>;
+  embedQuery(text: string): Promise<number[]>;
+}
+
+/** 本地模型适配器所需的最小模型接口。 */
+export interface EmbeddingModel {
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+export interface LocalEmbedderOptions {
+  name: string;
+  dimensions: number;
+  maxTokens: number;
+  loadModel: () => Promise<EmbeddingModel>;
+}

--- a/packages/runtime-ts/src/indexing/index.ts
+++ b/packages/runtime-ts/src/indexing/index.ts
@@ -1,0 +1,1 @@
+export * from "./workspace-indexer.js";

--- a/packages/runtime-ts/src/indexing/workspace-indexer.ts
+++ b/packages/runtime-ts/src/indexing/workspace-indexer.ts
@@ -1,0 +1,166 @@
+import { readdir, stat, readFile } from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createChunker } from "../chunking/index.js";
+import type { Embedder } from "../embedding/types.js";
+import type { VectorStore } from "../vector-store/types.js";
+import { ignored, Workspace } from "../workspace.js";
+
+const MAX_FILE_BYTES = 1 * 1024 * 1024;
+const DEFAULT_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".c", ".cpp", ".h", ".hpp", ".cs", ".rb", ".php",
+  ".md", ".markdown", ".txt", ".rst", ".adoc", ".json", ".yaml", ".yml", ".toml",
+]);
+const execFileAsync = promisify(execFile);
+
+export interface IndexAllOptions {
+  extensions?: string[];
+  maxFiles?: number;
+  onProgress?: (indexed: number, total: number) => void;
+}
+
+export interface IndexResult {
+  files_indexed: number;
+  chunks_indexed: number;
+}
+
+/** 负责把工作区文件转换成向量记录，不负责注册工具或持久化存储。 */
+export class WorkspaceIndexer {
+  private readonly workspace: Workspace;
+  private readonly workspaceId: string;
+
+  constructor(
+    workspaceRoot: string,
+    private readonly embedder: Embedder,
+    private readonly vectorStore: VectorStore,
+  ) {
+    this.workspace = new Workspace(workspaceRoot);
+    this.workspaceId = this.workspace.root;
+  }
+
+  async indexFile(relativePath: string): Promise<number> {
+    const source = this.normalizeRelativePath(relativePath);
+    if (!this.shouldIndex(source)) {
+      await this.vectorStore.delete({ source });
+      return 0;
+    }
+    const absolute = await this.workspace.resolveExisting(source);
+    const fileStat = await stat(absolute);
+    if (!fileStat.isFile()) throw new Error(`不是文件：${source}`);
+    if (fileStat.size > MAX_FILE_BYTES) throw new Error(`文件过大，超过 ${MAX_FILE_BYTES} 字节：${source}`);
+    const buffer = await readFile(absolute);
+    if (buffer.includes(0)) throw new Error(`二进制文件不能建立文本索引：${source}`);
+    const content = buffer.toString("utf8");
+    const chunks = createChunker(source).split(content, { source });
+    const vectors = await this.embedder.embed(chunks.map((chunk) => `${source}\n\n${chunk.text}`));
+    if (vectors.length !== chunks.length) throw new Error(`嵌入结果数量与分块数量不一致：${source}`);
+
+    // 先完成嵌入，再替换旧记录；模型失败时保留旧索引，避免索引出现空洞。
+    await this.vectorStore.delete({ source });
+    if (chunks.length === 0) return 0;
+    await this.vectorStore.add(chunks.map((chunk, index) => ({
+      vector: vectors[index]!,
+      text: chunk.text,
+      metadata: {
+        ...chunk.metadata,
+        source,
+        workspace_id: this.workspaceId,
+      } as Record<string, string | number | boolean>,
+    })));
+    return chunks.length;
+  }
+
+  async indexAll(options: IndexAllOptions = {}): Promise<IndexResult> {
+    const maxFiles = options.maxFiles ?? Number.POSITIVE_INFINITY;
+    if (maxFiles !== Number.POSITIVE_INFINITY && (!Number.isInteger(maxFiles) || maxFiles < 1)) throw new Error("maxFiles 必须是正整数");
+    const extensions = new Set((options.extensions ?? [...DEFAULT_EXTENSIONS]).map((extension) => extension.startsWith(".") ? extension.toLowerCase() : `.${extension.toLowerCase()}`));
+    const allFiles = (await this.listFiles(this.workspace.root)).filter((file) => extensions.has(path.extname(file).toLowerCase()) && this.shouldIndex(file));
+    const candidates: string[] = [];
+    for (const file of allFiles) {
+      if (candidates.length >= maxFiles) break;
+      if (await this.isTextFile(file) && !(await this.isGitIgnored(file))) candidates.push(file);
+    }
+    let filesIndexed = 0;
+    let chunksIndexed = 0;
+    options.onProgress?.(0, candidates.length);
+    for (const file of candidates) {
+      try {
+        chunksIndexed += await this.indexFile(file);
+        filesIndexed += 1;
+      } finally {
+        options.onProgress?.(filesIndexed, candidates.length);
+      }
+    }
+    return { files_indexed: filesIndexed, chunks_indexed: chunksIndexed };
+  }
+
+  async updateIndex(changedFiles: string[]): Promise<void> {
+    if (!Array.isArray(changedFiles)) throw new TypeError("changedFiles 必须是数组");
+    for (const file of changedFiles) {
+      const source = this.normalizeRelativePath(file);
+      try {
+        await this.indexFile(source);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") await this.vectorStore.delete({ source });
+        else throw error;
+      }
+    }
+  }
+
+  shouldIndex(relativePath: string): boolean {
+    const normalized = relativePath.replaceAll("\\", "/").replace(/^\.\//, "");
+    if (!normalized || normalized.startsWith("/") || normalized.split("/").some((part) => part === ".." || ignored.has(part))) return false;
+    const extension = path.posix.extname(normalized).toLowerCase();
+    return DEFAULT_EXTENSIONS.has(extension) && !path.posix.basename(normalized).startsWith(".");
+  }
+
+  private normalizeRelativePath(relativePath: string): string {
+    if (typeof relativePath !== "string" || !relativePath.trim()) throw new Error("relativePath 不能为空");
+    const absolute = this.workspace.resolve(relativePath);
+    const normalized = path.relative(this.workspace.root, absolute).split(path.sep).join("/");
+    if (!this.shouldIndex(normalized) && normalized !== relativePath.replaceAll("\\", "/").replace(/^\.\//, "")) {
+      throw new Error(`路径不在工作区内：${relativePath}`);
+    }
+    return normalized;
+  }
+
+  private async listFiles(directory: string): Promise<string[]> {
+    const output: string[] = [];
+    const walk = async (current: string): Promise<void> => {
+      const entries = await readdir(current, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && ignored.has(entry.name)) continue;
+        const absolute = path.join(current, entry.name);
+        if (entry.isDirectory()) await walk(absolute);
+        else if (entry.isFile()) output.push(path.relative(this.workspace.root, absolute).split(path.sep).join("/"));
+      }
+    };
+    await walk(directory);
+    return output.sort();
+  }
+
+  private async isTextFile(source: string): Promise<boolean> {
+    try {
+      const absolute = await this.workspace.resolveExisting(source);
+      const fileStat = await stat(absolute);
+      if (!fileStat.isFile() || fileStat.size > MAX_FILE_BYTES) return false;
+      const sample = await readFile(absolute, { flag: "r" });
+      return !sample.subarray(0, Math.min(sample.length, 8_192)).includes(0);
+    } catch {
+      return false;
+    }
+  }
+
+  private async isGitIgnored(source: string): Promise<boolean> {
+    try {
+      await execFileAsync("git", ["-C", this.workspace.root, "check-ignore", "--no-index", "--quiet", "--", source], { timeout: 5_000 });
+      return true;
+    } catch (error) {
+      const code = (error as { code?: number | string }).code;
+      return code === 0;
+    }
+  }
+}
+
+export { DEFAULT_EXTENSIONS, MAX_FILE_BYTES };

--- a/packages/runtime-ts/src/indexing/workspace-indexer.ts
+++ b/packages/runtime-ts/src/indexing/workspace-indexer.ts
@@ -25,6 +25,8 @@ export interface IndexResult {
   chunks_indexed: number;
 }
 
+export type IndexObserver = (source: string, chunks: readonly Chunk[]) => Promise<void> | void;
+
 /** 构造统一的嵌入文本；展示给用户的正文仍保存在 Chunk.text 中。 */
 export function formatEmbeddingText(source: string, chunk: Chunk): string {
   const symbol = typeof chunk.metadata.symbol === "string" ? `\n符号：${chunk.metadata.symbol}` : "";
@@ -41,6 +43,7 @@ export class WorkspaceIndexer {
     workspaceRoot: string,
     private readonly embedder: Embedder,
     private readonly vectorStore: VectorStore,
+    private readonly observer?: IndexObserver,
   ) {
     this.workspace = new Workspace(workspaceRoot);
     this.workspaceId = this.workspace.root;
@@ -50,6 +53,7 @@ export class WorkspaceIndexer {
     const source = this.normalizeRelativePath(relativePath);
     if (!this.shouldIndex(source)) {
       await this.vectorStore.delete({ source });
+      await this.observer?.(source, []);
       return 0;
     }
     const absolute = await this.workspace.resolveExisting(source);
@@ -65,7 +69,10 @@ export class WorkspaceIndexer {
 
     // 先完成嵌入，再替换旧记录；模型失败时保留旧索引，避免索引出现空洞。
     await this.vectorStore.delete({ source });
-    if (chunks.length === 0) return 0;
+    if (chunks.length === 0) {
+      await this.observer?.(source, []);
+      return 0;
+    }
     await this.vectorStore.add(chunks.map((chunk, index) => ({
       vector: vectors[index]!,
       text: chunk.text,
@@ -75,6 +82,7 @@ export class WorkspaceIndexer {
         workspace_id: this.workspaceId,
       } as Record<string, string | number | boolean>,
     })));
+    await this.observer?.(source, chunks);
     return chunks.length;
   }
 
@@ -109,7 +117,10 @@ export class WorkspaceIndexer {
       try {
         await this.indexFile(source);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") await this.vectorStore.delete({ source });
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          await this.vectorStore.delete({ source });
+          await this.observer?.(source, []);
+        }
         else throw error;
       }
     }

--- a/packages/runtime-ts/src/indexing/workspace-indexer.ts
+++ b/packages/runtime-ts/src/indexing/workspace-indexer.ts
@@ -2,7 +2,7 @@ import { readdir, stat, readFile } from "node:fs/promises";
 import path from "node:path";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { createChunker } from "../chunking/index.js";
+import { createChunker, type Chunk } from "../chunking/index.js";
 import type { Embedder } from "../embedding/types.js";
 import type { VectorStore } from "../vector-store/types.js";
 import { ignored, Workspace } from "../workspace.js";
@@ -23,6 +23,13 @@ export interface IndexAllOptions {
 export interface IndexResult {
   files_indexed: number;
   chunks_indexed: number;
+}
+
+/** 构造统一的嵌入文本；展示给用户的正文仍保存在 Chunk.text 中。 */
+export function formatEmbeddingText(source: string, chunk: Chunk): string {
+  const symbol = typeof chunk.metadata.symbol === "string" ? `\n符号：${chunk.metadata.symbol}` : "";
+  const kind = typeof chunk.metadata.symbol_kind === "string" ? `\n符号类型：${chunk.metadata.symbol_kind}` : "";
+  return `${source}${symbol}${kind}\n\n${chunk.text}`;
 }
 
 /** 负责把工作区文件转换成向量记录，不负责注册工具或持久化存储。 */
@@ -53,7 +60,7 @@ export class WorkspaceIndexer {
     if (buffer.includes(0)) throw new Error(`二进制文件不能建立文本索引：${source}`);
     const content = buffer.toString("utf8");
     const chunks = createChunker(source).split(content, { source });
-    const vectors = await this.embedder.embed(chunks.map((chunk) => `${source}\n\n${chunk.text}`));
+    const vectors = await this.embedder.embed(chunks.map((chunk) => formatEmbeddingText(source, chunk)));
     if (vectors.length !== chunks.length) throw new Error(`嵌入结果数量与分块数量不一致：${source}`);
 
     // 先完成嵌入，再替换旧记录；模型失败时保留旧索引，避免索引出现空洞。

--- a/packages/runtime-ts/src/retrieval/hybrid-search.ts
+++ b/packages/runtime-ts/src/retrieval/hybrid-search.ts
@@ -1,0 +1,72 @@
+import type { LexicalSearchResult } from "./lexical-index.js";
+import type { SearchResult, VectorRecord } from "../vector-store/types.js";
+
+export interface HybridSearchResult {
+  key: string;
+  score: number;
+  semantic_score: number;
+  lexical_score: number;
+  record: VectorRecord;
+}
+
+/** 使用 source 和 chunk_index 建立跨向量/关键词索引稳定一致的记录键。 */
+export function searchRecordKey(metadata: Record<string, string | number | boolean>): string {
+  return `${String(metadata.source ?? "")}#${String(metadata.chunk_index ?? "")}`;
+}
+
+/** 合并两路召回结果；分数保持在 0～1，便于向调用方解释和设置阈值。 */
+export function mergeHybridResults(
+  semanticResults: readonly SearchResult[],
+  lexicalResults: readonly LexicalSearchResult[],
+  semanticWeight = 0.7,
+  lexicalWeight = 0.3,
+): HybridSearchResult[] {
+  if (!Number.isFinite(semanticWeight) || !Number.isFinite(lexicalWeight) || semanticWeight < 0 || lexicalWeight < 0 || semanticWeight + lexicalWeight <= 0) {
+    throw new Error("混合检索权重必须是非负数且总和大于 0");
+  }
+  const totalWeight = semanticWeight + lexicalWeight;
+  const lexicalByKey = new Map(lexicalResults.map((result) => [result.key, result]));
+  const merged = new Map<string, HybridSearchResult>();
+  for (const result of semanticResults) {
+    const key = searchRecordKey(result.record.metadata);
+    const lexical = lexicalByKey.get(key);
+    const semanticScore = Math.max(0, Math.min(1, result.score));
+    const lexicalScore = lexical?.score ?? 0;
+    merged.set(key, {
+      key,
+      score: (semanticScore * semanticWeight + lexicalScore * lexicalWeight) / totalWeight,
+      semantic_score: semanticScore,
+      lexical_score: lexicalScore,
+      record: result.record,
+    });
+  }
+  // 关键词索引通常来自同一批向量记录，但保留这条分支可防止两个索引短暂不同步时丢失精确命中。
+  for (const lexical of lexicalResults) {
+    if (merged.has(lexical.key)) continue;
+    merged.set(lexical.key, {
+      key: lexical.key,
+      score: (lexical.score * lexicalWeight) / totalWeight,
+      semantic_score: 0,
+      lexical_score: lexical.score,
+      record: {
+        id: lexical.key,
+        vector: [],
+        text: lexical.text,
+        metadata: lexical.metadata,
+      },
+    });
+  }
+  return [...merged.values()].sort((left, right) => right.score - left.score || right.lexical_score - left.lexical_score || right.semantic_score - left.semantic_score);
+}
+
+/** 每个文件只保留综合分数最高的代码块，避免重叠分块占满结果。 */
+export function deduplicateBySource(results: readonly HybridSearchResult[], limit: number): HybridSearchResult[] {
+  if (!Number.isInteger(limit) || limit < 1) return [];
+  const best = new Map<string, HybridSearchResult>();
+  for (const result of results) {
+    const source = String(result.record.metadata.source ?? result.key);
+    const previous = best.get(source);
+    if (!previous || result.score > previous.score) best.set(source, result);
+  }
+  return [...best.values()].sort((left, right) => right.score - left.score || String(left.record.metadata.source).localeCompare(String(right.record.metadata.source))).slice(0, limit);
+}

--- a/packages/runtime-ts/src/retrieval/index.ts
+++ b/packages/runtime-ts/src/retrieval/index.ts
@@ -1,0 +1,1 @@
+export * from "./lexical-index.js";

--- a/packages/runtime-ts/src/retrieval/index.ts
+++ b/packages/runtime-ts/src/retrieval/index.ts
@@ -1,1 +1,2 @@
 export * from "./lexical-index.js";
+export * from "./hybrid-search.js";

--- a/packages/runtime-ts/src/retrieval/lexical-index.ts
+++ b/packages/runtime-ts/src/retrieval/lexical-index.ts
@@ -1,0 +1,136 @@
+import type { Chunk } from "../chunking/index.js";
+
+export interface LexicalSearchFilter {
+  pathPrefix?: string;
+  fileType?: "code" | "markdown" | "document" | "any";
+}
+
+export interface LexicalSearchResult {
+  key: string;
+  score: number;
+  text: string;
+  metadata: Record<string, string | number | boolean>;
+}
+
+interface LexicalRecord {
+  key: string;
+  source: string;
+  text: string;
+  normalizedText: string;
+  tokens: Set<string>;
+  metadata: Record<string, string | number | boolean>;
+}
+
+const CJK_RUN = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]+/gu;
+const LATIN_TOKEN = /[a-z0-9_$]+/gi;
+
+/**
+ * 将自然语言和代码标识符拆成可比较的词元。
+ * 同时保留完整标识符和驼峰/下划线拆分结果，避免精确符号查询丢失信息。
+ */
+export function tokenizeSearchText(text: string): string[] {
+  if (typeof text !== "string") return [];
+  const normalized = text.normalize("NFKC");
+  const tokens = new Set<string>();
+  for (const match of normalized.matchAll(CJK_RUN)) {
+    const run = match[0]!.toLocaleLowerCase();
+    if (run.length >= 2) tokens.add(run);
+    for (let index = 0; index + 1 < run.length; index += 1) tokens.add(run.slice(index, index + 2));
+  }
+  for (const match of normalized.matchAll(LATIN_TOKEN)) {
+    const token = match[0]!;
+    const lowerToken = token.toLocaleLowerCase();
+    if (lowerToken.length >= 2) tokens.add(lowerToken);
+    for (const part of token.split(/[_$-]+/u)) {
+      const lowerPart = part.toLocaleLowerCase();
+      if (lowerPart.length >= 2) tokens.add(lowerPart);
+      const camelParts = part.split(/(?<=[a-z0-9])(?=[A-Z])/u).filter((item) => item.length >= 2);
+      for (const camelPart of camelParts) tokens.add(camelPart.toLocaleLowerCase());
+    }
+  }
+  return [...tokens];
+}
+
+function metadataWithoutUndefined(chunk: Chunk): Record<string, string | number | boolean> {
+  return Object.fromEntries(Object.entries(chunk.metadata).filter(([, value]) => value !== undefined)) as Record<string, string | number | boolean>;
+}
+
+/** 轻量级倒排式关键词索引，第一阶段使用线性扫描以保持实现简单、结果可解释。 */
+export class LexicalIndex {
+  private readonly records = new Map<string, LexicalRecord>();
+
+  replace(source: string, chunks: readonly Chunk[]): void {
+    this.deleteSource(source);
+    for (const chunk of chunks) {
+      const metadata = metadataWithoutUndefined(chunk);
+      const key = `${source}#${String(metadata.chunk_index ?? this.records.size)}`;
+      const searchableText = [
+        source,
+        metadata.symbol,
+        metadata.symbol_kind,
+        metadata.section,
+        chunk.text,
+      ].filter((value): value is string => typeof value === "string" && value.length > 0).join("\n");
+      this.records.set(key, {
+        key,
+        source,
+        text: chunk.text,
+        normalizedText: searchableText.normalize("NFKC").toLocaleLowerCase(),
+        tokens: new Set(tokenizeSearchText(searchableText)),
+        metadata,
+      });
+    }
+  }
+
+  deleteSource(source: string): number {
+    let deleted = 0;
+    for (const [key, record] of this.records) {
+      if (record.source === source) {
+        this.records.delete(key);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  count(): number {
+    return this.records.size;
+  }
+
+  search(query: string, topK: number, filter?: LexicalSearchFilter): LexicalSearchResult[] {
+    if (typeof query !== "string" || !query.trim()) throw new Error("关键词查询不能为空");
+    if (!Number.isInteger(topK) || topK < 1) return [];
+    if (filter?.fileType && !["code", "markdown", "document", "any"].includes(filter.fileType)) throw new Error("fileType 无效");
+    const normalizedQuery = query.normalize("NFKC").toLocaleLowerCase().trim();
+    const queryTokens = tokenizeSearchText(query);
+    const results: Array<LexicalSearchResult & { sequence: number }> = [];
+    let sequence = 0;
+    for (const record of this.records.values()) {
+      if (!this.matchesFilter(record, filter)) continue;
+      const score = this.score(record, normalizedQuery, queryTokens);
+      if (score <= 0) continue;
+      results.push({ key: record.key, score, text: record.text, metadata: { ...record.metadata }, sequence });
+      sequence += 1;
+    }
+    return results.sort((left, right) => right.score - left.score || left.sequence - right.sequence).slice(0, topK).map(({ sequence: _sequence, ...result }) => result);
+  }
+
+  private matchesFilter(record: LexicalRecord, filter?: LexicalSearchFilter): boolean {
+    const pathPrefix = filter?.pathPrefix?.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "") ?? "";
+    if (pathPrefix && record.source !== pathPrefix && !record.source.startsWith(`${pathPrefix}/`)) return false;
+    const type = String(record.metadata.type ?? "text");
+    return !filter?.fileType || filter.fileType === "any" || type === filter.fileType;
+  }
+
+  private score(record: LexicalRecord, normalizedQuery: string, queryTokens: readonly string[]): number {
+    if (queryTokens.length === 0) return 0;
+    const matched = queryTokens.filter((token) => record.tokens.has(token));
+    let score = (matched.length / queryTokens.length) * 0.65;
+    if (record.normalizedText.includes(normalizedQuery)) score += 0.25;
+    const symbol = String(record.metadata.symbol ?? "").toLocaleLowerCase();
+    if (symbol && (symbol === normalizedQuery || symbol.includes(normalizedQuery))) score += 0.35;
+    const source = record.source.toLocaleLowerCase();
+    if (source.includes(normalizedQuery)) score += 0.15;
+    return Math.min(1, score);
+  }
+}

--- a/packages/runtime-ts/src/tools.ts
+++ b/packages/runtime-ts/src/tools.ts
@@ -16,6 +16,7 @@ import type { ParsedDocument } from "./document-parser/types.js";
 import { createTransformersEmbedder, type Embedder } from "./embedding/index.js";
 import { WorkspaceIndexer } from "./indexing/index.js";
 import { MemoryVectorStore } from "./vector-store/index.js";
+import { LexicalIndex } from "./retrieval/index.js";
 
 export type { ToolPermission } from "./tools-types.js";
 export type ToolResult = { ok: boolean; output: string; error?: string; errorType?: "runtime_error" | "rate_limited" | "timeout" | "schema_error" | "permission_denied" };
@@ -403,6 +404,7 @@ type SemanticIndexState = {
   embedder: Embedder;
   indexer: WorkspaceIndexer;
   store: MemoryVectorStore;
+  lexical: LexicalIndex;
   indexPromise?: Promise<{ files_indexed: number; chunks_indexed: number }>;
 };
 
@@ -414,7 +416,8 @@ export function createSemanticSearchTool(options: SemanticSearchToolOptions = {}
     if (existing) return existing;
     const embedder = options.createEmbedder?.() ?? createTransformersEmbedder();
     const store = new MemoryVectorStore(embedder.dimensions);
-    const state = { embedder, indexer: new WorkspaceIndexer(root, embedder, store), store };
+    const lexical = new LexicalIndex();
+    const state = { embedder, indexer: new WorkspaceIndexer(root, embedder, store, (source, chunks) => lexical.replace(source, chunks)), store, lexical };
     states.set(root, state);
     return state;
   };

--- a/packages/runtime-ts/src/tools.ts
+++ b/packages/runtime-ts/src/tools.ts
@@ -16,7 +16,7 @@ import type { ParsedDocument } from "./document-parser/types.js";
 import { createTransformersEmbedder, type Embedder } from "./embedding/index.js";
 import { WorkspaceIndexer } from "./indexing/index.js";
 import { MemoryVectorStore } from "./vector-store/index.js";
-import { LexicalIndex } from "./retrieval/index.js";
+import { deduplicateBySource, LexicalIndex, mergeHybridResults } from "./retrieval/index.js";
 
 export type { ToolPermission } from "./tools-types.js";
 export type ToolResult = { ok: boolean; output: string; error?: string; errorType?: "runtime_error" | "rate_limited" | "timeout" | "schema_error" | "permission_denied" };
@@ -460,14 +460,19 @@ export function createSemanticSearchTool(options: SemanticSearchToolOptions = {}
           await state.indexPromise;
         }
         const queryVector = await state.embedder.embedQuery(query);
-        const candidates = await state.store.search(queryVector, Math.min(100, topK * 5), undefined);
-        const filtered = candidates.filter((result) => {
+        const filter = { pathPrefix: relativePath, fileType: fileType as "code" | "markdown" | "document" | "any" };
+        const recordCount = await state.store.count();
+        const candidates = await state.store.search(queryVector, Math.max(1, recordCount), undefined);
+        const semanticCandidates = candidates.filter((result) => {
           const source = String(result.record.metadata.source ?? "");
           const type = String(result.record.metadata.type ?? "text");
           const pathMatches = !relativePath || source === relativePath || source.startsWith(`${relativePath}/`);
           const typeMatches = fileType === "any" || (fileType === "code" && type === "code") || (fileType === "markdown" && type === "markdown") || (fileType === "document" && type === "document");
           return pathMatches && typeMatches && result.score >= minScore;
-        }).slice(0, topK);
+        });
+        const lexicalCandidates = state.lexical.search(query, Math.max(1, recordCount), filter);
+        const hybrid = mergeHybridResults(semanticCandidates, lexicalCandidates);
+        const filtered = deduplicateBySource(hybrid, topK);
         if (filtered.length === 0) return ok(`No semantic results for: "${query}"`);
         const lines = [`Semantic search results for: "${query}"`, "Score | File:Line Range | Preview", "------|-------------------|--------"];
         for (const result of filtered) {

--- a/packages/runtime-ts/src/tools.ts
+++ b/packages/runtime-ts/src/tools.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createWriteStream, existsSync } from "node:fs";
 import { randomUUID } from "node:crypto";
+import { validateWorkflowGraph } from "@sztucode/protocol/workflow";
 import type { ToolPermission } from "./tools-types.js";
 import type { Workspace } from "./workspace.js";
 import { ignored } from "./workspace.js";

--- a/packages/runtime-ts/src/tools.ts
+++ b/packages/runtime-ts/src/tools.ts
@@ -13,6 +13,9 @@ import { classifyBashPermission } from "./bash-permission.js";
 import { SkillLoader } from "./skills.js";
 import { detectDocumentFormat } from "./document-parser/detect.js";
 import type { ParsedDocument } from "./document-parser/types.js";
+import { createTransformersEmbedder, type Embedder } from "./embedding/index.js";
+import { WorkspaceIndexer } from "./indexing/index.js";
+import { MemoryVectorStore } from "./vector-store/index.js";
 
 export type { ToolPermission } from "./tools-types.js";
 export type ToolResult = { ok: boolean; output: string; error?: string; errorType?: "runtime_error" | "rate_limited" | "timeout" | "schema_error" | "permission_denied" };
@@ -392,6 +395,93 @@ export function createWorkflowTool(run: (graph: unknown) => Promise<unknown>): T
   return { name: "run_workflow", description: "Execute a validated planner WorkflowGraph as a parallel specialist workflow", permission: "workspace_write", schema: { type: "object", properties: { workflow: { type: "object" } }, required: ["workflow"] }, async invoke(params) { try { return ok(JSON.stringify(await run(params.workflow))); } catch (error) { return fail(error instanceof Error ? error.message : String(error), "schema_error"); } } };
 }
 
+export interface SemanticSearchToolOptions {
+  createEmbedder?: () => Embedder;
+}
+
+type SemanticIndexState = {
+  embedder: Embedder;
+  indexer: WorkspaceIndexer;
+  store: MemoryVectorStore;
+  indexPromise?: Promise<{ files_indexed: number; chunks_indexed: number }>;
+};
+
+/** 创建按工作区懒加载的语义搜索工具。 */
+export function createSemanticSearchTool(options: SemanticSearchToolOptions = {}): Tool {
+  const states = new Map<string, SemanticIndexState>();
+  const getState = (root: string): SemanticIndexState => {
+    const existing = states.get(root);
+    if (existing) return existing;
+    const embedder = options.createEmbedder?.() ?? createTransformersEmbedder();
+    const store = new MemoryVectorStore(embedder.dimensions);
+    const state = { embedder, indexer: new WorkspaceIndexer(root, embedder, store), store };
+    states.set(root, state);
+    return state;
+  };
+
+  return {
+    name: "semantic_search",
+    description: "使用语义和含义搜索工作区代码与文档；不知道确切关键词时使用，并与 grep_search 互补。",
+    permission: "read_only",
+    timeoutMs: 120_000,
+    schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", minLength: 1, description: "描述目标代码或内容的自然语言查询" },
+        top_k: { type: "integer", minimum: 1, maximum: 20, default: 5, description: "返回结果数量" },
+        path: { type: "string", description: "可选的工作区相对目录前缀" },
+        file_type: { type: "string", enum: ["code", "markdown", "document", "any"], default: "any" },
+        min_score: { type: "number", minimum: -1, maximum: 1, default: 0, description: "最低余弦相似度；默认不过滤" },
+        auto_index: { type: "boolean", default: true, description: "索引为空时自动建立工作区索引" },
+      },
+      required: ["query"],
+    },
+    async invoke(params, context) {
+      const query = str(params, "query")?.trim();
+      if (!query) return fail("query is required", "schema_error");
+      const topK = params.top_k === undefined ? 5 : Number(params.top_k);
+      if (!Number.isInteger(topK) || topK < 1 || topK > 20) return fail("top_k must be an integer between 1 and 20", "schema_error");
+      const fileType = params.file_type === undefined ? "any" : String(params.file_type);
+      if (!["code", "markdown", "document", "any"].includes(fileType)) return fail("file_type is invalid", "schema_error");
+      const minScore = params.min_score === undefined ? 0 : Number(params.min_score);
+      if (!Number.isFinite(minScore) || minScore < -1 || minScore > 1) return fail("min_score must be between -1 and 1", "schema_error");
+      const relativePath = params.path === undefined ? "" : String(params.path).replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
+      if (relativePath.split("/").some((part) => part === "..")) return fail("path must stay inside the workspace", "schema_error");
+
+      try {
+        const state = getState(context.workspace.root);
+        const autoIndex = params.auto_index === undefined ? true : Boolean(params.auto_index);
+        if (await state.store.count() === 0) {
+          if (!autoIndex) return ok("Semantic index is empty. Set auto_index=true or build the index before searching.");
+          state.indexPromise ??= state.indexer.indexAll().catch((error) => { state.indexPromise = undefined; throw error; });
+          await state.indexPromise;
+        }
+        const queryVector = await state.embedder.embedQuery(query);
+        const candidates = await state.store.search(queryVector, Math.min(100, topK * 5), undefined);
+        const filtered = candidates.filter((result) => {
+          const source = String(result.record.metadata.source ?? "");
+          const type = String(result.record.metadata.type ?? "text");
+          const pathMatches = !relativePath || source === relativePath || source.startsWith(`${relativePath}/`);
+          const typeMatches = fileType === "any" || (fileType === "code" && type === "code") || (fileType === "markdown" && type === "markdown") || (fileType === "document" && type === "document");
+          return pathMatches && typeMatches && result.score >= minScore;
+        }).slice(0, topK);
+        if (filtered.length === 0) return ok(`No semantic results for: "${query}"`);
+        const lines = [`Semantic search results for: "${query}"`, "Score | File:Line Range | Preview", "------|-------------------|--------"];
+        for (const result of filtered) {
+          const source = String(result.record.metadata.source);
+          const start = Number(result.record.metadata.start_line ?? 1);
+          const end = Number(result.record.metadata.end_line ?? start);
+          const preview = result.record.text.split(/\r?\n/).slice(0, 3).join(" ").replace(/\s+/g, " ").slice(0, 240);
+          lines.push(`${result.score.toFixed(4)} | ${source}:${start}-${end} | ${preview}`);
+        }
+        return ok(lines.join("\n"));
+      } catch (error) {
+        return fail(error instanceof Error ? error.message : String(error));
+      }
+    },
+  };
+}
+
 export function createPlanTools(events: EventBus, runId: string, sessionId = "", tasksDir = path.join(process.env.SZTU_DATA_DIR ?? path.join(process.env.USERPROFILE ?? process.env.HOME ?? process.cwd(), ".sztu"), "runs", runId.replace(/[^A-Za-z0-9_.-]/g, "_"), "tasks")): Tool[] {
   const manager = new TaskManager(tasksDir);
   const publish = async () => { const items = await manager.listAll(); events.publish({ type: "plan.updated", run_id: runId, session_id: sessionId, items: items.map(({ id, subject, status, blocked_by }) => ({ id, subject, status, blocked_by })), ts: new Date().toISOString() }); };
@@ -430,6 +520,7 @@ export function createWorkspaceTools(extraTools: Tool[] = []): ToolRegistry {
       return ok(`${numbered}${suffix}`.trimEnd());
     } catch (error) { return fail(error instanceof Error ? error.message : String(error)); }
   }});
+  registry.register(createSemanticSearchTool());
   registry.register({ name: "parse_document", description: "Extract readable text, tables and metadata from binary documents (PDF, DOCX, XLSX) as Markdown", permission: "read_only", schema: { type: "object", properties: { path: { type: "string", description: "Path to the document, relative to workspace root" }, format: { type: "string", enum: ["auto", "pdf", "docx", "xlsx"], description: "Force a parser instead of extension/magic detection", default: "auto" }, max_pages: { type: "integer", minimum: 1, maximum: 200, description: "PDF: parse only the first N pages (default: all)" }, max_rows: { type: "integer", minimum: 1, maximum: 5000, description: "XLSX: maximum rows per sheet (default: 500)" } }, required: ["path"] }, async invoke(params, context) {
     const file = str(params, "path"); if (!file) return fail("path is required", "schema_error");
     try {
@@ -449,7 +540,7 @@ export function createWorkspaceTools(extraTools: Tool[] = []): ToolRegistry {
       return ok(formatDocumentMarkdown(doc));
     } catch (error) { return fail(error instanceof Error ? error.message : String(error)); }
   }});
-  registry.register({ name: "write_file", description: "Write a UTF-8 file inside the workspace", permission: "workspace_write", schema: { type: "object", properties: { path: { type: "string" }, content: { type: "string" } }, required: ["path", "content"] }, async invoke(params, context) {
+  registry.register({ name: "write_file", timeoutMs: 30_000, description: "Write a UTF-8 file inside the workspace", permission: "workspace_write", schema: { type: "object", properties: { path: { type: "string" }, content: { type: "string" } }, required: ["path", "content"] }, async invoke(params, context) {
     const file = str(params, "path"); const content = str(params, "content"); if (!file || content === null) return fail("path and content are required", "schema_error");
     try { const target = await context.workspace.resolveExisting(file); const before = await readFile(target, "utf8").catch(() => null); await mkdir(path.dirname(target), { recursive: true }); await writeFile(target, content, "utf8"); if (before !== content) context.onFileChanged?.(path.relative(context.workspace.root, target).split(path.sep).join("/")); return ok(`wrote ${file}`); } catch (error) { return fail(error instanceof Error ? error.message : String(error)); }
   }});

--- a/packages/runtime-ts/src/vector-store/index.ts
+++ b/packages/runtime-ts/src/vector-store/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export * from "./memory-store.js";

--- a/packages/runtime-ts/src/vector-store/memory-store.ts
+++ b/packages/runtime-ts/src/vector-store/memory-store.ts
@@ -1,0 +1,114 @@
+import { randomUUID } from "node:crypto";
+import type { MetadataValue, SearchResult, VectorRecord, VectorStore } from "./types.js";
+
+export function cosineSimilarity(left: number[], right: number[]): number {
+  if (left.length !== right.length) throw new Error("余弦相似度计算要求向量维度一致");
+  if (!left.every((value) => Number.isFinite(value)) || !right.every((value) => Number.isFinite(value))) throw new Error("余弦相似度计算要求向量只包含有限数值");
+  const leftScale = Math.max(...left.map((value) => Math.abs(value)));
+  const rightScale = Math.max(...right.map((value) => Math.abs(value)));
+  if (leftScale === 0 || rightScale === 0) return 0;
+  let dot = 0;
+  let leftNorm = 0;
+  let rightNorm = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const normalizedLeft = left[index]! / leftScale;
+    const normalizedRight = right[index]! / rightScale;
+    dot += normalizedLeft * normalizedRight;
+    leftNorm += normalizedLeft ** 2;
+    rightNorm += normalizedRight ** 2;
+  }
+  const denominator = Math.sqrt(leftNorm) * Math.sqrt(rightNorm);
+  return denominator === 0 ? 0 : dot / denominator;
+}
+
+interface StoredRecord {
+  record: VectorRecord;
+  sequence: number;
+}
+
+/** 适合第一阶段验证契约的线性扫描向量存储。 */
+export class MemoryVectorStore implements VectorStore {
+  readonly name: string;
+  readonly dimensions: number;
+
+  private readonly records = new Map<string, StoredRecord>();
+  private nextSequence = 0;
+
+  constructor(dimensions: number, name = "memory") {
+    if (!Number.isInteger(dimensions) || dimensions < 1) throw new Error("向量存储维度必须是正整数");
+    if (!name.trim()) throw new Error("向量存储名称不能为空");
+    this.dimensions = dimensions;
+    this.name = name;
+  }
+
+  async add(records: Omit<VectorRecord, "id">[]): Promise<string[]> {
+    if (!Array.isArray(records)) throw new TypeError("records 必须是数组");
+    for (const record of records) this.validateRecord(record);
+    const ids: string[] = [];
+    for (const input of records) {
+      const id = randomUUID();
+      this.records.set(id, {
+        sequence: this.nextSequence++,
+        record: { id, vector: [...input.vector], text: input.text, metadata: { ...input.metadata } },
+      });
+      ids.push(id);
+    }
+    return ids;
+  }
+
+  async delete(filter?: Partial<Record<string, MetadataValue>>): Promise<number> {
+    let deleted = 0;
+    for (const [id, stored] of this.records) {
+      if (this.matches(stored.record.metadata, filter)) {
+        this.records.delete(id);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+
+  async search(query: number[], topK: number, filter?: Partial<Record<string, MetadataValue>>): Promise<SearchResult[]> {
+    this.validateVector(query, "查询");
+    if (!Number.isInteger(topK) || !Number.isFinite(topK)) throw new Error("topK 必须是有限整数");
+    if (topK < 1) return [];
+    return [...this.records.values()]
+      .filter((stored) => this.matches(stored.record.metadata, filter))
+      .map((stored) => ({ record: this.cloneRecord(stored.record), score: cosineSimilarity(query, stored.record.vector), sequence: stored.sequence }))
+      .sort((left, right) => right.score - left.score || left.sequence - right.sequence)
+      .slice(0, topK)
+      .map(({ record, score }) => ({ record, score }));
+  }
+
+  async count(filter?: Partial<Record<string, MetadataValue>>): Promise<number> {
+    let count = 0;
+    for (const stored of this.records.values()) if (this.matches(stored.record.metadata, filter)) count += 1;
+    return count;
+  }
+
+  async clear(): Promise<void> {
+    this.records.clear();
+  }
+
+  private matches(metadata: Record<string, MetadataValue>, filter?: Partial<Record<string, MetadataValue>>): boolean {
+    if (!filter) return true;
+    return Object.entries(filter).every(([key, value]) => metadata[key] === value);
+  }
+
+  private validateRecord(record: Omit<VectorRecord, "id">): void {
+    if (!record || typeof record.text !== "string") throw new Error("向量记录的 text 必须是字符串");
+    if (!record.metadata || typeof record.metadata !== "object" || Array.isArray(record.metadata)) throw new Error("向量记录的 metadata 必须是对象");
+    for (const value of Object.values(record.metadata)) {
+      if (!((typeof value === "string") || (typeof value === "boolean") || (typeof value === "number" && Number.isFinite(value)))) throw new Error("向量记录的 metadata 只能包含字符串、有限数字或布尔值");
+    }
+    this.validateVector(record.vector, "记录");
+  }
+
+  private validateVector(vector: number[], label: string): void {
+    if (!Array.isArray(vector) || vector.length !== this.dimensions) throw new Error(`${label}向量维度错误：期望 ${this.dimensions}，实际 ${vector?.length ?? "非数组"}`);
+    if (!vector.every((value) => typeof value === "number" && Number.isFinite(value))) throw new Error(`${label}向量包含非有限数值`);
+  }
+
+  private cloneRecord(record: VectorRecord): VectorRecord {
+    return { id: record.id, vector: [...record.vector], text: record.text, metadata: { ...record.metadata } };
+  }
+}

--- a/packages/runtime-ts/src/vector-store/types.ts
+++ b/packages/runtime-ts/src/vector-store/types.ts
@@ -1,0 +1,23 @@
+export type MetadataValue = string | number | boolean;
+
+export interface VectorRecord {
+  id: string;
+  vector: number[];
+  text: string;
+  metadata: Record<string, MetadataValue>;
+}
+
+export interface SearchResult {
+  record: VectorRecord;
+  score: number;
+}
+
+export interface VectorStore {
+  readonly name: string;
+  readonly dimensions: number;
+  add(records: Omit<VectorRecord, "id">[]): Promise<string[]>;
+  delete(filter?: Partial<Record<string, MetadataValue>>): Promise<number>;
+  search(query: number[], topK: number, filter?: Partial<Record<string, MetadataValue>>): Promise<SearchResult[]>;
+  count(filter?: Partial<Record<string, MetadataValue>>): Promise<number>;
+  clear(): Promise<void>;
+}

--- a/packages/runtime-ts/tests/chunking.test.ts
+++ b/packages/runtime-ts/tests/chunking.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CodeSplitter, MarkdownSplitter, TextSplitter, createChunker } from "../src/chunking/index.js";
+
+test("代码分块保留声明边界、行号和语言元数据", () => {
+  const content = [
+    "const prefix = true;",
+    "",
+    "export function authenticate(user: string): boolean {",
+    "  return user.length > 0;",
+    "}",
+    "",
+    "function compactContext(input: string): string {",
+    "  return input.trim();",
+    "}",
+  ].join("\n");
+  const chunks = new CodeSplitter({ maxChars: 90, overlapLines: 2 }, "typescript").split(content, { source: "auth.ts" });
+  assert.ok(chunks.length >= 2);
+  assert.match(chunks[0]!.text, /authenticate/);
+  assert.ok(chunks.some((chunk) => chunk.text.includes("compactContext")));
+  assert.equal(chunks[0]!.metadata.type, "code");
+  assert.equal(chunks[0]!.metadata.language, "typescript");
+  assert.equal(chunks[0]!.metadata.source, "auth.ts");
+  assert.equal(chunks[0]!.metadata.start_line, 1);
+  assert.equal(chunks[0]!.metadata.chunk_index, 0);
+  if (chunks.length > 1) assert.ok(Number(chunks[1]!.metadata.start_line) <= Number(chunks[0]!.metadata.end_line));
+});
+
+test("短代码不会被过度拆分，CRLF 会标准化", () => {
+  const chunks = new CodeSplitter().split("function one() {\r\n  return 1;\r\n}\r\n", { source: "one.js" });
+  assert.equal(chunks.length, 1);
+  assert.match(chunks[0]!.text, /function one\(\) \{\n  return 1;/);
+});
+
+test("Markdown 按标题拆分，但围栏代码中的标题不作为边界", () => {
+  const content = [
+    "# 总览",
+    "介绍内容。",
+    "## 示例",
+    "```ts",
+    "# 这不是标题",
+    "const value = 1;",
+    "```",
+    "示例说明。",
+    "## 结论",
+    "最终内容。",
+  ].join("\n");
+  const chunks = new MarkdownSplitter({ maxChars: 200 }).split(content, { source: "guide.md" });
+  assert.equal(chunks.length, 3);
+  assert.match(chunks[0]!.text, /^# 总览/);
+  assert.match(chunks[1]!.text, /# 这不是标题/);
+  assert.match(chunks[1]!.text, /示例说明/);
+  assert.match(chunks[2]!.text, /^## 结论/);
+  assert.equal(chunks[1]!.metadata.type, "markdown");
+});
+
+test("纯文本按段落合并并限制块大小，工厂按扩展名选择分块器", () => {
+  const chunks = new TextSplitter({ maxChars: 15 }).split("第一段内容。\n\n第二段内容。\n\n第三段内容。", { source: "notes.txt" });
+  assert.ok(chunks.length >= 2);
+  assert.ok(chunks.every((chunk) => chunk.text.length <= 15));
+  assert.equal(createChunker("main.ts").constructor, CodeSplitter);
+  assert.equal(createChunker("README.md").constructor, MarkdownSplitter);
+  assert.equal(createChunker("notes.txt").constructor, TextSplitter);
+});
+
+test("分块来源和参数错误会被明确拒绝", () => {
+  assert.throws(() => new CodeSplitter({ overlapLines: -1 }), /overlapLines/);
+  assert.throws(() => new MarkdownSplitter().split("内容", {}), /source/);
+});

--- a/packages/runtime-ts/tests/chunking.test.ts
+++ b/packages/runtime-ts/tests/chunking.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { CodeSplitter, MarkdownSplitter, TextSplitter, createChunker } from "../src/chunking/index.js";
+import { CodeSplitter, MarkdownSplitter, TextSplitter, createChunker, extractSymbols } from "../src/chunking/index.js";
 
 test("代码分块保留声明边界、行号和语言元数据", () => {
   const content = [
@@ -23,7 +23,24 @@ test("代码分块保留声明边界、行号和语言元数据", () => {
   assert.equal(chunks[0]!.metadata.source, "auth.ts");
   assert.equal(chunks[0]!.metadata.start_line, 1);
   assert.equal(chunks[0]!.metadata.chunk_index, 0);
+  assert.match(String(chunks.find((chunk) => chunk.text.includes("authenticate"))?.metadata.symbol), /authenticate/);
+  assert.match(String(chunks.find((chunk) => chunk.text.includes("compactContext"))?.metadata.symbol), /compactContext/);
   if (chunks.length > 1) assert.ok(Number(chunks[1]!.metadata.start_line) <= Number(chunks[0]!.metadata.end_line));
+});
+
+test("代码符号提取支持常见语言声明", () => {
+  const symbols = extractSymbols([
+    "export class AuthService {}",
+    "def load_profile(value):",
+    "func checkAccess() {}",
+    "pub fn compact_context() {}",
+  ].join("\n"));
+  assert.deepEqual(symbols, [
+    { name: "AuthService", kind: "class" },
+    { name: "load_profile", kind: "python_function" },
+    { name: "checkAccess", kind: "go_function" },
+    { name: "compact_context", kind: "rust_function" },
+  ]);
 });
 
 test("短代码不会被过度拆分，CRLF 会标准化", () => {

--- a/packages/runtime-ts/tests/embedding.test.ts
+++ b/packages/runtime-ts/tests/embedding.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LocalEmbedder, createTransformersEmbedder, type EmbeddingModel } from "../src/embedding/index.js";
+
+function createEmbedder(loadModel: () => Promise<EmbeddingModel>) {
+  return new LocalEmbedder({ name: "test-model", dimensions: 2, maxTokens: 128, loadModel });
+}
+
+test("空批次不会加载模型，embedQuery 复用批量接口", async () => {
+  let loads = 0;
+  const embedder = createEmbedder(async () => {
+    loads += 1;
+    return { embed: async (texts) => texts.map((text) => [text.length, 1]) };
+  });
+  assert.deepEqual(await embedder.embed([]), []);
+  assert.equal(loads, 0);
+  assert.deepEqual(await embedder.embedQuery("abc"), [3, 1]);
+  assert.equal(loads, 1);
+  await assert.rejects(embedder.embedQuery("   "), /不能为空/);
+});
+
+test("并发首次调用只加载一次模型，并校验模型返回的向量", async () => {
+  let loads = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const embedder = createEmbedder(async () => {
+    loads += 1;
+    await gate;
+    return { embed: async (texts) => texts.map(() => [1, 0]) };
+  });
+  const first = embedder.embed(["a"]);
+  const second = embedder.embed(["b"]);
+  await Promise.resolve();
+  assert.equal(loads, 1);
+  release();
+  assert.deepEqual(await Promise.all([first, second]), [[[1, 0]], [[1, 0]]]);
+});
+
+test("模型加载失败会传递给调用者，后续调用可以重试", async () => {
+  let loads = 0;
+  const embedder = createEmbedder(async () => {
+    loads += 1;
+    if (loads === 1) throw new Error("模型加载失败");
+    return { embed: async () => [[0, 1]] };
+  });
+  await assert.rejects(embedder.embed(["第一次"]), /模型加载失败/);
+  assert.deepEqual(await embedder.embed(["第二次"]), [[0, 1]]);
+  assert.equal(loads, 2);
+});
+
+test("模型返回数量、维度或数值非法时失败", async () => {
+  const wrongCount = createEmbedder(async () => ({ embed: async () => [] }));
+  await assert.rejects(wrongCount.embed(["文本"]), /期望 1 个/);
+  const wrongDimension = createEmbedder(async () => ({ embed: async () => [[1]] }));
+  await assert.rejects(wrongDimension.embed(["文本"]), /维度错误/);
+  const wrongValue = createEmbedder(async () => ({ embed: async () => [[1, Number.NaN]] }));
+  await assert.rejects(wrongValue.embed(["文本"]), /非有限/);
+});
+
+test("默认 transformers.js 适配器只声明配置，不在创建时下载模型", () => {
+  const embedder = createTransformersEmbedder();
+  assert.equal(embedder.name, "Xenova/all-MiniLM-L6-v2");
+  assert.equal(embedder.dimensions, 384);
+  assert.equal(embedder.maxTokens, 512);
+  assert.throws(() => createTransformersEmbedder({ batchSize: 0 }), /批大小/);
+});

--- a/packages/runtime-ts/tests/hybrid-search.test.ts
+++ b/packages/runtime-ts/tests/hybrid-search.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deduplicateBySource, mergeHybridResults } from "../src/retrieval/index.js";
+import type { LexicalSearchResult } from "../src/retrieval/lexical-index.js";
+import type { SearchResult } from "../src/vector-store/types.js";
+
+function semantic(source: string, chunkIndex: number, score: number, text: string): SearchResult {
+  return { score, record: { id: `${source}-${chunkIndex}`, vector: [1], text, metadata: { source, chunk_index: chunkIndex, type: "code" } } };
+}
+
+function lexical(source: string, chunkIndex: number, score: number, text: string): LexicalSearchResult {
+  return { key: `${source}#${chunkIndex}`, score, text, metadata: { source, chunk_index: chunkIndex, type: "code" } };
+}
+
+test("混合排序会用精确关键词命中纠正语义排序", () => {
+  const results = mergeHybridResults(
+    [semantic("src/generic.ts", 0, 1, "通用请求处理"), semantic("src/auth.ts", 0, 0.8, "checkPermission")],
+    [lexical("src/auth.ts", 0, 1, "checkPermission")],
+  );
+  assert.equal(results[0]!.record.metadata.source, "src/auth.ts");
+  assert.ok(results[0]!.lexical_score > 0);
+});
+
+test("混合结果按文件去重，只保留最高分块", () => {
+  const results = deduplicateBySource([
+    { ...mergeHybridResults([semantic("src/auth.ts", 0, 0.8, "one")], []).at(0)!, score: 0.8 },
+    { ...mergeHybridResults([semantic("src/auth.ts", 1, 0.9, "two")], []).at(0)!, score: 0.9 },
+    { ...mergeHybridResults([semantic("src/context.ts", 0, 0.7, "three")], []).at(0)!, score: 0.7 },
+  ], 2);
+  assert.deepEqual(results.map((result) => result.record.metadata.source), ["src/auth.ts", "src/context.ts"]);
+  assert.equal(results[0]!.record.text, "two");
+});

--- a/packages/runtime-ts/tests/lexical-index.test.ts
+++ b/packages/runtime-ts/tests/lexical-index.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LexicalIndex, tokenizeSearchText } from "../src/retrieval/index.js";
+import type { Chunk } from "../src/chunking/index.js";
+
+function chunk(source: string, text: string, metadata: Record<string, string | number> = {}): Chunk {
+  return { text, metadata: { source, type: "code", chunk_index: 0, ...metadata } };
+}
+
+test("关键词分词同时支持中文短语、下划线和驼峰标识符", () => {
+  const tokens = tokenizeSearchText("权限检查 checkPermission");
+  assert.ok(tokens.includes("权限检查"));
+  assert.ok(tokens.includes("权限"));
+  assert.ok(tokens.includes("checkpermission"));
+  assert.ok(tokens.includes("permission"));
+});
+
+test("关键词索引优先返回精确符号和短语命中", () => {
+  const index = new LexicalIndex();
+  index.replace("src/permissions.ts", [chunk("src/permissions.ts", "export function checkPermission() {}", { symbol: "checkPermission", symbol_kind: "function" })]);
+  index.replace("src/context.ts", [chunk("src/context.ts", "检查上下文是否需要压缩。", { symbol: "compactContext" })]);
+  const exact = index.search("checkPermission", 5);
+  assert.equal(exact[0]!.metadata.symbol, "checkPermission");
+  const chinese = index.search("上下文压缩", 5);
+  assert.equal(chinese[0]!.metadata.source, "src/context.ts");
+});
+
+test("关键词索引在排序前应用目录和类型过滤", () => {
+  const index = new LexicalIndex();
+  index.replace("src/auth.ts", [chunk("src/auth.ts", "权限检查 permission", { symbol: "checkPermission" })]);
+  index.replace("docs/auth.md", [{ ...chunk("docs/auth.md", "权限检查 permission", { type: "markdown" }), metadata: { source: "docs/auth.md", type: "markdown", chunk_index: 0 } }]);
+  const results = index.search("permission", 5, { pathPrefix: "src", fileType: "code" });
+  assert.equal(results.length, 1);
+  assert.equal(results[0]!.metadata.source, "src/auth.ts");
+});

--- a/packages/runtime-ts/tests/semantic-search.test.ts
+++ b/packages/runtime-ts/tests/semantic-search.test.ts
@@ -54,6 +54,26 @@ test("semantic_search 支持路径、类型、分数和空索引选项", async (
   } finally { await rm(root, { recursive: true, force: true }); }
 });
 
+test("semantic_search 混合排序会提升精确符号命中", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-semantic-hybrid-"));
+  try {
+    await writeFile(path.join(root, "generic.ts"), "export function handleRequest() { return true; }", "utf8");
+    await writeFile(path.join(root, "auth.ts"), "export function checkPermission() { return true; }", "utf8");
+    const embedder: Embedder = {
+      name: "hybrid-test",
+      dimensions: 2,
+      maxTokens: 128,
+      async embed(texts) { return texts.map((text) => text.includes("handleRequest") ? [1, 0] : [0.8, 0.6]); },
+      async embedQuery() { return [1, 0]; },
+    };
+    const tool = createSemanticSearchTool({ createEmbedder: () => embedder });
+    const result = await tool.invoke({ query: "checkPermission", top_k: 1 }, { workspace: new Workspace(root) });
+    assert.equal(result.ok, true);
+    const firstResult = result.output.split("\n")[3] ?? "";
+    assert.match(firstResult, /auth\.ts/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
 test("createWorkspaceTools 注册 semantic_search 且保持只读权限", () => {
   const tool = createWorkspaceTools().get("semantic_search");
   assert.ok(tool);

--- a/packages/runtime-ts/tests/semantic-search.test.ts
+++ b/packages/runtime-ts/tests/semantic-search.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createSemanticSearchTool, createWorkspaceTools } from "../src/tools.js";
+import type { Embedder } from "../src/embedding/index.js";
+import { Workspace } from "../src/workspace.js";
+
+function fixedEmbedder(loads: { count: number }): Embedder {
+  return {
+    name: "fixed",
+    dimensions: 2,
+    maxTokens: 128,
+    async embed(texts) { return texts.map((text) => text.includes("权限") || text.includes("permission") ? [1, 0] : [0, 1]); },
+    async embedQuery(text) { loads.count += 1; return text.includes("权限") ? [1, 0] : [0, 1]; },
+  };
+}
+
+test("semantic_search 首次调用自动索引并返回文件、行号和预览", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-semantic-tool-"));
+  try {
+    await writeFile(path.join(root, "auth.ts"), "export function checkPermission() {\n  // 权限检查\n  return true;\n}\n", "utf8");
+    await writeFile(path.join(root, "notes.md"), "# 说明\n普通内容。", "utf8");
+    const loads = { count: 0 };
+    const tool = createSemanticSearchTool({ createEmbedder: () => fixedEmbedder(loads) });
+    assert.equal(loads.count, 0);
+    const result = await tool.invoke({ query: "权限检查", top_k: 2 }, { workspace: new Workspace(root) });
+    assert.equal(result.ok, true);
+    assert.match(result.output, /Semantic search results/);
+    assert.match(result.output, /auth\.ts:\d+-\d+/);
+    assert.match(result.output, /checkPermission/);
+    assert.equal(loads.count, 1);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("semantic_search 支持路径、类型、分数和空索引选项", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-semantic-filter-"));
+  try {
+    await mkdir(path.join(root, "src"));
+    await writeFile(path.join(root, "src", "auth.ts"), "// 权限 permission\n", "utf8");
+    await writeFile(path.join(root, "README.md"), "权限说明", "utf8");
+    const tool = createSemanticSearchTool({ createEmbedder: () => fixedEmbedder({ count: 0 }) });
+    const context = { workspace: new Workspace(root) };
+    const noIndex = await tool.invoke({ query: "权限", auto_index: false }, context);
+    assert.match(noIndex.output, /index is empty/);
+    const filtered = await tool.invoke({ query: "权限", path: "src", file_type: "code", min_score: 0.9 }, context);
+    assert.equal(filtered.ok, true);
+    assert.match(filtered.output, /src[\\/]auth\.ts/);
+    assert.doesNotMatch(filtered.output, /README\.md/);
+    const noMatch = await tool.invoke({ query: "权限", min_score: 1.1 }, context);
+    assert.equal(noMatch.ok, false);
+    assert.match(noMatch.error ?? "", /min_score/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("createWorkspaceTools 注册 semantic_search 且保持只读权限", () => {
+  const tool = createWorkspaceTools().get("semantic_search");
+  assert.ok(tool);
+  assert.equal(tool.permission, "read_only");
+  assert.equal(tool.timeoutMs, 120_000);
+  assert.deepEqual(tool.schema.required, ["query"]);
+});

--- a/packages/runtime-ts/tests/vector-store.test.ts
+++ b/packages/runtime-ts/tests/vector-store.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MemoryVectorStore, cosineSimilarity } from "../src/vector-store/index.js";
+
+const records = [
+  { vector: [1, 0, 0], text: "认证密码校验", metadata: { source: "auth.ts", workspace_id: "one", kind: "code" } },
+  { vector: [0, 1, 0], text: "上下文压缩", metadata: { source: "context.ts", workspace_id: "one", kind: "code" } },
+  { vector: [Math.SQRT1_2, Math.SQRT1_2, 0], text: "登录错误处理", metadata: { source: "login.ts", workspace_id: "two", kind: "code" } },
+];
+
+test("内存向量库存储、排序和 topK", async () => {
+  const store = new MemoryVectorStore(3);
+  const ids = await store.add(records);
+  assert.equal(ids.length, 3);
+  assert.equal(new Set(ids).size, 3);
+  assert.equal(await store.count(), 3);
+
+  const results = await store.search([1, 0, 0], 2);
+  assert.deepEqual(results.map((result) => result.record.text), ["认证密码校验", "登录错误处理"]);
+  assert.equal(results[0]?.score, 1);
+  assert.equal(results.length, 2);
+  assert.deepEqual(await store.search([1, 0, 0], 0), []);
+});
+
+test("元数据过滤在排序前生效，并支持删除和清空", async () => {
+  const store = new MemoryVectorStore(3);
+  await store.add(records);
+  const filtered = await store.search([1, 0, 0], 10, { workspace_id: "one", kind: "code" });
+  assert.deepEqual(filtered.map((result) => result.record.text), ["认证密码校验", "上下文压缩"]);
+  assert.equal(await store.count({ workspace_id: "two" }), 1);
+  assert.equal(await store.delete({ workspace_id: "two" }), 1);
+  assert.equal(await store.count(), 2);
+  assert.equal(await store.delete(), 2);
+  assert.equal(await store.count(), 0);
+  await store.add([records[0]!]);
+  await store.clear();
+  assert.equal(await store.count(), 0);
+});
+
+test("向量维度、非有限值和 topK 参数会被明确校验", async () => {
+  const store = new MemoryVectorStore(3);
+  await assert.rejects(store.add([{ vector: [1, 0], text: "错误", metadata: {} }]), /维度错误/);
+  await assert.rejects(store.add([{ vector: [1, Number.NaN, 0], text: "错误", metadata: {} }]), /非有限/);
+  await assert.rejects(store.add([{ vector: [1, 0, 0], text: "错误", metadata: { invalid: [] as never } }]), /metadata/);
+  await assert.rejects(store.search([1, 0], 1), /维度错误/);
+  await assert.rejects(store.search([1, 0, 0], 1.5), /topK/);
+});
+
+test("零向量查询不会产生 NaN，分数相同时保持插入顺序", async () => {
+  const store = new MemoryVectorStore(3);
+  await store.add([
+    { vector: [0, 0, 0], text: "先加入", metadata: {} },
+    { vector: [0, 0, 0], text: "后加入", metadata: {} },
+  ]);
+  const results = await store.search([0, 0, 0], 10);
+  assert.deepEqual(results.map((result) => result.record.text), ["先加入", "后加入"]);
+  assert.ok(results.every((result) => Number.isFinite(result.score)));
+  assert.equal(cosineSimilarity([1, 0, 0], [0, 0, 0]), 0);
+  assert.ok(Number.isFinite(cosineSimilarity([Number.MAX_VALUE, 0, 0], [Number.MAX_VALUE, 0, 0])));
+});

--- a/packages/runtime-ts/tests/workspace-indexer.test.ts
+++ b/packages/runtime-ts/tests/workspace-indexer.test.ts
@@ -30,7 +30,7 @@ test("索引单文件时会分块、携带路径上下文并保存元数据", as
     const indexer = new WorkspaceIndexer(root, createEmbedder(calls), store);
     const count = await indexer.indexFile("auth.ts");
     assert.equal(count, 1);
-    assert.match(calls[0]![0]!, /^auth\.ts\n\n/);
+    assert.match(calls[0]![0]!, /^auth\.ts\n符号：checkPermission\n符号类型：function\n\n/);
     const result = await store.search([0, 1], 1);
     assert.equal(result[0]!.record.metadata.source, "auth.ts");
     assert.equal(result[0]!.record.metadata.workspace_id, root);

--- a/packages/runtime-ts/tests/workspace-indexer.test.ts
+++ b/packages/runtime-ts/tests/workspace-indexer.test.ts
@@ -38,6 +38,20 @@ test("索引单文件时会分块、携带路径上下文并保存元数据", as
   } finally { await rm(root, { recursive: true, force: true }); }
 });
 
+test("索引完成后通知观察者，嵌入失败时不提前替换观察结果", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-observer-"));
+  try {
+    await writeFile(path.join(root, "auth.ts"), "export function checkPermission() { return true; }", "utf8");
+    const observed: Array<[string, number]> = [];
+    const store = new MemoryVectorStore(2);
+    const indexer = new WorkspaceIndexer(root, createEmbedder(), store, (source, chunks) => observed.push([source, chunks.length]));
+    await indexer.indexFile("auth.ts");
+    await writeFile(path.join(root, "auth.ts"), "", "utf8");
+    await indexer.indexFile("auth.ts");
+    assert.deepEqual(observed, [["auth.ts", 1], ["auth.ts", 0]]);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
 test("全量索引过滤噪音目录、扩展名和文件数量，并报告进度", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-all-"));
   try {

--- a/packages/runtime-ts/tests/workspace-indexer.test.ts
+++ b/packages/runtime-ts/tests/workspace-indexer.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { WorkspaceIndexer } from "../src/indexing/index.js";
+import type { Embedder } from "../src/embedding/index.js";
+import { MemoryVectorStore } from "../src/vector-store/index.js";
+
+const execFileAsync = promisify(execFile);
+
+function createEmbedder(calls: string[][] = []): Embedder {
+  return {
+    name: "test",
+    dimensions: 2,
+    maxTokens: 128,
+    async embed(texts) { calls.push(texts); return texts.map((text) => text.includes("权限") ? [1, 0] : [0, 1]); },
+    async embedQuery() { return [1, 0]; },
+  };
+}
+
+test("索引单文件时会分块、携带路径上下文并保存元数据", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-indexer-"));
+  try {
+    await writeFile(path.join(root, "auth.ts"), "export function checkPermission() {\n  return true;\n}\n", "utf8");
+    const calls: string[][] = [];
+    const store = new MemoryVectorStore(2);
+    const indexer = new WorkspaceIndexer(root, createEmbedder(calls), store);
+    const count = await indexer.indexFile("auth.ts");
+    assert.equal(count, 1);
+    assert.match(calls[0]![0]!, /^auth\.ts\n\n/);
+    const result = await store.search([0, 1], 1);
+    assert.equal(result[0]!.record.metadata.source, "auth.ts");
+    assert.equal(result[0]!.record.metadata.workspace_id, root);
+    assert.equal(result[0]!.record.metadata.start_line, 1);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("全量索引过滤噪音目录、扩展名和文件数量，并报告进度", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-all-"));
+  try {
+    await mkdir(path.join(root, "node_modules"));
+    await writeFile(path.join(root, "one.ts"), "const one = 1;", "utf8");
+    await writeFile(path.join(root, "two.md"), "# two\nbody", "utf8");
+    await writeFile(path.join(root, "ignored.bin"), "binary", "utf8");
+    await writeFile(path.join(root, "node_modules", "bad.ts"), "const bad = 1;", "utf8");
+    const progress: Array<[number, number]> = [];
+    const store = new MemoryVectorStore(2);
+    const indexer = new WorkspaceIndexer(root, createEmbedder(), store);
+    const result = await indexer.indexAll({ extensions: ["ts", "md"], maxFiles: 1, onProgress: (indexed, total) => progress.push([indexed, total]) });
+    assert.equal(result.files_indexed, 1);
+    assert.equal(await store.count(), 1);
+    assert.deepEqual(progress, [[0, 1], [1, 1]]);
+    assert.equal(indexer.shouldIndex("node_modules/bad.ts"), false);
+    assert.equal(indexer.shouldIndex("ignored.bin"), false);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("全量索引遵守 Git 的 .gitignore 规则", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-gitignore-"));
+  try {
+    await execFileAsync("git", ["init", "--quiet", root]);
+    await writeFile(path.join(root, ".gitignore"), "private.ts\nignored-dir/\n", "utf8");
+    await mkdir(path.join(root, "ignored-dir"));
+    await writeFile(path.join(root, "private.ts"), "const privateValue = 1;", "utf8");
+    await writeFile(path.join(root, "public.ts"), "const publicValue = 1;", "utf8");
+    await writeFile(path.join(root, "ignored-dir", "nested.ts"), "const nestedValue = 1;", "utf8");
+    const store = new MemoryVectorStore(2);
+    const indexer = new WorkspaceIndexer(root, createEmbedder(), store);
+    const result = await indexer.indexAll();
+    assert.equal(result.files_indexed, 1);
+    assert.equal((await store.search([0, 1], 5))[0]!.record.metadata.source, "public.ts");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("重建文件先嵌入后替换旧记录，删除文件时增量更新会清理索引", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-update-"));
+  try {
+    const file = path.join(root, "note.txt");
+    await writeFile(file, "旧内容", "utf8");
+    const store = new MemoryVectorStore(2);
+    const indexer = new WorkspaceIndexer(root, createEmbedder(), store);
+    await indexer.indexFile("note.txt");
+    assert.equal(await store.count(), 1);
+    await writeFile(file, "新内容", "utf8");
+    await indexer.updateIndex(["note.txt"]);
+    assert.equal(await store.count(), 1);
+    assert.equal((await store.search([0, 1], 1))[0]!.record.text, "新内容");
+    await rm(file);
+    await indexer.updateIndex(["note.txt"]);
+    assert.equal(await store.count(), 0);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("索引器拒绝工作区外路径和过大文件", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-boundary-"));
+  try {
+    const indexer = new WorkspaceIndexer(root, createEmbedder(), new MemoryVectorStore(2));
+    await assert.rejects(indexer.indexFile("../outside.ts"), /路径不在工作区内|Path escapes workspace/);
+    await writeFile(path.join(root, "large.ts"), "x".repeat(1_048_577), "utf8");
+    await assert.rejects(indexer.indexFile("large.ts"), /文件过大/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("嵌入失败时保留旧索引，避免索引被替换为空", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-index-failure-"));
+  try {
+    const file = path.join(root, "stable.ts");
+    await writeFile(file, "旧内容", "utf8");
+    const store = new MemoryVectorStore(2);
+    const working = new WorkspaceIndexer(root, createEmbedder(), store);
+    await working.indexFile("stable.ts");
+    const failing: Embedder = { ...createEmbedder(), async embed() { throw new Error("模型暂时不可用"); } };
+    const failed = new WorkspaceIndexer(root, failing, store);
+    await writeFile(file, "新内容", "utf8");
+    await assert.rejects(failed.indexFile("stable.ts"), /模型暂时不可用/);
+    assert.equal(await store.count(), 1);
+    assert.equal((await store.search([0, 1], 1))[0]!.record.text, "旧内容");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});

--- a/scripts/eval-semantic-search.ts
+++ b/scripts/eval-semantic-search.ts
@@ -1,0 +1,116 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createTransformersEmbedder } from "../packages/runtime-ts/src/embedding/index.js";
+import { MemoryVectorStore } from "../packages/runtime-ts/src/vector-store/index.js";
+import { createChunker } from "../packages/runtime-ts/src/chunking/index.js";
+
+type Sample = { path: string; text: string };
+type QueryCase = { query: string; expected: string[] };
+type EvalRow = {
+  query: string;
+  expected: string[];
+  results: Array<{ path: string | number | boolean; score: number }>;
+  recall_at_1: number;
+  recall_at_3: number;
+  recall_at_5: number;
+  reciprocal_rank: number;
+  latency_ms: number;
+};
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const samplePaths = [
+  "packages/runtime-ts/src/context.ts",
+  "packages/runtime-ts/src/permissions.ts",
+  "packages/runtime-ts/src/subagent.ts",
+  "packages/runtime-ts/src/workflow.ts",
+  "packages/runtime-ts/src/tools.ts",
+  "packages/runtime-ts/src/memory.ts",
+];
+
+const queryCases: QueryCase[] = [
+  { query: "上下文压缩在什么条件下触发？", expected: ["packages/runtime-ts/src/context.ts"] },
+  { query: "后台子 Agent 如何启动、取消并获取结果？", expected: ["packages/runtime-ts/src/subagent.ts"] },
+  { query: "工具调用前如何检查权限并处理拒绝？", expected: ["packages/runtime-ts/src/permissions.ts", "packages/runtime-ts/src/tools.ts"] },
+];
+
+async function loadSamples(): Promise<Sample[]> {
+  return Promise.all(samplePaths.map(async (relativePath) => ({
+    path: relativePath,
+    text: await readFile(path.join(repoRoot, relativePath), "utf8"),
+  })));
+}
+
+function recallAt(results: string[], expected: readonly string[], k: number): number {
+  const returned = new Set(results.slice(0, k));
+  return expected.some((item) => returned.has(item)) ? 1 : 0;
+}
+
+function reciprocalRank(results: string[], expected: readonly string[]): number {
+  const expectedSet = new Set(expected);
+  const rank = results.findIndex((item) => expectedSet.has(item));
+  return rank < 0 ? 0 : 1 / (rank + 1);
+}
+
+async function main(): Promise<void> {
+  const started = performance.now();
+  const samples = await loadSamples();
+  const embedder = createTransformersEmbedder();
+  const store = new MemoryVectorStore(embedder.dimensions);
+  const chunks = samples.flatMap((sample) => createChunker(sample.path, { maxChars: 3_500, overlapLines: 20 }).split(sample.text, { source: sample.path }));
+  const vectors = await embedder.embed(chunks.map((chunk) => chunk.text));
+  await store.add(chunks.map((chunk, index) => ({
+    vector: vectors[index]!,
+    text: chunk.text,
+    metadata: Object.fromEntries(Object.entries(chunk.metadata).filter(([, value]) => value !== undefined)) as Record<string, string | number | boolean>,
+  })));
+  const indexMs = performance.now() - started;
+
+  const rows: EvalRow[] = [];
+  for (const testCase of queryCases) {
+    const queryStarted = performance.now();
+    const queryVector = await embedder.embedQuery(testCase.query);
+    const chunkResults = await store.search(queryVector, 10);
+    const bestBySource = new Map<string, (typeof chunkResults)[number]>();
+    for (const result of chunkResults) {
+      const source = String(result.record.metadata.source);
+      const previous = bestBySource.get(source);
+      if (!previous || result.score > previous.score) bestBySource.set(source, result);
+    }
+    const results = [...bestBySource.values()].sort((left, right) => right.score - left.score).slice(0, 5);
+    const queryMs = performance.now() - queryStarted;
+    const paths = results.map((result) => String(result.record.metadata.source));
+    rows.push({
+      query: testCase.query,
+      expected: testCase.expected,
+      results: results.map((result) => ({ path: result.record.metadata.source, score: Number(result.score.toFixed(4)) })),
+      recall_at_1: recallAt(paths, testCase.expected, 1),
+      recall_at_3: recallAt(paths, testCase.expected, 3),
+      recall_at_5: recallAt(paths, testCase.expected, 5),
+      reciprocal_rank: reciprocalRank(paths, testCase.expected),
+      latency_ms: Number(queryMs.toFixed(2)),
+    });
+  }
+
+  const mean = (key: "recall_at_1" | "recall_at_3" | "recall_at_5" | "reciprocal_rank" | "latency_ms") => rows.reduce((sum, row) => sum + row[key], 0) / rows.length;
+  console.log(JSON.stringify({
+    model: embedder.name,
+    dimensions: embedder.dimensions,
+    sample_count: samples.length,
+    chunk_count: chunks.length,
+    index_ms: Number(indexMs.toFixed(2)),
+    summary: {
+      recall_at_1: Number(mean("recall_at_1").toFixed(4)),
+      recall_at_3: Number(mean("recall_at_3").toFixed(4)),
+      recall_at_5: Number(mean("recall_at_5").toFixed(4)),
+      mrr: Number(mean("reciprocal_rank").toFixed(4)),
+      query_latency_ms: Number(mean("latency_ms").toFixed(2)),
+    },
+    queries: rows,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/eval-semantic-search.ts
+++ b/scripts/eval-semantic-search.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { createTransformersEmbedder } from "../packages/runtime-ts/src/embedding/index.js";
 import { MemoryVectorStore } from "../packages/runtime-ts/src/vector-store/index.js";
 import { createChunker } from "../packages/runtime-ts/src/chunking/index.js";
+import { formatEmbeddingText } from "../packages/runtime-ts/src/indexing/workspace-indexer.js";
 
 type Sample = { path: string; text: string };
 type QueryCase = { query: string; expected: string[] };
@@ -58,7 +59,7 @@ async function main(): Promise<void> {
   const embedder = createTransformersEmbedder();
   const store = new MemoryVectorStore(embedder.dimensions);
   const chunks = samples.flatMap((sample) => createChunker(sample.path, { maxChars: 3_500, overlapLines: 20 }).split(sample.text, { source: sample.path }));
-  const vectors = await embedder.embed(chunks.map((chunk) => chunk.text));
+  const vectors = await embedder.embed(chunks.map((chunk) => formatEmbeddingText(String(chunk.metadata.source), chunk)));
   await store.add(chunks.map((chunk, index) => ({
     vector: vectors[index]!,
     text: chunk.text,

--- a/scripts/eval-semantic-search.ts
+++ b/scripts/eval-semantic-search.ts
@@ -5,6 +5,7 @@ import { createTransformersEmbedder } from "../packages/runtime-ts/src/embedding
 import { MemoryVectorStore } from "../packages/runtime-ts/src/vector-store/index.js";
 import { createChunker } from "../packages/runtime-ts/src/chunking/index.js";
 import { formatEmbeddingText } from "../packages/runtime-ts/src/indexing/workspace-indexer.js";
+import { deduplicateBySource, LexicalIndex, mergeHybridResults } from "../packages/runtime-ts/src/retrieval/index.js";
 
 type Sample = { path: string; text: string };
 type QueryCase = { query: string; expected: string[] };
@@ -65,20 +66,19 @@ async function main(): Promise<void> {
     text: chunk.text,
     metadata: Object.fromEntries(Object.entries(chunk.metadata).filter(([, value]) => value !== undefined)) as Record<string, string | number | boolean>,
   })));
+  const lexical = new LexicalIndex();
+  for (const sample of samples) {
+    lexical.replace(sample.path, chunks.filter((chunk) => chunk.metadata.source === sample.path));
+  }
   const indexMs = performance.now() - started;
 
   const rows: EvalRow[] = [];
   for (const testCase of queryCases) {
     const queryStarted = performance.now();
     const queryVector = await embedder.embedQuery(testCase.query);
-    const chunkResults = await store.search(queryVector, 10);
-    const bestBySource = new Map<string, (typeof chunkResults)[number]>();
-    for (const result of chunkResults) {
-      const source = String(result.record.metadata.source);
-      const previous = bestBySource.get(source);
-      if (!previous || result.score > previous.score) bestBySource.set(source, result);
-    }
-    const results = [...bestBySource.values()].sort((left, right) => right.score - left.score).slice(0, 5);
+    const chunkResults = await store.search(queryVector, await store.count());
+    const lexicalResults = lexical.search(testCase.query, await store.count());
+    const results = deduplicateBySource(mergeHybridResults(chunkResults, lexicalResults), 5);
     const queryMs = performance.now() - queryStarted;
     const paths = results.map((result) => String(result.record.metadata.source));
     rows.push({


### PR DESCRIPTION
Part of #145
## Summary

实现 Issue #145 第一阶段的语义搜索基础设施。增加本地 Embedding、代码/Markdown 分块、内存向量库、工作区索引器和 `semantic_search` 工具，为后续会话记忆增强提供基础。

## Behavior

- 新增只读 `semantic_search` 工具。
- 支持 `query`、`top_k`、路径、文件类型、最低分数和自动索引。
- 使用 `Xenova/all-MiniLM-L6-v2` 生成本地向量。
- 支持代码、Markdown 和文本文件索引。
- npm 发布包将 `transformers.js` 作为目标平台外部依赖，避免捆绑原生 `.node` 文件。
- 不修改 Agent 主循环和会话记忆协议。

## Validation

```text
npm run typecheck                 通过
npm test                          232 项通过；首次运行有 1 次 Windows EPERM 竞态，单独重跑通过
npx tsx --test packages/runtime-ts/tests/npm-package.test.ts packages/runtime-ts/tests/phase2-tools.test.ts
                                  14 项通过
npm run eval:semantic             Recall@3=1.0，Recall@5=1.0
node npm/sztucode-tui/scripts/install.js
                                  通过