### PR TITLE
[Agent Core] 为 Python Run 建立墙钟截止时间基础

### DIFF
--- a/py-runtime/src/sztu_code/core/context.py
+++ b/py-runtime/src/sztu_code/core/context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 class TerminationReason(StrEnum):
     SUCCESS = "success"                         # LLM 返回 end_turn，正常完成
     MAX_TURNS = "max_turns"                     # 达到 max_steps 上限
+    MAX_WALL_CLOCK_EXCEEDED = "max_wall_clock_exceeded"  # 墙钟预算耗尽
     CANCELLED = "cancelled"                      # 用户手动取消
     LLM_ERROR = "llm_error"                      # LLM API 调用异常
     REPEATED_ERROR = "repeated_error"            # 同一错误连续 N 次
@@ -72,7 +74,10 @@ class ExecutionContext:
     # Token 预算准入按本字段累计：请求前估算的是完整 prompt，口径必须一致
     total_prompt_tokens: int = 0
     last_context_pct: float = 0.0  # 最近一次 LLM 调用的上下文占用百分比（用于 run 级结算透传）
-    started_at: float = 0.0       # run 开始墙钟（time.monotonic()），loop 惰性初始化
+    started_at: float = 0.0       # run 开始墙钟（由 monotonic clock 提供）
+    clock: Callable[[], float] = field(default=time.monotonic, repr=False, compare=False)
+    deadline_at: float | None = field(default=None, init=False)
+    _deadline_initialized: bool = field(default=False, init=False, repr=False)
     max_budget_usd: float = 0.0   # USD 成本上限（0 = 不限制）
     # --- Claude Code 风格终止/继续系统 ---
     # 错误累积器：{tool_name: {error_type: count}} — 同一工具同类错误重复 N 次触发熔断
@@ -226,17 +231,42 @@ class ExecutionContext:
     def token_budget_exhausted(self) -> bool:
         return self.max_tokens > 0 and self.budget_spend_tokens() >= self.max_tokens
 
+    # 在 Run 开始时只建立一次绝对 monotonic deadline；重复进入同一 context 不重置预算。
+    def start(self) -> None:
+        if self._deadline_initialized:
+            return
+
+        start_at = self.started_at if self.started_at > 0 else self.clock()
+        self.started_at = start_at
+        self.deadline_at = (
+            start_at + float(self.max_wall_clock_s)
+            if self.max_wall_clock_s > 0
+            else None
+        )
+        self._deadline_initialized = True
+
+    # 返回当前 Run 的剩余墙钟秒数；None 表示未配置墙钟上限，耗尽时钳制为 0。
+    def remaining_s(self) -> float | None:
+        self.start()
+        if self.deadline_at is None:
+            return None
+        return max(0.0, self.deadline_at - self.clock())
+
     # 返回 run 已运行的墙钟秒数；started_at 未初始化时返回 0
     def elapsed_s(self) -> float:
-        return time.monotonic() - self.started_at if self.started_at > 0 else 0.0
-
-    # 返回墙钟预算是否已超时；max_wall_clock_s=0 视为不限
-    def wall_clock_exceeded(self) -> bool:
         return (
-            self.max_wall_clock_s > 0
-            and self.started_at > 0
-            and self.elapsed_s() >= self.max_wall_clock_s
+            self.clock() - self.started_at
+            if self._deadline_initialized or self.started_at > 0
+            else 0.0
         )
+
+    # 返回墙钟预算是否已超时；Deadline 建立后以其自身为准，不受配置字段后续变化影响
+    def wall_clock_exceeded(self) -> bool:
+        if not self._deadline_initialized:
+            if self.started_at <= 0:
+                return False
+            self.start()
+        return self.deadline_at is not None and self.remaining_s() == 0.0
 
     # --- Claude Code 风格错误累积 ---
 

--- a/py-runtime/src/sztu_code/core/loop.py
+++ b/py-runtime/src/sztu_code/core/loop.py
@@ -350,6 +350,9 @@ class AgentLoop:
 
     # 驱动 plan→act→observe 循环直到上下文终止；CancelledError 向上传播
     async def run(self, context: ExecutionContext) -> None:
+        # 直接使用 AgentLoop 的调用方也必须在 Run 入口固定起点，不能把
+        # 压缩等待、阶段切换或后续重入排除在同一个墙钟预算之外。
+        context.start()
         # Phase 2: 初始化任务画布（若未由外部注入）
         from sztu_code.core.compact.canvas import TaskCanvas
         if context.canvas is None:
