### PR TITLE
feat(search): persist semantic index incrementally

### DIFF
--- a/desktop/scripts/prepare-runtime.js
+++ b/desktop/scripts/prepare-runtime.js
@@ -78,7 +78,11 @@ for (const vipsVersion of await readdir(sharpVendor).catch(() => [])) {
 if (process.platform === "linux") {
   for (const file of await readdir(runtimeRoot)) {
     if (file.endsWith(".node")) {
-      const patched = spawnSync("patchelf", ["--set-rpath", "$ORIGIN", path.join(runtimeRoot, file)], { stdio: "inherit" });
+      const nativePath = path.join(runtimeRoot, file);
+      // .node 只是扩展名；只有 ELF 原生模块才能由 patchelf 修改 RPATH。
+      const header = readFileSync(nativePath).subarray(0, 4);
+      if (header.length < 4 || header[0] !== 0x7f || header[1] !== 0x45 || header[2] !== 0x4c || header[3] !== 0x46) continue;
+      const patched = spawnSync("patchelf", ["--set-rpath", "$ORIGIN", nativePath], { stdio: "inherit" });
       if (patched.status !== 0) throw new Error(`patchelf failed for ${file}`);
     }
   }

--- a/packages/runtime-ts/src/indexing/workspace-indexer.ts
+++ b/packages/runtime-ts/src/indexing/workspace-indexer.ts
@@ -39,6 +39,8 @@ export class WorkspaceIndexer {
   private readonly workspace: Workspace;
   private readonly workspaceId: string;
 
+  get workspaceRoot(): string { return this.workspace.root; }
+
   constructor(
     workspaceRoot: string,
     private readonly embedder: Embedder,
@@ -80,6 +82,8 @@ export class WorkspaceIndexer {
         ...chunk.metadata,
         source,
         workspace_id: this.workspaceId,
+        mtime_ms: fileStat.mtimeMs,
+        file_size: fileStat.size,
       } as Record<string, string | number | boolean>,
     })));
     await this.observer?.(source, chunks);
@@ -108,6 +112,16 @@ export class WorkspaceIndexer {
       }
     }
     return { files_indexed: filesIndexed, chunks_indexed: chunksIndexed };
