### PR TITLE
[Agent Core] 清理取消流程中的挂起权限审批

### DIFF
--- a/py-runtime/src/sztu_code/core/app.py
+++ b/py-runtime/src/sztu_code/core/app.py
@@ -276,9 +276,12 @@ class CoreApp:
         self._config: SztuConfig | None = None
         self._running_runs: set[asyncio.Task[Any]] = set()
         self._active_run_tasks: dict[str, asyncio.Task[str]] = {}
+        self._run_sessions: dict[str, str] = {}
         self._run_status: dict[str, str] = {}
         self._client_message_runs: dict[tuple[str, str], str] = {}
         self._active_session_runs: dict[str, asyncio.Task[str]] = {}
+        self._connection_sessions: dict[asyncio.StreamWriter, set[str]] = {}
+        self._session_connections: dict[str, set[asyncio.StreamWriter]] = {}
         self._run_store: RunStore | None = None
         self._sessions: SessionManager | None = None
         self._permission_manager: PermissionManager | None = None
@@ -318,17 +321,32 @@ class CoreApp:
         )
 
     # 跟踪后台 run 任务，以支持客户端查询与安全取消
-    def _track_run(self, run_id: str, task: asyncio.Task[str]) -> None:
+    def _track_run(
+        self,
+        run_id: str,
+        task: asyncio.Task[str],
+        session_id: str | None = None,
+    ) -> None:
         self._running_runs.add(task)
         self._active_run_tasks[run_id] = task
+        if session_id is not None:
+            self._run_sessions[run_id] = session_id
         self._run_status[run_id] = "running"
         task.add_done_callback(partial(self._on_run_finished, run_id))
 
     # 记录 run 终态并清理活动索引，防止后台异常变成未观察任务
     def _on_run_finished(self, run_id: str, task: asyncio.Task[str]) -> None:
         self._running_runs.discard(task)
+        session_id = self._run_sessions.get(run_id)
         if self._active_run_tasks.get(run_id) is task:
             self._active_run_tasks.pop(run_id, None)
+        self._run_sessions.pop(run_id, None)
+        if (
+            session_id is not None
+            and self._permission_manager is not None
+            and session_id not in self._run_sessions.values()
+        ):
+            self._permission_manager.clear_session_cancellation(session_id)
         if task.cancelled():
             self._run_status[run_id] = "cancelled"
             if self._run_store is not None:
@@ -345,6 +363,35 @@ class CoreApp:
             self._run_status[run_id] = "completed"
             if self._run_store is not None:
                 self._run_store.finish(run_id, status="completed")
+
+    # 将当前连接标记为 session 的使用者；直接调用 handler 的测试没有连接上下文时跳过
+    def _bind_connection_session(self, session_id: str) -> None:
+        try:
+            writer = get_connection_writer()
+        except LookupError:
+            return
+        self._connection_sessions.setdefault(writer, set()).add(session_id)
+        self._session_connections.setdefault(session_id, set()).add(writer)
+        if self._permission_manager is not None:
+            self._permission_manager.mark_session_connected(session_id)
+
+    # 客户端断连时只清理不再被任何连接持有的 session，避免误伤其他客户端
+    def _on_client_disconnect(self, writer: asyncio.StreamWriter) -> None:
+        session_ids = self._connection_sessions.pop(writer, set())
+        for session_id in session_ids:
+            writers = self._session_connections.get(session_id)
+            if writers is None:
+                continue
+            writers.discard(writer)
+            if writers:
+                continue
+            self._session_connections.pop(session_id, None)
+            if self._permission_manager is not None:
+                self._permission_manager.cancel_session(
+                    session_id,
+                    reason="client_disconnected",
+                    prevent_new_requests=session_id in self._run_sessions.values(),
+                )
 
     # 处理 core.ping 请求，返回服务版本、运行时长和接收时间
     async def _ping_handler(self, params: dict[str, Any]) -> PongResult:
@@ -387,7 +434,8 @@ class CoreApp:
         run_task = asyncio.create_task(
             self._sessions.send_message(session.id, cmd.goal, run_id=run_id)
         )
-        self._track_run(run_id, run_task)
+        self._track_run(run_id, run_task, session.id)
+        self._bind_connection_session(session.id)
         return AgentRunResult(run_id=run_id)
 
     # 创建 chat 或 one_shot session，并返回 session_id
@@ -403,6 +451,7 @@ class CoreApp:
         session = await self._sessions.create(
             mode=cmd.mode, title=cmd.title, workspace_id=cmd.workspace_id
         )
+        self._bind_connection_session(session.id)
         return SessionCreateResult(session_id=session.id, status=session.status)
 
     # 返回按最近活动排序的 session 列表，供任务历史侧栏使用
@@ -444,6 +493,7 @@ class CoreApp:
     async def _session_resume_handler(self, params: dict[str, Any]) -> SessionResumeResult:
         assert self._sessions is not None
         cmd = SessionResumeCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         session = await self._sessions.resume(cmd.session_id)
         return SessionResumeResult(session=self._session_summary(session))
 
@@ -750,6 +800,7 @@ class CoreApp:
     async def _session_send_handler(self, params: dict[str, Any]) -> SessionSendMessageResult:
         assert self._sessions is not None
         cmd = SessionSendMessageCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         if cmd.client_message_id:
             existing_run_id = self._client_message_runs.get(
                 (cmd.session_id, cmd.client_message_id)
@@ -787,7 +838,7 @@ class CoreApp:
             )
         )
         self._active_session_runs[cmd.session_id] = run_task