@@ -368,17 +371,14 @@ class AgentLoop:
             if self._compactor is not None:
                 await self._compactor.wait_pending()
             self._drain_steering(context)
-            # 惰性记录 run 开始墙钟（runner/子 agent 都可能未设置）
-            if context.started_at <= 0.0:
-                context.started_at = time.monotonic()
 
             # [budget] 墙钟上限预检：超时直接终止，不再发起 LLM 调用
             # 若已有 result（上一步已产出内容），优先保留而非丢弃
             if context.wall_clock_exceeded():
                 if context.result:
-                    context.mark_interrupted("max_wall_clock_exceeded")
+                    context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
                 else:
-                    context.mark_failed("max_wall_clock_exceeded")
+                    context.mark_failed(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
                 break
 
             context.step += 1
@@ -745,20 +745,24 @@ class AgentLoop:
                     },
                 )
 
-            # Termination check — end_turn wins over everything if it hits
+            # A completed end_turn is successful only while the run is still within
+            # its wall-clock budget; preserve late text but expose the timeout.
             if response.stop_reason == "end_turn" and not steering_received:
                 base = response.text or ""
                 if pending_summaries:
                     base += "\n\n" + "\n".join(pending_summaries)
                 context.result = base
-                context.mark_success()
+                if context.wall_clock_exceeded():
+                    context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+                else:
+                    context.mark_success()
 
             # --- 终止检测 ---
             # 累计 Token 只用于统计，不再作为跨轮硬终止条件；否则大上下文任务
             # 会在真正完成前因重复计入 input tokens 而提前停止。
             # wall_clock: 累计时间已超限
             elif context.wall_clock_exceeded():
-                context.mark_interrupted("max_wall_clock_exceeded")
+                context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
 
             # token_budget: 累计消耗（全量 prompt + 输出）已达上限；
             # 估算误差导致的单步超支在此收口，下一步准入也会兜底阻断

--- a/py-runtime/src/sztu_code/core/runner.py
+++ b/py-runtime/src/sztu_code/core/runner.py
@@ -368,6 +368,8 @@ class AgentRunner:
             max_tokens=self._config.budget.max_tokens,
             max_wall_clock_s=self._config.budget.max_wall_clock_s,
         )