+  }
+
+  /** 扫描当前工作区，返回符合索引规则且未被 Git 忽略的文件。 */
+  async discoverFiles(): Promise<string[]> {
+    const allFiles = await this.listFiles(this.workspace.root);
+    const candidates: string[] = [];
+    for (const file of allFiles) {
+      if (this.shouldIndex(file) && await this.isTextFile(file) && !(await this.isGitIgnored(file))) candidates.push(file);
+    }
+    return candidates;
   }
 
   async updateIndex(changedFiles: string[]): Promise<void> {

--- a/packages/runtime-ts/src/tools.ts
+++ b/packages/runtime-ts/src/tools.ts
@@ -14,8 +14,9 @@ import { SkillLoader } from "./skills.js";
 import { detectDocumentFormat } from "./document-parser/detect.js";
 import type { ParsedDocument } from "./document-parser/types.js";
 import { createTransformersEmbedder, type Embedder } from "./embedding/index.js";
+import type { Chunk } from "./chunking/index.js";
 import { WorkspaceIndexer } from "./indexing/index.js";
-import { MemoryVectorStore } from "./vector-store/index.js";
+import { JsonlVectorStore } from "./vector-store/index.js";
 import { deduplicateBySource, LexicalIndex, mergeHybridResults } from "./retrieval/index.js";
 
 export type { ToolPermission } from "./tools-types.js";
@@ -405,23 +406,34 @@ export interface SemanticSearchToolOptions {
 type SemanticIndexState = {
   embedder: Embedder;
   indexer: WorkspaceIndexer;
-  store: MemoryVectorStore;
+  store: JsonlVectorStore;
   lexical: LexicalIndex;
   indexPromise?: Promise<{ files_indexed: number; chunks_indexed: number }>;
 };
 
 /** 创建按工作区懒加载的语义搜索工具。 */
 export function createSemanticSearchTool(options: SemanticSearchToolOptions = {}): Tool {
-  const states = new Map<string, SemanticIndexState>();
-  const getState = (root: string): SemanticIndexState => {
+  const states = new Map<string, Promise<SemanticIndexState>>();
+  const getState = (root: string): Promise<SemanticIndexState> => {
     const existing = states.get(root);
     if (existing) return existing;
-    const embedder = options.createEmbedder?.() ?? createTransformersEmbedder();
-    const store = new MemoryVectorStore(embedder.dimensions);
-    const lexical = new LexicalIndex();
-    const state = { embedder, indexer: new WorkspaceIndexer(root, embedder, store, (source, chunks) => lexical.replace(source, chunks)), store, lexical };
-    states.set(root, state);
-    return state;
+    const statePromise = (async () => {
+      const embedder = options.createEmbedder?.() ?? createTransformersEmbedder();
+      const store = await JsonlVectorStore.open(path.join(root, ".sztu", "vector", "semantic-index.jsonl"), embedder.dimensions, "jsonl", { embedderName: embedder.name });
+      const lexical = new LexicalIndex();
+      const chunksBySource = new Map<string, Array<{ text: string; metadata: Record<string, string | number | boolean> }>>();
+      for (const record of store.exportRecords()) {
+        const source = String(record.metadata.source ?? "");
+        const chunks = chunksBySource.get(source) ?? [];
+        chunks.push({ text: record.text, metadata: { ...record.metadata } });
+        chunksBySource.set(source, chunks);
+      }
+      for (const [source, chunks] of chunksBySource) lexical.replace(source, chunks as Chunk[]);
+      return { embedder, indexer: new WorkspaceIndexer(root, embedder, store, (source, chunks) => lexical.replace(source, chunks)), store, lexical };
+    })();
+    states.set(root, statePromise);
+    void statePromise.catch(() => states.delete(root));
+    return statePromise;
   };
 
   return {
@@ -454,13 +466,14 @@ export function createSemanticSearchTool(options: SemanticSearchToolOptions = {}
       if (relativePath.split("/").some((part) => part === "..")) return fail("path must stay inside the workspace", "schema_error");
 
       try {
-        const state = getState(context.workspace.root);
+        const state = await getState(context.workspace.root);
         const autoIndex = params.auto_index === undefined ? true : Boolean(params.auto_index);
         if (await state.store.count() === 0) {
           if (!autoIndex) return ok("Semantic index is empty. Set auto_index=true or build the index before searching.");
           state.indexPromise ??= state.indexer.indexAll().catch((error) => { state.indexPromise = undefined; throw error; });
           await state.indexPromise;
         }
+        await refreshSemanticIndex(state);
         const queryVector = await state.embedder.embedQuery(query);
         const filter = { pathPrefix: relativePath, fileType: fileType as "code" | "markdown" | "document" | "any" };
         const recordCount = await state.store.count();
@@ -490,6 +503,30 @@ export function createSemanticSearchTool(options: SemanticSearchToolOptions = {}
       }
     },
   };
+}
+
+/** 检查已持久化文件的轻量元数据，只增量重建发生变化的文件。 */
+async function refreshSemanticIndex(state: SemanticIndexState): Promise<void> {
+  const sources = new Map<string, Record<string, string | number | boolean>>();
+  for (const record of state.store.exportRecords()) {
+    const source = String(record.metadata.source ?? "");
+    if (source && !sources.has(source)) sources.set(source, record.metadata);
+  }
+  const changed: string[] = [];
+  for (const [source, metadata] of sources) {
+    try {
+      const file = await stat(path.join(state.indexer.workspaceRoot, source));
+      if (!file.isFile() || Number(metadata.mtime_ms) !== file.mtimeMs || Number(metadata.file_size) !== file.size) changed.push(source);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") changed.push(source);
+      else throw error;
+    }
+  }
+  const indexedSources = new Set(sources.keys());
+  for (const source of await state.indexer.discoverFiles()) {
+    if (!indexedSources.has(source)) changed.push(source);
+  }
+  if (changed.length > 0) await state.indexer.updateIndex([...new Set(changed)]);
 }
 
 export function createPlanTools(events: EventBus, runId: string, sessionId = "", tasksDir = path.join(process.env.SZTU_DATA_DIR ?? path.join(process.env.USERPROFILE ?? process.env.HOME ?? process.cwd(), ".sztu"), "runs", runId.replace(/[^A-Za-z0-9_.-]/g, "_"), "tasks")): Tool[] {

--- a/packages/runtime-ts/src/vector-store/index.ts
+++ b/packages/runtime-ts/src/vector-store/index.ts
@@ -1,2 +1,3 @@
 export * from "./types.js";
 export * from "./memory-store.js";
+export * from "./jsonl-store.js";

--- a/packages/runtime-ts/src/vector-store/jsonl-store.ts
+++ b/packages/runtime-ts/src/vector-store/jsonl-store.ts
@@ -1,0 +1,100 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { MemoryVectorStore } from "./memory-store.js";
+import type { MetadataValue, SearchResult, VectorRecord, VectorStore } from "./types.js";
+
+const FORMAT_VERSION = 1;
+
+type JsonlHeader = {
+  type: "header";
+  format_version: number;
+  dimensions: number;
+  embedder_name?: string;
+};
+
+type JsonlLine = JsonlHeader | VectorRecord;
+
+export interface JsonlVectorStoreOptions {
+  embedderName?: string;
+}
+
+/** 带 JSONL 持久化的线性向量存储，检索仍由内存索引完成。 */
+export class JsonlVectorStore implements VectorStore {
+  readonly name: string;
+  readonly dimensions: number;
+  private readonly memory: MemoryVectorStore;
+  private readonly filePath: string;
+  private readonly embedderName?: string;
+
+  private constructor(filePath: string, dimensions: number, name: string, options: JsonlVectorStoreOptions) {
+    this.filePath = path.resolve(filePath);
+    this.name = name;
+    this.dimensions = dimensions;
+    this.embedderName = options.embedderName;
+    this.memory = new MemoryVectorStore(dimensions, name);
+  }
+
+  static async open(filePath: string, dimensions: number, name = "jsonl", options: JsonlVectorStoreOptions = {}): Promise<JsonlVectorStore> {
+    const store = new JsonlVectorStore(filePath, dimensions, name, options);
+    try {
+      await store.load();
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    return store;
+  }
+
+  async add(records: Omit<VectorRecord, "id">[]): Promise<string[]> {
+    const ids = await this.memory.add(records);
+    await this.persist();
+    return ids;
+  }
+
+  async delete(filter?: Partial<Record<string, MetadataValue>>): Promise<number> {
+    const deleted = await this.memory.delete(filter);
+    if (deleted > 0) await this.persist();
+    return deleted;
+  }
+
+  search(query: number[], topK: number, filter?: Partial<Record<string, MetadataValue>>): Promise<SearchResult[]> {
+    return this.memory.search(query, topK, filter);
+  }
+
+  count(filter?: Partial<Record<string, MetadataValue>>): Promise<number> {
+    return this.memory.count(filter);
+  }
+
+  exportRecords(): VectorRecord[] {
+    return this.memory.exportRecords();
+  }
+
+  async clear(): Promise<void> {
+    await this.memory.clear();
+    await this.persist();
+  }
+
+  private async load(): Promise<void> {
+    const text = await readFile(this.filePath, "utf8");
+    const lines = text.split(/\r?\n/u).filter((line) => line.trim());
+    if (lines.length === 0) return;
+    const header = JSON.parse(lines[0]!) as Partial<JsonlHeader>;
+    if (header.type !== "header" || header.format_version !== FORMAT_VERSION || header.dimensions !== this.dimensions) {
+      throw new Error(`向量索引格式或维度不匹配：${this.filePath}`);
+    }
+    if (this.embedderName && header.embedder_name && header.embedder_name !== this.embedderName) {
+      throw new Error(`向量索引模型不匹配：文件使用 ${header.embedder_name}，当前使用 ${this.embedderName}`);
+    }
+    const records = lines.slice(1).map((line) => JSON.parse(line) as VectorRecord);
+    this.memory.importRecords(records);
+  }
+
+  private async persist(): Promise<void> {
+    const directory = path.dirname(this.filePath);
+    await mkdir(directory, { recursive: true });
+    const header: JsonlHeader = { type: "header", format_version: FORMAT_VERSION, dimensions: this.dimensions, ...(this.embedderName ? { embedder_name: this.embedderName } : {}) };
+    const lines = [header, ...this.memory.exportRecords()].map((line: JsonlLine) => JSON.stringify(line));
+    const temporaryPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(temporaryPath, `${lines.join("\n")}\n`, "utf8");
+    await rename(temporaryPath, this.filePath);
+  }
+}

--- a/packages/runtime-ts/src/vector-store/memory-store.ts
+++ b/packages/runtime-ts/src/vector-store/memory-store.ts
@@ -89,6 +89,21 @@ export class MemoryVectorStore implements VectorStore {
     this.records.clear();
   }
 
+  /** 导出稳定副本，供持久化存储保存索引内容。 */
+  exportRecords(): VectorRecord[] {
+    return [...this.records.values()].map(({ record }) => this.cloneRecord(record));
+  }
+
+  /** 从持久化文件恢复记录；恢复前会清空当前内容。 */
+  importRecords(records: readonly VectorRecord[]): void {
+    this.records.clear();
+    this.nextSequence = 0;
+    for (const record of records) {
+      this.validateRecord(record);
+      this.records.set(record.id, { sequence: this.nextSequence++, record: this.cloneRecord(record) });
+    }
+  }
+
   private matches(metadata: Record<string, MetadataValue>, filter?: Partial<Record<string, MetadataValue>>): boolean {
     if (!filter) return true;
     return Object.entries(filter).every(([key, value]) => metadata[key] === value);

--- a/packages/runtime-ts/tests/offload.test.ts
+++ b/packages/runtime-ts/tests/offload.test.ts
@@ -33,9 +33,9 @@ test("agent loop offloads tool output and can recover it with read_ref", async (
     const provider: ModelProvider = { complete: async (messages) => {
       call += 1;
       if (call === 1) return { text: "", tool_calls: [{ id: "read-1", name: "read_file", input: { path: "large.txt" } }], stop_reason: "tool_use" };
-      const last = String(messages.at(-1)?.content ?? "");
-      if (call === 2) { assert.match(last, /\[上下文卸载:/); refPath = /\[上下文卸载: ([^\]]+)\]/.exec(last)?.[1] ?? ""; return { text: "", tool_calls: [{ id: "ref-1", name: "read_ref", input: { ref_path: refPath, limit: 8000 } }], stop_reason: "tool_use" }; }
-      recovered = last; return { text: "done", tool_calls: [], stop_reason: "end_turn" };
+      const contents = messages.map((message) => String(message.content ?? ""));
+      if (call === 2) { const placeholder = contents.find((content) => content.includes("[上下文卸载:")) ?? ""; assert.match(placeholder, /\[上下文卸载:/); refPath = /\[上下文卸载: ([^\]]+)\]/.exec(placeholder)?.[1] ?? ""; return { text: "", tool_calls: [{ id: "ref-1", name: "read_ref", input: { ref_path: refPath, limit: 8000 } }], stop_reason: "tool_use" }; }
+      recovered = contents.find((content) => content.includes("[ref page:")) ?? contents.at(-1) ?? ""; return { text: "done", tool_calls: [], stop_reason: "end_turn" };
     } };
     const loop = new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, new EventBus(path.join(root, "events.jsonl")), { check: async () => true }, { offloadRoot: path.join(root, "run-data"), offloadMinChars: 100 });
     assert.equal((await loop.run("run-1", "read it", 4)).text, "done");
@@ -55,10 +55,11 @@ test("agent loop falls back to bounded context when offload storage fails", asyn
   try {
     const blocked = path.join(root, "not-a-directory"); await writeFile(blocked, "file");
     let calls = 0; let observed = "";
-    const provider: ModelProvider = { complete: async (messages) => { calls += 1; if (calls === 1) return { text: "", tool_calls: [{ id: "large", name: "read_file", input: { path: "large.txt" } }], stop_reason: "tool_use" }; observed = String(messages.at(-1)?.content ?? ""); return { text: "done", tool_calls: [], stop_reason: "end_turn" }; } };
+    const provider: ModelProvider = { complete: async (messages) => { calls += 1; if (calls === 1) return { text: "", tool_calls: [{ id: "large", name: "read_file", input: { path: "large.txt" } }], stop_reason: "tool_use" }; observed = messages.filter((message) => message.role === "tool").map((message) => String(message.content ?? "")).join("\n"); return { text: "done", tool_calls: [], stop_reason: "end_turn" }; } };
     await writeFile(path.join(root, "large.txt"), "x".repeat(20_000));
     const loop = new AgentLoop(provider, createWorkspaceTools(), { workspace: new Workspace(root) }, events, { check: async () => true }, { offloadRoot: blocked, offloadMinChars: 100 });
     assert.equal((await loop.run("fallback", "read it", 3)).text, "done");
-    assert.match(observed, /chars omitted/); assert.ok(observed.length <= 4_000);
+    const boundedToolResult = observed.includes("chars omitted") ? observed : "";
+    assert.match(boundedToolResult, /chars omitted/); assert.ok(boundedToolResult.length <= 4_000);
   } finally { await events.flush(); await rm(root, { recursive: true, force: true }); }
 });

--- a/packages/runtime-ts/tests/semantic-search.test.ts
+++ b/packages/runtime-ts/tests/semantic-search.test.ts
@@ -74,6 +74,52 @@ test("semantic_search 混合排序会提升精确符号命中", async () => {
   } finally { await rm(root, { recursive: true, force: true }); }
 });
 
+test("semantic_search 新实例会恢复 JSONL 索引并保留关键词检索", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-semantic-persist-"));
+  try {
+    await writeFile(path.join(root, "auth.ts"), "export function checkPermission() { return true; }", "utf8");
+    const first = createSemanticSearchTool({ createEmbedder: () => fixedEmbedder({ count: 0 }) });
+    const context = { workspace: new Workspace(root) };
+    assert.equal((await first.invoke({ query: "checkPermission" }, context)).ok, true);
+    const second = createSemanticSearchTool({ createEmbedder: () => fixedEmbedder({ count: 0 }) });
+    const restored = await second.invoke({ query: "checkPermission", auto_index: false }, context);
+    assert.equal(restored.ok, true);
+    assert.match(restored.output, /auth\.ts/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("semantic_search 会在文件变化后只更新对应索引", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-semantic-update-"));
+  try {
+    const file = path.join(root, "note.ts");
+    await writeFile(file, "const oldValue = true;", "utf8");
+    const tool = createSemanticSearchTool({ createEmbedder: () => fixedEmbedder({ count: 0 }) });
+    const context = { workspace: new Workspace(root) };
+    assert.equal((await tool.invoke({ query: "普通内容" }, context)).ok, true);
+    await writeFile(file, "const newValue = true;\n// 文件已经更新", "utf8");
+    const updated = await tool.invoke({ query: "普通内容" }, context);
+    assert.equal(updated.ok, true);
+    assert.match(updated.output, /newValue|文件已经更新/);
+    await rm(file);
+    const removed = await tool.invoke({ query: "普通内容" }, context);
+    assert.match(removed.output, /No semantic results/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("semantic_search 会发现索引建立后新增的文件", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-semantic-new-file-"));
+  try {
+    await writeFile(path.join(root, "first.ts"), "const first = true;", "utf8");
+    const tool = createSemanticSearchTool({ createEmbedder: () => fixedEmbedder({ count: 0 }) });
+    const context = { workspace: new Workspace(root) };
+    assert.equal((await tool.invoke({ query: "普通内容" }, context)).ok, true);
+    await writeFile(path.join(root, "second.ts"), "const second = true;\n// 新文件", "utf8");
+    const result = await tool.invoke({ query: "普通内容", top_k: 10 }, context);
+    assert.equal(result.ok, true);
+    assert.match(result.output, /second\.ts/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
 test("createWorkspaceTools 注册 semantic_search 且保持只读权限", () => {
   const tool = createWorkspaceTools().get("semantic_search");
   assert.ok(tool);

--- a/packages/runtime-ts/tests/vector-store.test.ts
+++ b/packages/runtime-ts/tests/vector-store.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
-import { MemoryVectorStore, cosineSimilarity } from "../src/vector-store/index.js";
+import { JsonlVectorStore, MemoryVectorStore, cosineSimilarity } from "../src/vector-store/index.js";
 
 const records = [
   { vector: [1, 0, 0], text: "认证密码校验", metadata: { source: "auth.ts", workspace_id: "one", kind: "code" } },
@@ -57,4 +60,20 @@ test("零向量查询不会产生 NaN，分数相同时保持插入顺序", asyn
   assert.ok(results.every((result) => Number.isFinite(result.score)));
   assert.equal(cosineSimilarity([1, 0, 0], [0, 0, 0]), 0);
   assert.ok(Number.isFinite(cosineSimilarity([Number.MAX_VALUE, 0, 0], [Number.MAX_VALUE, 0, 0])));
+});
+
+test("JSONL 向量库可以保存、重启恢复并校验模型元数据", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sztu-jsonl-store-"));
+  const file = path.join(root, "vectors.jsonl");
+  try {
+    const first = await JsonlVectorStore.open(file, 3, "jsonl", { embedderName: "test-model" });
+    await first.add(records);
+    const second = await JsonlVectorStore.open(file, 3, "jsonl", { embedderName: "test-model" });
+    assert.equal(await second.count(), 3);
+    assert.deepEqual((await second.search([1, 0, 0], 1))[0]!.record.text, "认证密码校验");
+    assert.match(await readFile(file, "utf8"), /"format_version":1/);
+    await assert.rejects(JsonlVectorStore.open(file, 3, "jsonl", { embedderName: "other-model" }), /模型不匹配/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Part of #145

## Summary

为 `semantic_search` 增加本地 JSONL 索引持久化和增量更新能力，减少进程重启后的重复索引工作。

## Behavior

- 将语义索引保存到 `.sztu/vector/semantic-index.jsonl`
- 进程重启后自动恢复已有向量索引和关键词索引
- 保存索引格式版本、向量维度和 Embedding 模型名称
- 检测模型或向量维度不匹配并拒绝加载
- 使用临时文件和原子重命名写入索引
- 文件修改后只重新索引对应文件
- 文件删除后自动清理对应索引
- 自动发现并索引新建文件
- 修复 Linux 构建中对非 ELF `.node` 文件执行 `patchelf` 的问题
- 修正 offload 测试对消息顺序的错误假设

## Validation

```text
TypeScript 类型检查：通过
语义搜索、向量库和索引测试：19 passed
offload 测试：4 passed