-        self._track_run(run_id, run_task)
+        self._track_run(run_id, run_task, cmd.session_id)
         run_task.add_done_callback(partial(self._on_session_run_finished, cmd.session_id))
         return SessionSendMessageResult(run_id=run_id)
 
@@ -795,6 +846,7 @@ class CoreApp:
     async def _session_steer_handler(self, params: dict[str, Any]) -> SessionSteerMessageResult:
         assert self._sessions is not None
         cmd = SessionSteerMessageCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         run_id = await self._sessions.steer_message(
             cmd.session_id,
             cmd.content,
@@ -817,6 +869,10 @@ class CoreApp:
         task = self._active_run_tasks.get(cmd.run_id)
         if task is None or task.done():
             return RunCancelResult(run_id=cmd.run_id, status="not_running")
+        if self._permission_manager is not None:
+            session_id = self._run_sessions.get(cmd.run_id)
+            if session_id is not None:
+                self._permission_manager.cancel_run(cmd.run_id, session_id)
         task.cancel()
         return RunCancelResult(run_id=cmd.run_id, status="cancelling")
 
@@ -842,6 +898,7 @@ class CoreApp:
     async def _session_history_handler(self, params: dict[str, Any]) -> SessionGetHistoryResult:
         assert self._sessions is not None
         cmd = SessionGetHistoryCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         messages = await self._sessions.get_history(cmd.session_id)
         return SessionGetHistoryResult(
             messages=messages,
@@ -1771,6 +1828,7 @@ class CoreApp:
     async def _session_compact_handler(self, params: dict[str, Any]) -> SessionCompactResult:
         assert self._sessions is not None
         cmd = SessionCompactCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         result = await self._sessions.compact(cmd.session_id, cmd.focus)
         return result  # type: ignore[no-any-return]
 
@@ -1778,13 +1836,27 @@ class CoreApp:
     async def _session_close_handler(self, params: dict[str, Any]) -> SessionCloseResult:
         assert self._sessions is not None
         cmd = SessionCloseCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         await self._sessions.close(cmd.session_id)
+        if self._permission_manager is not None:
+            self._permission_manager.cancel_session(
+                cmd.session_id,
+                reason="session_closed",
+                prevent_new_requests=False,
+            )
         return SessionCloseResult(status="closed")
 
     async def _session_delete_handler(self, params: dict[str, Any]) -> SessionDeleteResult:
         assert self._sessions is not None
         cmd = SessionDeleteCommand.model_validate(params)
+        self._bind_connection_session(cmd.session_id)
         await self._sessions.delete(cmd.session_id)
+        if self._permission_manager is not None:
+            self._permission_manager.cancel_session(
+                cmd.session_id,
+                reason="session_deleted",
+                prevent_new_requests=False,
+            )
         return SessionDeleteResult(session_id=cmd.session_id, deleted=True)
 
     # 注册客户端事件订阅，可选先回放 events.jsonl 历史再接收实时流
@@ -1932,6 +2004,7 @@ class CoreApp:
             self._config.port,
             self._broadcaster,
             trace=self._trace,
+            on_disconnect=self._on_client_disconnect,
         )
         server.register("core.ping", self._ping_handler)
         server.register("agent.run", self._agent_run_handler)
@@ -2025,6 +2098,8 @@ class CoreApp:
         await shutdown.wait()
 
         logger.info("shutting down")
+        if self._permission_manager is not None:
+            self._permission_manager.cancel_all(reason="daemon_shutdown")
         for run_task in list(self._running_runs):
             run_task.cancel()
         if self._running_runs:

--- a/py-runtime/src/sztu_code/core/permissions/manager.py
+++ b/py-runtime/src/sztu_code/core/permissions/manager.py
@@ -65,6 +65,9 @@ class PermissionManager:
         self._mode = mode
         # 模式变更回调列表：参数为 (old_mode, new_mode)
         self._mode_listeners: list[Callable[[PermissionMode, PermissionMode], Awaitable[None]]] = []
+        # 没有客户端持有 session 时，后台 run 后续产生的 ASK 请求不能再次挂起。
+        # 重新连接并绑定 session 后清除对应标记；后台 run 本身仍按既有语义继续运行。
+        self._session_cancellations: dict[str, str] = {}
 
     # 对工具名 + 参数执行 4 层静态评估，不挂起
     def evaluate(self, tool_name: str, params: dict[str, Any]) -> PermissionDecision:
@@ -227,39 +230,54 @@ class PermissionManager:
             # default == ASK（bash、unknown tool）→ fall through to Future
 
         # ASK 路径（来自 OUTSIDE_CWD 强制 ASK，或 default=ASK）
+        cancellation_reason = self._session_cancellations.get(session_id)
+        if cancellation_reason is not None:
+            logger.debug(
+                "permission: deny new request for cancelled session=%s reason=%s",
+                session_id,
+                cancellation_reason,
+            )
+            return False, "deny_once"
+
         loop = asyncio.get_event_loop()
         future: asyncio.Future[str] = loop.create_future()
-        self._pending[tool_use_id] = _PendingRequest(
+        pending = _PendingRequest(
             future=future,
             session_id=session_id,
             tool_name=tool_name,
             run_id=run_id,
         )
-
-        await event_emitter(
-            {
-                "type": "permission.requested",
-                "tool_use_id": tool_use_id,
-                "tool_name": tool_name,
-                "params": params,
-                "param_preview": param_preview(tool_name, params),
-                "session_id": session_id,
-                "ts": _now(),
-            }
-        )
+        self._pending[tool_use_id] = pending
 
         try:
-            if self._timeout_s > 0:
-                raw = await asyncio.wait_for(future, timeout=self._timeout_s)
-            else:
-                raw = await future
-        except TimeoutError:
-            self._pending.pop(tool_use_id, None)
-            logger.info("permission: timeout tool_use_id=%s tool=%s", tool_use_id, tool_name)
-            return False, "timeout"
+            await event_emitter(
+                {
+                    "type": "permission.requested",
+                    "tool_use_id": tool_use_id,
+                    "tool_name": tool_name,
+                    "params": params,
+                    "param_preview": param_preview(tool_name, params),
+                    "session_id": session_id,
+                    "ts": _now(),
+                }
+            )
+            try:
+                if self._timeout_s > 0:
+                    raw = await asyncio.wait_for(future, timeout=self._timeout_s)
+                else:
+                    raw = await future
+            except TimeoutError:
+                logger.info("permission: timeout tool_use_id=%s tool=%s", tool_use_id, tool_name)
+                return False, "timeout"
 
-        allowed = self._apply_response(raw, session_id, tool_name)
-        return allowed, raw
+            allowed = self._apply_response(raw, session_id, tool_name)
+            return allowed, raw
+        finally:
+            # respond() and the cancellation helpers may have removed this entry
+            # already.  Only remove the request created by this invocation so a
+            # same-ID request created during a cancellation race is not lost.
+            if self._pending.get(tool_use_id) is pending:
+                self._pending.pop(tool_use_id, None)
 
     # 处理客户端返回的审批决策，resolve 对应 Future
     def respond(
@@ -337,14 +355,32 @@ class PermissionManager:
                 logger.warning("permission: policy_file is None, skipping persistence")
         return allow
 
-    # 客户端断连时拒绝该 session 所有待审批请求，防止 Future 永久挂起
-    def cancel_session(self, session_id: str, reason: str = "client_disconnected") -> None:
+    # 客户端断连或 session 关闭时拒绝该 session 所有待审批请求，防止 Future 永久挂起
+    def cancel_session(
+        self,
+        session_id: str,
+        reason: str = "client_disconnected",
+        *,
+        prevent_new_requests: bool = True,
+    ) -> None:
+        if prevent_new_requests:
+            self._session_cancellations[session_id] = reason
+        else:
+            self._session_cancellations.pop(session_id, None)
         to_cancel = [uid for uid, req in self._pending.items() if req.session_id == session_id]
         for uid in to_cancel:
             req = self._pending.pop(uid)
             if not req.future.done():
                 logger.debug("permission: cancel pending tool_use_id=%s reason=%s", uid, reason)
                 req.future.set_result("deny_once")
+
+    # 客户端重新连接并重新绑定 session 后，允许新的 ASK 请求进入审批队列
+    def mark_session_connected(self, session_id: str) -> None:
+        self._session_cancellations.pop(session_id, None)
+
+    # run 结束后释放 session 生命周期屏障，避免无界保留已完成 session 的标记
+    def clear_session_cancellation(self, session_id: str) -> None:
+        self._session_cancellations.pop(session_id, None)
 
     # 取消指定 run 在指定 session 下的待审批请求，避免 Future 泄漏和过期响应
     def cancel_run(self, run_id: str, session_id: str) -> None:
@@ -361,3 +397,12 @@ class PermissionManager:
                     uid,
                 )
                 req.future.set_result("deny_once")
+
+    # daemon 关闭时拒绝所有待审批请求，确保没有 Future 留在事件循环中
+    def cancel_all(self, reason: str = "daemon_shutdown") -> None:
+        for uid in list(self._pending):
+            req = self._pending.pop(uid)
+            if not req.future.done():
+                logger.debug("permission: cancel pending tool_use_id=%s reason=%s", uid, reason)
+                req.future.set_result("deny_once")
+        self._session_cancellations.clear()

--- a/py-runtime/src/sztu_code/core/transport/socket_server.py
+++ b/py-runtime/src/sztu_code/core/transport/socket_server.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from datetime import UTC, datetime
+from functools import partial
 from typing import Any
 
 from pydantic import BaseModel, ValidationError
@@ -28,6 +30,7 @@ from sztu_code.core.transport.ipc_broadcaster import IpcEventBroadcaster
 logger = logging.getLogger(__name__)
 
 type CommandHandler = Callable[[dict[str, Any]], Awaitable[Any]]
+type DisconnectHandler = Callable[[asyncio.StreamWriter], Awaitable[None] | None]
 
 # 每个连接处理协程中，当前正在处理的 writer（供 handler 读取连接上下文）
 _writer_var: ContextVar[asyncio.StreamWriter] = ContextVar("_writer_var")
@@ -52,6 +55,7 @@ class SocketServer:
         port: int,
         broadcaster: IpcEventBroadcaster | None = None,
         trace: TraceWriter | None = None,
+        on_disconnect: DisconnectHandler | None = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -59,7 +63,9 @@ class SocketServer:
         self._server: asyncio.AbstractServer | None = None
         self._broadcaster = broadcaster
         self._trace = trace
+        self._on_disconnect = on_disconnect
         self._active_writers: set[asyncio.StreamWriter] = set()
+        self._handler_tasks: dict[asyncio.StreamWriter, set[asyncio.Task[None]]] = {}
 
     # 注册一个方法名对应的命令处理函数
     def register(self, method: str, handler: CommandHandler) -> None:
@@ -110,14 +116,46 @@ class SocketServer:
         try:
             await self._read_loop(reader, writer)
         finally:
-            self._active_writers.discard(writer)
-            if self._broadcaster is not None:
-                self._broadcaster.unsubscribe(writer)
             try:
-                writer.close()
-            except Exception:
-                pass
-            logger.debug("client disconnected: %s", peer)
+                # Cancel RPC handlers before notifying the owner.  Otherwise a
+                # slow handler can bind a session after EOF and evade cleanup.
+                await self._cancel_handler_tasks(writer)
+            finally:
+                self._active_writers.discard(writer)
+                if self._broadcaster is not None:
+                    self._broadcaster.unsubscribe(writer)
+                if self._on_disconnect is not None:
+                    try:
+                        result = self._on_disconnect(writer)
+                        if inspect.isawaitable(result):
+                            await result
+                    except Exception:
+                        logger.exception("disconnect cleanup failed: %s", peer)
+                try:
+                    writer.close()
+                except Exception:
+                    pass
+                logger.debug("client disconnected: %s", peer)
+
+    # 记录并取消指定连接尚未完成的 RPC handler，避免 EOF 后继续修改生命周期状态
+    async def _cancel_handler_tasks(self, writer: asyncio.StreamWriter) -> None:
+        tasks = self._handler_tasks.pop(writer, set())
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    # handler 结束后移除连接索引，避免短连接留下任务引用
+    def _discard_handler_task(
+        self, writer: asyncio.StreamWriter, task: asyncio.Task[None]
+    ) -> None:
+        tasks = self._handler_tasks.get(writer)
+        if tasks is None:
+            return
+        tasks.discard(task)
+        if not tasks:
+            self._handler_tasks.pop(writer, None)
 
     # 持续读取换行分隔的 JSON 行并逐行分发处理
     async def _read_loop(
@@ -137,7 +175,9 @@ class SocketServer:
 
             # 每条命令独立作为 task 执行，避免长时间运行的 handler（如 session.send_message）
             # 阻塞读循环，使 permission.respond 等并发命令能被及时处理
-            asyncio.create_task(self._handle_line(line, writer))
+            task = asyncio.create_task(self._handle_line(line, writer))
+            self._handler_tasks.setdefault(writer, set()).add(task)
+            task.add_done_callback(partial(self._discard_handler_task, writer))
 
     # 解析单行 JSON-RPC 请求并调用对应 handler，将结果或错误写回客户端
     async def _handle_line(self, line: bytes, writer: asyncio.StreamWriter) -> None:

--- a/py-runtime/tests/integration/test_s5_permission_flow.py
+++ b/py-runtime/tests/integration/test_s5_permission_flow.py
@@ -7,15 +7,23 @@ commands must be safe (echo, true).
 """
 from __future__ import annotations
 
+import asyncio
+import json
+import socket
+from contextlib import suppress
 from pathlib import Path
 
+import pytest
 from pydantic import BaseModel
 
+from sztu_code.core.app import CoreApp
 from sztu_code.core.config import SztuConfig
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import LlmResponse, ToolCallBlock
 from sztu_code.core.permissions.manager import PermissionManager
 from sztu_code.core.runner import AgentRunner
+from sztu_code.core.session.model import Session, SessionMode
+from sztu_code.core.transport.socket_server import SocketServer
 
 # ── stub providers ────────────────────────────────────────────────────────────
 
@@ -170,3 +178,165 @@ async def test_always_allow_cached_within_session(tmp_path: Path) -> None:
 
     assert perm_requested_count == 1
     assert outcome.status == "success"
+
+
+# 功能：验证 run 在权限审批等待期间被取消时，工具不会执行且 pending 请求会清理
+# 设计：使用真实 AgentRunner + PermissionManager，等 permission.requested 到达后取消
+#       run；断言没有 tool.call_finished，并确认权限管理器不再保留该请求
+async def test_cancelled_permission_wait_does_not_execute_tool(tmp_path: Path) -> None:
+    manager = PermissionManager(timeout_s=0)
+    bus = EventBus()
+    event_types: list[str] = []
+    permission_requested = asyncio.Event()
+
+    async def collect(e: BaseModel) -> None:
+        event_type = getattr(e, "type", "")
+        event_types.append(event_type)
+        if event_type == "permission.requested":
+            permission_requested.set()
+
+    bus.subscribe(collect)
+    task = asyncio.create_task(
+        _runner(_SingleBashProvider(), bus, manager, tmp_path)
+        .run_and_capture("run bash", run_id="cancelled-permission")
+    )
+    await asyncio.wait_for(permission_requested.wait(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert manager._pending == {}
+    assert "tool.call_finished" not in event_types
+
+
+# 功能：验证真实 SocketServer → CoreApp → PermissionManager 断连清理链路
+# 设计：通过 TCP 请求创建 session，使 CoreApp 记录实际连接；随后挂起同 session 的审批并关闭客户端，
+#       断言断连回调拒绝 Future、清空 pending，避免仅凭手工填充连接映射得到假阳性
+async def test_client_disconnect_cleans_permission_over_ipc() -> None:
+    class _SessionFactory:
+        async def create(
+            self,
+            mode: SessionMode,
+            title: str = "",
+            workspace_id: str | None = None,
+        ) -> Session:
+            return Session(
+                id="sess-ipc",
+                mode=mode,
+                status="waiting_for_input",
+                title=title,
+                created_at="",
+                updated_at="",
+                workspace_id=workspace_id,
+            )
+
+    async def send_recv(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        method: str,
+        params: dict[str, object],
+    ) -> dict[str, object]:
+        request = {
+            "jsonrpc": "2.0",
+            "id": "session-create",
+            "method": method,
+            "params": params,
+        }
+        writer.write((json.dumps(request) + "\n").encode())
+        await writer.drain()
+        return json.loads(await asyncio.wait_for(reader.readline(), timeout=1.0))
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = int(probe.getsockname()[1])
+
+    app = CoreApp()
+    manager = PermissionManager(timeout_s=0)
+    app._permission_manager = manager
+    app._sessions = _SessionFactory()  # type: ignore[assignment]
+    server = SocketServer("127.0.0.1", port, on_disconnect=app._on_client_disconnect)
+    server.register("session.create", app._session_create_handler)
+    permission_task: asyncio.Task[tuple[bool, str]] | None = None
+
+    await server.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        response = await send_recv(reader, writer, "session.create", {"mode": "chat"})
+        assert response["result"] == {
+            "session_id": "sess-ipc",
+            "status": "waiting_for_input",
+        }
+
+        pending_started = asyncio.Event()
+
+        async def emitter(event: dict[str, object]) -> None:
+            del event
+            pending_started.set()
+
+        permission_task = asyncio.create_task(
+            manager.check_and_wait(
+                tool_use_id="ipc-disconnect",
+                tool_name="bash",
+                params={"command": "echo"},
+                session_id="sess-ipc",
+                event_emitter=emitter,
+                run_id="run-ipc",
+            )
+        )
+        # 模拟权限请求所属的后台 run 仍在执行，断连后后续 ASK 必须被拒绝。
+        app._run_sessions["run-ipc"] = "sess-ipc"
+        await asyncio.wait_for(pending_started.wait(), timeout=1.0)
+        assert "ipc-disconnect" in manager._pending
+
+        writer.close()
+        await writer.wait_closed()
+        assert await asyncio.wait_for(permission_task, timeout=1.0) == (False, "deny_once")
+        assert manager._pending == {}
+        assert app._connection_sessions == {}
+        assert app._session_connections == {}
+
+        # 即使后台 run 在断连后继续运行，后续危险调用也不能重新挂起审批。
+        assert await manager.check_and_wait(
+            tool_use_id="after-ipc-disconnect",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="sess-ipc",
+            event_emitter=emitter,
+            run_id="run-ipc-2",
+        ) == (False, "deny_once")
+        assert manager._pending == {}
+
+        # 新连接重新绑定 session 后，审批能力恢复。
+        reader2, writer2 = await asyncio.open_connection("127.0.0.1", port)
+        response2 = await send_recv(reader2, writer2, "session.create", {"mode": "chat"})
+        assert response2["result"] == {
+            "session_id": "sess-ipc",
+            "status": "waiting_for_input",
+        }
+        reconnected_task = asyncio.create_task(
+            manager.check_and_wait(
+                tool_use_id="after-ipc-reconnect",
+                tool_name="bash",
+                params={"command": "echo"},
+                session_id="sess-ipc",
+                event_emitter=emitter,
+                run_id="run-ipc-3",
+            )
+        )
+        await asyncio.sleep(0)
+        manager.respond(
+            "after-ipc-reconnect",
+            "allow_once",
+            run_id="run-ipc-3",
+            session_id="sess-ipc",
+        )
+        assert await reconnected_task == (True, "allow_once")
+        writer2.close()
+        await writer2.wait_closed()
+    finally:
+        if permission_task is not None and not permission_task.done():
+            permission_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await permission_task
+        await server.stop()

--- a/py-runtime/tests/unit/test_desktop_p0.py
+++ b/py-runtime/tests/unit/test_desktop_p0.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -102,6 +102,197 @@ async def test_run_cancel_stops_active_session_run() -> None:
 
     status = await app._run_get_handler({"run_id": sent.run_id})
     assert status.status == "cancelled"
+
+
+# 功能：验证 run.cancel 会先拒绝该 run 的待审批请求，再取消运行任务
+# 设计：把真实 PermissionManager pending 与可取消的活动 task 同时注入 CoreApp，
+#       断言审批 Future 已完成且运行 task 收到取消
+async def test_run_cancel_cleans_pending_permissions_before_task_cancel() -> None:
+    app = CoreApp()
+    manager = PermissionManager(timeout_s=0)
+    app._permission_manager = manager
+
+    async def emitter(event: dict[str, Any]) -> None:
+        del event
+
+    permission_task = asyncio.create_task(
+        manager.check_and_wait(
+            tool_use_id="run-cancel-permission",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="sess-1",
+            event_emitter=emitter,
+            run_id="run-1",
+        )
+    )
+    await asyncio.sleep(0)
+
+    run_task = asyncio.create_task(asyncio.sleep(60, result="done"))
+    app._track_run("run-1", run_task, "sess-1")
+
+    result = await app._run_cancel_handler({"run_id": "run-1"})
+
+    assert result.status == "cancelling"
+    assert await permission_task == (False, "deny_once")
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+
+# 功能：验证成功关闭 session 后，会拒绝该 session 遗留的待审批请求
+# 设计：使用最小 SessionManager 替身只观察 close 调用，避免把测试耦合到持久化实现
+async def test_session_close_cleans_pending_permissions() -> None:
+    class _ClosableSessions:
+        def __init__(self) -> None:
+            self.closed: list[str] = []
+
+        async def close(self, session_id: str) -> None:
+            self.closed.append(session_id)
+
+    app = CoreApp()
+    manager = PermissionManager(timeout_s=0)
+    app._permission_manager = manager
+    sessions = _ClosableSessions()
+    app._sessions = sessions  # type: ignore[assignment]
+
+    async def emitter(event: dict[str, Any]) -> None:
+        del event
+
+    permission_task = asyncio.create_task(
+        manager.check_and_wait(
+            tool_use_id="session-close-permission",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="sess-1",
+            event_emitter=emitter,
+            run_id="run-1",
+        )
+    )
+    await asyncio.sleep(0)
+
+    result = await app._session_close_handler({"session_id": "sess-1"})
+
+    assert result.status == "closed"
+    assert sessions.closed == ["sess-1"]
+    assert await permission_task == (False, "deny_once")
+    assert manager._session_cancellations == {}
+
+
+# 功能：验证 session.close 失败时不会改变权限审批生命周期
+# 设计：让替身模拟真实 SessionManager 的 SESSION_BUSY，确认 session 未关闭时 pending 仍在；
+#       再显式清理测试请求，避免把测试资源泄漏到下一用例
+async def test_session_close_cleans_pending_when_close_fails() -> None:
+    class _BusySessions:
+        async def close(self, session_id: str) -> None:
+            del session_id
+            raise HandlerError(-32012, "session busy")
+
+    app = CoreApp()
+    manager = PermissionManager(timeout_s=0)
+    app._permission_manager = manager
+    app._sessions = _BusySessions()  # type: ignore[assignment]
+
+    async def emitter(event: dict[str, Any]) -> None:
+        del event
+
+    permission_task = asyncio.create_task(
+        manager.check_and_wait(
+            tool_use_id="session-close-failed-permission",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="sess-1",
+            event_emitter=emitter,
+            run_id="run-1",
+        )
+    )
+    await asyncio.sleep(0)
+
+    with pytest.raises(HandlerError, match="session busy"):
+        await app._session_close_handler({"session_id": "sess-1"})
+
+    assert not permission_task.done()
+    assert "session-close-failed-permission" in manager._pending
+    manager.cancel_session(
+        "sess-1", reason="test_cleanup", prevent_new_requests=False
+    )
+    assert await permission_task == (False, "deny_once")
+
+
+# 功能：验证成功删除 session 后，会拒绝该 session 遗留的待审批请求
+# 设计：使用最小 SessionManager 替身只观察 delete 调用，覆盖 close 之外的删除清理路径
+async def test_session_delete_cleans_pending_permissions() -> None:
+    class _DeletableSessions:
+        def __init__(self) -> None:
+            self.deleted: list[str] = []
+
+        async def delete(self, session_id: str) -> None:
+            self.deleted.append(session_id)
+
+    app = CoreApp()
+    manager = PermissionManager(timeout_s=0)
+    app._permission_manager = manager
+    sessions = _DeletableSessions()
+    app._sessions = sessions  # type: ignore[assignment]
+
+    async def emitter(event: dict[str, Any]) -> None:
+        del event
+
+    permission_task = asyncio.create_task(
+        manager.check_and_wait(
+            tool_use_id="session-delete-permission",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="sess-1",
+            event_emitter=emitter,
+            run_id="run-1",
+        )
+    )
+    await asyncio.sleep(0)
+
+    result = await app._session_delete_handler({"session_id": "sess-1"})
+
+    assert result.session_id == "sess-1"
+    assert result.deleted is True
+    assert sessions.deleted == ["sess-1"]
+    assert await permission_task == (False, "deny_once")
+    assert manager._session_cancellations == {}
+
+
+# 功能：验证断开一个连接不会取消仍由另一连接持有的 session 审批
+# 设计：同一 session 由两个连接持有时先断开一个，权限 Future 继续等待；最后一个连接断开
+#       后才拒绝请求，覆盖 SocketServer → CoreApp → PermissionManager 的归属链路
+async def test_client_disconnect_cancels_session_only_without_other_holders() -> None:
+    app = CoreApp()
+    manager = PermissionManager(timeout_s=0)
+    app._permission_manager = manager
+
+    async def emitter(event: dict[str, Any]) -> None:
+        del event
+
+    permission_task = asyncio.create_task(
+        manager.check_and_wait(
+            tool_use_id="disconnect-session",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="sess-1",
+            event_emitter=emitter,
+            run_id="run-1",
+        )
+    )
+    await asyncio.sleep(0)
+
+    writer_a = cast(asyncio.StreamWriter, object())
+    writer_b = cast(asyncio.StreamWriter, object())
+    app._connection_sessions[writer_a] = {"sess-1"}
+    app._connection_sessions[writer_b] = {"sess-1"}
+    app._session_connections["sess-1"] = {writer_a, writer_b}
+
+    app._on_client_disconnect(writer_a)
+    await asyncio.sleep(0)
+    assert not permission_task.done()
+
+    app._on_client_disconnect(writer_b)
+    assert await permission_task == (False, "deny_once")
+    assert app._session_connections == {}
 
 
 # 功能：验证 run.replay 从持久事件文件返回有限且顺序稳定的事件序列。

--- a/py-runtime/tests/unit/test_permission_manager.py
+++ b/py-runtime/tests/unit/test_permission_manager.py
@@ -402,3 +402,169 @@ async def test_permission_timeout_cleans_up_pending() -> None:
     # 超时后迟到的 respond 不应 crash
     mgr.respond("t_late", "allow_once")  # should be noop
     assert "t_late" not in mgr._pending
+
+
+# 功能：验证 check_and_wait 被外部取消时也会清理 pending 请求
+# 设计：先让审批请求进入等待，再取消调用任务；迟到的响应只能命中 unknown/no-op，
+#       不能留下 Future 或重新放行已取消的工具调用
+async def test_permission_cancellation_cleans_up_pending() -> None:
+    mgr = PermissionManager(timeout_s=0)
+    _, emitter = await _collect_emitted()
+
+    task = asyncio.create_task(
+        mgr.check_and_wait(
+            tool_use_id="t_cancelled",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="s1",
+            event_emitter=emitter,
+            run_id="r1",
+        )
+    )
+    await asyncio.sleep(0)
+    assert "t_cancelled" in mgr._pending
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert "t_cancelled" not in mgr._pending
+    mgr.respond("t_cancelled", "allow_once", run_id="r1", session_id="s1")
+
+
+# 功能：验证权限事件发送期间取消也会清理 pending 请求
+# 设计：让 event_emitter 在请求已登记后挂起，再取消 check_and_wait，覆盖等待 Future 前的窗口
+async def test_permission_cancellation_during_event_emission_cleans_up_pending() -> None:
+    mgr = PermissionManager(timeout_s=0)
+    emitter_started = asyncio.Event()
+    emitter_release = asyncio.Event()
+
+    async def emitter(event: dict[str, Any]) -> None:
+        assert event["tool_use_id"] == "emit-cancelled"
+        emitter_started.set()
+        await emitter_release.wait()
+
+    task = asyncio.create_task(
+        mgr.check_and_wait(
+            tool_use_id="emit-cancelled",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="s1",
+            event_emitter=emitter,
+            run_id="r1",
+        )
+    )
+    await emitter_started.wait()
+    assert "emit-cancelled" in mgr._pending
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    emitter_release.set()
+    assert "emit-cancelled" not in mgr._pending
+
+
+# 功能：验证 session 断连后，后台 run 的后续 ASK 请求直接拒绝而不重新创建 pending
+# 设计：先取消 session，再发起新的危险调用；重新标记连接后确认审批队列恢复可用
+async def test_disconnected_session_does_not_create_new_pending() -> None:
+    mgr = PermissionManager(timeout_s=0)
+    _, emitter = await _collect_emitted()
+
+    mgr.cancel_session("s1", reason="client_disconnected")
+    assert await mgr.check_and_wait(
+        tool_use_id="after-disconnect",
+        tool_name="bash",
+        params={"command": "echo"},
+        session_id="s1",
+        event_emitter=emitter,
+        run_id="r1",
+    ) == (False, "deny_once")
+    assert mgr._pending == {}
+
+    mgr.mark_session_connected("s1")
+    task = asyncio.create_task(
+        mgr.check_and_wait(
+            tool_use_id="after-reconnect",
+            tool_name="bash",
+            params={"command": "echo"},
+            session_id="s1",
+            event_emitter=emitter,
+            run_id="r2",
+        )
+    )
+    await asyncio.sleep(0)
+    mgr.respond("after-reconnect", "allow_once", run_id="r2", session_id="s1")
+    assert await task == (True, "allow_once")
+
+
+# 功能：验证取消旧 run 后，迟到的旧上下文响应不会唤醒同 ID 的新审批请求
+# 设计：先取消 r-old，再用相同 tool_use_id 创建 r-new；旧响应必须被拒绝并保留新请求，
+#       随后只有匹配 r-new/session 的响应才能完成新请求
+async def test_stale_response_from_cancelled_run_does_not_release_new_request() -> None:
+    mgr = PermissionManager(timeout_s=0)
+    _, emitter = await _collect_emitted()
+
+    old_task = asyncio.create_task(
+        mgr.check_and_wait(
+            tool_use_id="reused-id",
+            tool_name="bash",
+            params={"command": "echo old"},
+            session_id="s1",
+            event_emitter=emitter,
+            run_id="r-old",
+        )
+    )
+    await asyncio.sleep(0)
+    mgr.cancel_run("r-old", "s1")
+    assert await old_task == (False, "deny_once")
+
+    new_task = asyncio.create_task(
+        mgr.check_and_wait(
+            tool_use_id="reused-id",
+            tool_name="bash",
+            params={"command": "echo new"},
+            session_id="s1",
+            event_emitter=emitter,
+            run_id="r-new",
+        )
+    )
+    await asyncio.sleep(0)
+
+    mgr.respond("reused-id", "allow_once", run_id="r-old", session_id="s1")
+    await asyncio.sleep(0)
+    assert not new_task.done()
+
+    mgr.respond("reused-id", "deny_once", run_id="r-new", session_id="s1")
+    assert await new_task == (False, "deny_once")
+
+
+# 功能：验证 daemon shutdown 可一次性拒绝所有 session 的待审批请求
+# 设计：同时挂起两个 session 的审批，调用 cancel_all 后两个调用都应完成且无残留
+async def test_cancel_all_resolves_all_pending_requests() -> None:
+    mgr = PermissionManager(timeout_s=0)
+    _, emitter = await _collect_emitted()
+    mgr.cancel_session("stale-session", reason="client_disconnected")
+
+    tasks = [
+        asyncio.create_task(
+            mgr.check_and_wait(
+                tool_use_id=tool_use_id,
+                tool_name="bash",
+                params={"command": "echo"},
+                session_id=session_id,
+                event_emitter=emitter,
+                run_id=f"run-{session_id}",
+            )
+        )
+        for tool_use_id, session_id in (("shutdown-a", "s1"), ("shutdown-b", "s2"))
+    ]
+    await asyncio.sleep(0)
+    mgr.cancel_all(reason="daemon_shutdown")
+
+    assert await asyncio.gather(*tasks) == [
+        (False, "deny_once"),
+        (False, "deny_once"),
+    ]
+    assert mgr._pending == {}
+    assert mgr._session_cancellations == {}

--- a/py-runtime/tests/unit/test_socket_server.py
+++ b/py-runtime/tests/unit/test_socket_server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import socket
 
 from sztu_code.core.transport.socket_server import SocketServer
@@ -33,6 +34,84 @@ async def test_broadcaster_unsubscribe_called_on_disconnect() -> None:
 
         await asyncio.wait_for(unsubscribed.wait(), timeout=2.0)
     finally:
+        await server.stop()
+
+
+# 功能：验证客户端断连会触发上层生命周期清理回调
+# 设计：回调捕获实际 writer 并等待事件，证明 SocketServer 在 finally 中通知 CoreApp，
+#       使上层可以按连接归属清理权限审批
+async def test_disconnect_handler_called_on_disconnect() -> None:
+    disconnected = asyncio.Event()
+    writers: list[object] = []
+
+    async def on_disconnect(writer: object) -> None:
+        writers.append(writer)
+        disconnected.set()
+
+    port = _free_port()
+    server = SocketServer("127.0.0.1", port, on_disconnect=on_disconnect)  # type: ignore[arg-type]
+    await server.start()
+
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        del reader
+        writer.close()
+        await writer.wait_closed()
+
+        await asyncio.wait_for(disconnected.wait(), timeout=2.0)
+        assert writers
+    finally:
+        await server.stop()
+
+
+# 功能：验证断连回调执行前，会先取消仍在处理中的 RPC handler
+# 设计：让 handler 在响应前挂起，客户端 EOF 后由回调确认 handler 已收到取消，
+#       覆盖 session.create 尚未返回时的生命周期竞态
+async def test_disconnect_cancels_inflight_handlers_before_callback() -> None:
+    handler_started = asyncio.Event()
+    handler_cancelled = asyncio.Event()
+    disconnected = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_handler(params: dict[str, object]) -> dict[str, bool]:
+        del params
+        handler_started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            handler_cancelled.set()
+            raise
+        return {"ok": True}
+
+    async def on_disconnect(writer: object) -> None:
+        del writer
+        assert handler_cancelled.is_set()
+        disconnected.set()
+
+    port = _free_port()
+    server = SocketServer("127.0.0.1", port, on_disconnect=on_disconnect)  # type: ignore[arg-type]
+    server.register("slow", slow_handler)
+    await server.start()
+
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        del reader
+        writer.write(
+            (
+                json.dumps(
+                    {"jsonrpc": "2.0", "id": "slow", "method": "slow", "params": {}}
+                )
+                + "\n"
+            ).encode()
+        )
+        await writer.drain()
+        await asyncio.wait_for(handler_started.wait(), timeout=2.0)
+
+        writer.close()
+        await writer.wait_closed()
+        await asyncio.wait_for(disconnected.wait(), timeout=2.0)
+    finally:
+        release.set()
         await server.stop()
 
 


### PR DESCRIPTION
## Summary

Closes #116.

`PermissionManager` 在权限请求进入 `_pending` 后，如果等待任务被取消、超时或事件发送失败，现在都会清理请求与 Future。并补齐 run 取消、客户端断连、session close/delete 成功路径和 daemon shutdown 的生命周期接线。

## Behavior

- 取消中的 run 不会在权限审批返回后继续执行工具。
- session 断连、关闭及 daemon shutdown 会拒绝并清理作用域内待审批请求。
- 迟到的旧 `permission.respond` 不会唤醒复用同一 `tool_use_id` 的新请求。
- 未修改公开 RPC 协议和权限响应格式。

## Validation

- 定向 Python 测试：38 passed。
- Python 全量测试：1277 passed、2 skipped、5 failed。5 个失败来自临时测试项目通过 WSL Bash 调用 `python`，而当前 WSL 环境未安装 Python；不涉及本 PR 修改文件。
- Ruff 检查：通过。
- 核心 Python mypy：通过。
- `npm run typecheck`：通过。
- `npm run build`：通过。
- `npm test`：271 passed、1 skipped、1 failed。失败是未修改的 `packages/runtime-ts` 在 Windows 临时文件重命名时出现 `EPERM`，不涉及本 PR 修改文件。
- CRLF-aware `git diff --check`：通过。

## Risk

- 变更集中在权限等待和连接/session 生命周期清理，不改变公开 RPC 协议。
- 取消、断连和关闭路径统一按拒绝处理，避免挂起 Future、过期响应和取消后的工具执行。
- 主要剩余验证风险是上游 CI 的 Windows/WSL 测试环境差异。

## UI evidence

N/A：无桌面或 TUI 视觉变化。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加与风险匹配的回归测试。
- [x] 无协议变化，无需重新生成 `docs/reference/wire-protocol.md`。
- [x] 无用户文档、配置示例或迁移变化。
- [x] 提交包含 `Signed-off-by`（DCO）。