+        # 固定完整 Run 的墙钟起点，覆盖 run.started 事件之后的 provider/registry 初始化。
+        context.start()
         dynamic_reminder = "\n\n".join(
             part
             for part in (

--- a/py-runtime/tests/integration/test_deadline_foundation.py
+++ b/py-runtime/tests/integration/test_deadline_foundation.py
@@ -1,0 +1,77 @@
+"""Offline integration coverage for the run wall-clock deadline foundation."""
+from __future__ import annotations
+
+from typing import Any
+
+from sztu_code.core.context import ExecutionContext, TerminationReason
+from sztu_code.core.events.bus import EventBus
+from sztu_code.core.llm.types import LlmResponse, ToolCallBlock
+from sztu_code.core.loop import AgentLoop
+from sztu_code.core.tools.registry import ToolRegistry
+
+
+class _DeadlineAdvancingProvider:
+    """Advance the injected clock after one response, then keep the loop offline."""
+
+    def __init__(self, clock: list[float], *, end_turn: bool = False) -> None:
+        self._clock = clock
+        self._end_turn = end_turn
+        self.calls = 0
+
+    async def chat(
+        self,
+        messages: list[dict[str, Any]],
+        tool_schemas: list[dict[str, Any]],
+        bus: EventBus,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+        usage_estimator: object | None = None,
+    ) -> LlmResponse:
+        del messages, tool_schemas, bus, run_id, step, system, usage_estimator
+        self.calls += 1
+        self._clock[0] = 1.0
+        if self._end_turn:
+            return LlmResponse(stop_reason="end_turn", text="late result")
+        return LlmResponse(
+            stop_reason="tool_use",
+            tool_calls=[ToolCallBlock(id="unknown-1", name="missing_tool", input={})],
+        )
+
+
+async def test_agent_loop_stops_before_second_provider_request_after_deadline() -> None:
+    clock = [0.0]
+    provider = _DeadlineAdvancingProvider(clock)
+    context = ExecutionContext(
+        run_id="deadline-integration",
+        goal="exercise the deadline",
+        max_steps=5,
+        max_wall_clock_s=1,
+        clock=lambda: clock[0],
+    )
+
+    await AgentLoop(provider, ToolRegistry(), EventBus()).run(context)  # type: ignore[arg-type]
+
+    assert provider.calls == 1
+    assert context.status == "interrupted"
+    assert context.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+
+
+async def test_agent_loop_preserves_late_end_turn_result_as_interrupted() -> None:
+    clock = [0.0]
+    provider = _DeadlineAdvancingProvider(clock, end_turn=True)
+    context = ExecutionContext(
+        run_id="late-end-turn",
+        goal="preserve the late result",
+        max_steps=5,
+        max_wall_clock_s=1,
+        clock=lambda: clock[0],
+    )
+
+    await AgentLoop(provider, ToolRegistry(), EventBus()).run(context)  # type: ignore[arg-type]
+
+    assert provider.calls == 1
+    assert context.status == "interrupted"
+    assert context.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+    assert context.result == "late result"

--- a/py-runtime/tests/unit/test_context.py
+++ b/py-runtime/tests/unit/test_context.py
@@ -111,3 +111,57 @@ def test_message_order_across_steps() -> None:
 def test_step_counter_default() -> None:
     ctx = ExecutionContext(run_id="r1", goal="g", max_steps=20)
     assert ctx.step == 0
+
+
+# 功能：验证有限墙钟预算在 Run 开始时只建立一次绝对 Deadline
+# 设计：使用可控 monotonic clock 推进时间，检查重复 start 不会重置 deadline，
+#       并且 remaining_s 在耗尽后钳制为 0 而不是返回负数
+def test_wall_clock_deadline_is_absolute_and_does_not_reset() -> None:
+    clock = [0.0]
+    ctx = ExecutionContext(
+        run_id="deadline-1",
+        goal="g",
+        max_steps=5,
+        max_wall_clock_s=10,
+        clock=lambda: clock[0],
+    )
+
+    ctx.start()
+    assert ctx.started_at == 0.0
+    assert ctx.deadline_at == 10.0
+    assert ctx.elapsed_s() == 0.0
+    assert ctx.remaining_s() == 10.0
+
+    clock[0] = 4.5
+    ctx.start()
+    assert ctx.started_at == 0.0
+    assert ctx.deadline_at == 10.0
+    assert ctx.elapsed_s() == 4.5
+    assert ctx.remaining_s() == 5.5
+
+    clock[0] = 10.0
+    assert ctx.remaining_s() == 0.0
+    assert ctx.wall_clock_exceeded() is True
+
+    # 继续越过 Deadline 后仍保持钳制，不会产生负数。
+    clock[0] = 11.0
+    assert ctx.remaining_s() == 0.0
+
+
+# 功能：验证 max_wall_clock_s=0 保持“不限时”语义
+# 设计：推进可控时钟后 remaining_s 仍表示 unlimited，且 wall_clock_exceeded 不误报
+def test_unlimited_wall_clock_has_no_deadline() -> None:
+    clock = [100.0]
+    ctx = ExecutionContext(
+        run_id="deadline-unlimited",
+        goal="g",
+        max_steps=5,
+        clock=lambda: clock[0],
+    )
+
+    ctx.start()
+    clock[0] = 100_000.0
+
+    assert ctx.deadline_at is None
+    assert ctx.remaining_s() is None
+    assert ctx.wall_clock_exceeded() is False

--- a/py-runtime/tests/unit/test_loop.py
+++ b/py-runtime/tests/unit/test_loop.py
@@ -1285,7 +1285,7 @@ async def test_pricing_catalog_budget_stops_loop() -> None:
 
 
 # 功能：验证墙钟超时在 loop 内正确终止
-# 设计：设 max_wall_clock_s=0（已超时），预检应触发中断
+# 设计：将 started_at 预置到 Deadline 之前，预检应触发中断
 async def test_wall_clock_exceeded_stops_loop() -> None:
     provider = _MockProvider([LlmResponse(stop_reason="end_turn", text="ok")])
     loop, _ = _make_loop(provider)
@@ -1308,13 +1308,15 @@ async def test_wall_clock_exceeded_preserves_result() -> None:
     ])
     loop, _ = _make_loop(provider)
     ctx = _ctx(max_steps=10)
+    clock = [100.0]
+    ctx.max_wall_clock_s = 1
+    ctx.clock = lambda: clock[0]
     await loop.run(ctx)  # 先正常完成一次 run
     assert ctx.status == "success"
     assert ctx.result == "final answer"
     # 再次 run（模拟 resume），墙钟已超时
     ctx.status = "running"
-    ctx.started_at = time.monotonic() - 10.0
-    ctx.max_wall_clock_s = 1
+    clock[0] = 102.0
     await loop.run(ctx)
     assert ctx.status == "interrupted"  # 有 result，保留
     assert ctx.result == "final answer"

--- a/py-runtime/tests/unit/test_runner.py
+++ b/py-runtime/tests/unit/test_runner.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import BaseModel
 
 from sztu_code.core.config import SztuConfig
+from sztu_code.core.context import ExecutionContext
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.types import LlmResponse, ToolCallBlock, UsageStats
 from sztu_code.core.runner import AgentRunner
@@ -369,6 +370,36 @@ async def test_run_started_event_published(tmp_path: Path) -> None:
     assert "run.started" in types
     started = next(e for e in events if e.type == "run.started")  # type: ignore[attr-defined]
     assert started.goal == "my goal"  # type: ignore[attr-defined]
+
+
+# 功能：验证 Runner 在发布 run.started 前就固定 Run 的墙钟起点
+# 设计：记录 ExecutionContext.start 与事件处理的顺序，避免把事件发布之后的惰性 loop 起点
+#       误当作完整 Run 的开始时间
+async def test_run_deadline_starts_before_run_started_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sequence: list[str] = []
+    original_start = ExecutionContext.start
+
+    def record_start(self: ExecutionContext) -> None:
+        sequence.append("deadline.start")
+        original_start(self)
+
+    async def record_event(event: BaseModel) -> None:
+        if event.type == "run.started":  # type: ignore[attr-defined]
+            sequence.append("run.started")
+
+    monkeypatch.setattr(ExecutionContext, "start", record_start)
+    runner = AgentRunner(
+        _config(),
+        provider=_EndTurnProvider(),  # type: ignore[arg-type]
+        extra_handlers=[record_event],
+        runs_dir=tmp_path,
+    )
+
+    await runner.run("deadline start")
+
+    assert sequence.index("deadline.start") < sequence.index("run.started")
 
 
 # 功能：验证成功完成时发布 status=success 的 run.finished 事件


### PR DESCRIPTION
## Summary

这是 Issue #69 的第一个可独立 Review 的 PR，范围仅限 Python runtime 的 Run deadline foundation。

- 在 Run 开始时基于 monotonic clock 建立一次绝对 deadline。
- 在 ExecutionContext 中提供 remaining_s()。
- 保证同一个 Run 重入时不重置 deadline。
- 统一使用 max_wall_clock_exceeded 表示墙钟预算耗尽。
- late end_turn 保留已生成结果，同时将 Run 标记为 interrupted。

## Behavior

Runner 会在发布 run.started 之前固定墙钟起点，直接调用 AgentLoop.run() 时也会初始化 deadline。deadline 到达后，AgentLoop 不会再开始新的模型请求；如果模型响应已经迟到，仍保留其文本结果，但不会错误地报告为 success。

本 PR 基于当前 main。当前 main 已包含已合并的 #158（权限审批取消流程清理），本 PR 不重复修改权限生命周期逻辑。

Provider、工具、权限等待、Subagent、retry、compaction、cleanup 和 Trace 的剩余时间传播属于后续独立 PR，本 PR 不声称完整解决 #69。

## Validation

- 定向 Python 测试：100 passed
- Ruff：通过
- 生产代码 mypy：通过
- CRLF-aware git diff --check：通过
- Python 全量测试：1293 passed、6 failed、2 skipped
- 全量测试的 6 个失败位于既有 multi-agent workflow 和 session IPC 测试，失败文件不在本 PR 改动列表，与此前基线结果一致。
- 未修改 TypeScript、桌面端、协议或 UI，因此未运行对应构建和视觉检查。

## Risk

本 PR 只提供统一 deadline 的基础设施，不会取消正在执行的 Provider 或工具 await，也不会改变权限响应协议。后续 PR 将在此基础上接入剩余时间、硬截止、取消清理和统一终止事件。

## UI evidence

N/A：无 TUI 或桌面端视觉变化。

## Checklist

- [x] 变更范围与关联 Issue 一致，没有混入无关重构。
- [x] 没有提交凭据、日志、缓存、私有源码或本地评测产物。
- [x] 已添加与风险匹配的回归测试。
- [x] 无协议变化，无需重新生成协议文档。
- [x] 无用户文档、配置示例或迁移变化。
- [x] 提交包含 Signed-off-by（DCO）。

Refs #69