### PR TITLE
[Agent Core] 为 Agent Loop 增加 LLM Hard Cutoff

### DIFF
--- a/py-runtime/src/sztu_code/core/deadline.py
+++ b/py-runtime/src/sztu_code/core/deadline.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+
+class RunDeadlineExceeded(Exception):
+    """Internal signal that a run-level wall-clock deadline was reached."""
+
+
+def supports_keyword(callable_obj: Any, keyword: str) -> bool:
+    """Check whether a callable accepts a keyword, preserving legacy doubles."""
+    try:
+        parameters = inspect.signature(callable_obj).parameters.values()
+    except (TypeError, ValueError):
+        # Dynamic callables cannot be inspected reliably; use the new contract.
+        return True
+    return any(
+        parameter.name == keyword or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+
+
+def add_remaining_s(
+    callable_obj: Any,
+    kwargs: dict[str, Any],
+    remaining_s: float | None,
+) -> None:
+    """Add the optional budget unless a legacy callable cannot accept it."""
+    if remaining_s is not None and supports_keyword(callable_obj, "remaining_s"):
+        kwargs["remaining_s"] = remaining_s

--- a/py-runtime/src/sztu_code/core/llm/base.py
+++ b/py-runtime/src/sztu_code/core/llm/base.py
@@ -21,4 +21,5 @@ class LLMProvider(Protocol):
         system: str | None = None,
         usage_estimator: Any | None = None,
         max_output_tokens: int | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse: ...

--- a/py-runtime/src/sztu_code/core/llm/openai_provider.py
+++ b/py-runtime/src/sztu_code/core/llm/openai_provider.py
@@ -471,12 +471,18 @@ class OpenAIProvider:
         system: str | None = None,
         usage_estimator: Any | None = None,
         max_output_tokens: int | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         effective_max_output = (
             max_output_tokens if max_output_tokens is not None else self._max_output_tokens
         )
         await bus.publish(
-            LlmModelSelectedEvent(run_id=run_id, model=self._model, strategy=getattr(self, "_routing_strategy", "static"), ts=_now())
+            LlmModelSelectedEvent(
+                run_id=run_id,
+                model=self._model,
+                strategy=getattr(self, "_routing_strategy", "static"),
+                ts=_now(),
+            )
         )
 
         openai_msgs = _anth_to_openai_messages(

--- a/py-runtime/src/sztu_code/core/llm/provider.py
+++ b/py-runtime/src/sztu_code/core/llm/provider.py
@@ -168,12 +168,18 @@ class AnthropicProvider:
         system: str | None = None,
         usage_estimator: Any | None = None,
         max_output_tokens: int | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         effective_max_output = (
             max_output_tokens if max_output_tokens is not None else self._max_output_tokens
         )
         await bus.publish(
-            LlmModelSelectedEvent(run_id=run_id, model=self._model, strategy=getattr(self, "_routing_strategy", "static"), ts=_now())
+            LlmModelSelectedEvent(
+                run_id=run_id,
+                model=self._model,
+                strategy=getattr(self, "_routing_strategy", "static"),
+                ts=_now(),
+            )
         )
 
         system_block: dict[str, object] = {

--- a/py-runtime/src/sztu_code/core/llm/smart.py
+++ b/py-runtime/src/sztu_code/core/llm/smart.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict
 from typing import Any
 
+from sztu_code.core.deadline import add_remaining_s
 from sztu_code.core.llm.base import LLMProvider
 
 
@@ -15,9 +16,16 @@ def task_requires_flagship(messages: list[dict[str, object]]) -> bool:
         if isinstance(content, str):
             texts.append(content)
         elif isinstance(content, list):
-            texts.extend(str(block.get("text", "")) for block in content if isinstance(block, dict) and block.get("type") == "text")
+            texts.extend(
+                str(block.get("text", ""))
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
     task = "\n".join(texts[-3:]).lower()
-    signals = ("architecture", "migration", "security audit", "distributed", "root cause", "架构", "迁移", "安全审计", "分布式", "根因", "跨模块", "复杂", "多agent", "多个 agent")
+    signals = (
+        "architecture", "migration", "security audit", "distributed", "root cause",
+        "架构", "迁移", "安全审计", "分布式", "根因", "跨模块", "复杂", "多agent", "多个 agent",
+    )
     return len(task) > 6000 or any(signal in task for signal in signals)
 
 
@@ -27,14 +35,31 @@ class SmartProvider:
         self.flagship = flagship
         self._choices: OrderedDict[str, bool] = OrderedDict()
 
-    async def chat(self, messages: list[dict[str, object]], tool_schemas: list[dict[str, object]], bus: Any, run_id: str, **kwargs: Any) -> Any:
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: Any,
+        run_id: str,
+        *,
+        remaining_s: float | None = None,
+        **kwargs: Any,
+    ) -> Any:
         # Keep tool/thinking continuations on the original model and preserve its cache prefix.
         if run_id not in self._choices:
             self._choices[run_id] = task_requires_flagship(messages)
         self._choices.move_to_end(run_id)
         selected = self.flagship if self._choices[run_id] else self.standard
+        selected_kwargs = dict(kwargs)
+        add_remaining_s(selected.chat, selected_kwargs, remaining_s)
         try:
-            response = await selected.chat(messages, tool_schemas, bus, run_id, **kwargs)
+            response = await selected.chat(
+                messages,
+                tool_schemas,
+                bus,
+                run_id,
+                **selected_kwargs,
+            )
         except BaseException:
             self._choices.pop(run_id, None)
             raise

--- a/py-runtime/src/sztu_code/core/loop.py
+++ b/py-runtime/src/sztu_code/core/loop.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sztu_code.core.budget import (
     DEFAULT_MAX_OUTPUT_TOKENS,
@@ -24,6 +24,7 @@ from sztu_code.core.bus.events import (
 from sztu_code.core.compact.budget import truncate_tool_results
 from sztu_code.core.compact.context_usage import IncrementalUsageEstimator
 from sztu_code.core.context import ContinueReason, ExecutionContext, TerminationReason
+from sztu_code.core.deadline import RunDeadlineExceeded, add_remaining_s
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.base import LLMProvider
 from sztu_code.core.llm.types import LlmResponse, ToolCallBlock
@@ -32,6 +33,7 @@ from sztu_code.core.pricing import PricingCatalog, UnknownPricingPolicy
 from sztu_code.core.stuck_tracker import stuck_signature
 from sztu_code.core.tools.base import (
     _PERMISSION_GRANT_KEY,
+    ToolExecutionState,
     ToolPermission,
     ToolResult,
 )
@@ -144,6 +146,7 @@ async def _invoke_scheduled_tool(
     tool_call: ToolCallBlock,
     bus: EventBus,
     run_id: str,
+    context: ExecutionContext,
     permission_manager: PermissionManager | None,
     session_id: str,
     semaphore: asyncio.Semaphore,
@@ -152,9 +155,15 @@ async def _invoke_scheduled_tool(
     queued_at: str,
     queued_monotonic: float,
     classified_permission: ToolPermission | None = None,
-) -> ToolResult:
+) -> ToolResult | None:
+    # A queued call may acquire a semaphore only after another tool has
+    # consumed the run budget. Do not start it after the deadline.
+    if context.wall_clock_exceeded():
+        return None
     try:
         async with semaphore:
+            if context.wall_clock_exceeded():
+                return None
             return await invoke_tool(
                 registry,
                 tool_call,
@@ -173,6 +182,15 @@ async def _invoke_scheduled_tool(
     except Exception as exc:
         # Isolate an unexpected call-level failure from the rest of the batch.
         return ToolResult(content=str(exc), is_error=True, error_type="runtime_error")
+
+
+def _deadline_skipped_tool_result() -> ToolResult:
+    return ToolResult(
+        content="Tool call skipped because the run wall-clock deadline was reached.",
+        is_error=True,
+        error_type="deadline_exceeded",
+        execution_state=ToolExecutionState.NOT_STARTED,
+    )
 
 
 class AgentLoop:
@@ -319,7 +337,7 @@ class AgentLoop:
         return admission
 
     # 按准入结果调用 provider：仅在收缩输出上限时才传 max_output_tokens，
-    # None 时省略参数，交由 provider 使用其构造配置的默认输出上限
+    # 同时传递本次请求的 Run 剩余时间；None 表示不限制墙钟时间
     async def _chat(
         self,
         context: ExecutionContext,
@@ -352,26 +370,54 @@ class AgentLoop:
                 ts=_now(),
             )
         )
+        remaining_s = context.remaining_s()
+        if remaining_s is not None and remaining_s <= 0:
+            # Do not even create the provider coroutine once the run is out of
+            # time. This is the pre-request hard cutoff.
+            raise RunDeadlineExceeded
+
+        provider_kwargs: dict[str, Any] = {
+            "messages": messages,
+            "tool_schemas": tool_schemas,
+            "bus": self._bus,
+            "run_id": context.run_id,
+            "step": context.step,
+            "usage_estimator": self._usage_estimator,
+            "system": system,
+        }
+        add_remaining_s(self._provider.chat, provider_kwargs, remaining_s)
         if admission.request_max_output_tokens is not None:
-            return await self._provider.chat(
-                messages=messages,
-                tool_schemas=tool_schemas,
-                bus=self._bus,
-                run_id=context.run_id,
-                step=context.step,
-                usage_estimator=self._usage_estimator,
-                system=system,
-                max_output_tokens=admission.request_max_output_tokens,
-            )
-        return await self._provider.chat(
-            messages=messages,
-            tool_schemas=tool_schemas,
-            bus=self._bus,
-            run_id=context.run_id,
-            step=context.step,
-            usage_estimator=self._usage_estimator,
-            system=system,
-        )
+            provider_kwargs["max_output_tokens"] = admission.request_max_output_tokens
+
+        if remaining_s is None:
+            return await self._provider.chat(**provider_kwargs)
+
+        timeout = asyncio.timeout(remaining_s)
+        try:
+            async with timeout:
+                response = await self._provider.chat(**provider_kwargs)
+        except asyncio.CancelledError as exc:
+            if timeout.expired():
+                raise RunDeadlineExceeded from exc
+            raise
+        except TimeoutError as exc:
+            # A provider-raised timeout before the run deadline keeps its
+            # normal error semantics; the outer timeout is mapped otherwise.
+            if timeout.expired():
+                raise RunDeadlineExceeded from exc
+            raise
+        except Exception as exc:
+            # A provider may catch cancellation and fail while cleaning up.
+            # Once the outer timeout expires, it still owns the result.
+            if timeout.expired():
+                raise RunDeadlineExceeded from exc
+            raise
+        # A provider can return after an injected clock crosses the deadline
+        # without the real await timeout expiring. The run loop handles that
+        # response as late and does not start another operation.
+        if timeout.expired():
+            raise RunDeadlineExceeded
+        return response
 
     # 驱动 plan→act→observe 循环直到上下文终止；CancelledError 向上传播
     async def run(self, context: ExecutionContext) -> None:
@@ -400,10 +446,7 @@ class AgentLoop:
             # [budget] 墙钟上限预检：超时直接终止，不再发起 LLM 调用
             # 若已有 result（上一步已产出内容），优先保留而非丢弃
             if context.wall_clock_exceeded():
-                if context.result:
-                    context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
-                else:
-                    context.mark_failed(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+                context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
                 break
 
             context.step += 1
@@ -500,6 +543,17 @@ class AgentLoop:
                     system=outgoing_system,
                     admission=admission,
                 )
+            except RunDeadlineExceeded:
+                log.info(
+                    "LLM request reached run deadline run_id=%s step=%d",
+                    context.run_id,
+                    context.step,
+                )
+                context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+                await self._bus.publish(
+                    StepFinishedEvent(run_id=context.run_id, step=context.step, ts=_now())
+                )
+                break
             except asyncio.CancelledError:
                 context.mark_failed("cancelled")
                 raise
@@ -508,6 +562,16 @@ class AgentLoop:
                     "LLM call failed run_id=%s step=%d", context.run_id, context.step
                 )
                 context.mark_failed("llm_error")
+                break
+
+            # A fake clock or a provider that returns at the timeout boundary
+            # can finish without raising TimeoutError. Do not process its
+            # response or start tools/wrap-up after the absolute deadline.
+            if context.wall_clock_exceeded():
+                context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+                await self._bus.publish(
+                    StepFinishedEvent(run_id=context.run_id, step=context.step, ts=_now())
+                )
                 break
 
             # [budget] usage 缺失/全零 → 记账失败计数；恢复正常即清零。
@@ -611,6 +675,7 @@ class AgentLoop:
                                 tool_call,
                                 self._bus,
                                 context.run_id,
+                                context,
                                 self._permission_manager,
                                 self._session_id,
                                 semaphore,
@@ -629,23 +694,34 @@ class AgentLoop:
 
                 for index, tc in enumerate(response.tool_calls):
                     if concurrent_results is None:
-                        result = await invoke_tool(
-                            self._registry,
-                            tc,
-                            self._bus,
-                            context.run_id,
-                            permission_manager=self._permission_manager,
-                            session_id=self._session_id,
-                            batch_id=batch_id,
-                            scheduler_mode="serial",
-                            queued_at=queued_at,
-                            queued_monotonic=queued_monotonic,
-                        )
+                        if context.wall_clock_exceeded():
+                            context.mark_interrupted(
+                                TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+                            )
+                            result = _deadline_skipped_tool_result()
+                        else:
+                            result = await invoke_tool(
+                                self._registry,
+                                tc,
+                                self._bus,
+                                context.run_id,
+                                permission_manager=self._permission_manager,
+                                session_id=self._session_id,
+                                batch_id=batch_id,
+                                scheduler_mode="serial",
+                                queued_at=queued_at,
+                                queued_monotonic=queued_monotonic,
+                            )
                     else:
                         scheduled_result = concurrent_results[index]
                         if isinstance(scheduled_result, asyncio.CancelledError):
                             raise scheduled_result
-                        if not isinstance(scheduled_result, ToolResult):
+                        if scheduled_result is None:
+                            context.mark_interrupted(
+                                TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+                            )
+                            result = _deadline_skipped_tool_result()
+                        elif not isinstance(scheduled_result, ToolResult):
                             result = ToolResult(
                                 content=str(scheduled_result),
                                 is_error=True,
@@ -829,7 +905,9 @@ class AgentLoop:
                     concluded, conclusion_text = await self._conclude(
                         context, pending_summaries
                     )
-                    if concluded:
+                    if context.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED:
+                        pass
+                    elif concluded:
                         context.result = conclusion_text
                         context.mark_success()
                     else:
@@ -839,12 +917,14 @@ class AgentLoop:
                     # 收尾回合：步数到限时给一次总结，避免裸失败
                     if self._wrap_up_on_max_steps:
                         summary = await self._wrap_up(context, pending_summaries)
-                        context.result = summary or (
-                            "\n".join(pending_summaries) if pending_summaries else ""
-                        )
+                        if context.reason != TerminationReason.MAX_WALL_CLOCK_EXCEEDED:
+                            context.result = summary or (
+                                "\n".join(pending_summaries) if pending_summaries else ""
+                            )
                     elif pending_summaries:
                         context.result = "\n".join(pending_summaries)
-                    context.mark_interrupted("exceeded_max_steps")
+                    if context.reason != TerminationReason.MAX_WALL_CLOCK_EXCEEDED:
+                        context.mark_interrupted("exceeded_max_steps")
 
             # Claude Code 风格继续原因追踪
             if not context.is_done() and response.stop_reason == "tool_use":
@@ -931,6 +1011,10 @@ class AgentLoop:
     async def _wrap_up(
         self, context: ExecutionContext, pending_summaries: list[str]
     ) -> str:
+        if context.wall_clock_exceeded():
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+            return ""
+
         instruction = (
             "The agent run has reached its step limit and must stop now. "
             "Provide a concise summary covering: (1) progress made so far, "
@@ -969,6 +1053,9 @@ class AgentLoop:
                 admission.remaining_tokens,
             )
             return ""
+        if context.wall_clock_exceeded():
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+            return ""
         context.messages.append({"role": "user", "content": instruction})
         try:
             response = await self._chat(
@@ -980,11 +1067,17 @@ class AgentLoop:
             )
         except asyncio.CancelledError:
             raise
+        except RunDeadlineExceeded:
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+            return ""
         except Exception:
             logging.getLogger(__name__).exception(
                 "wrap-up LLM call failed run_id=%s step=%d",
                 context.run_id, context.step,
             )
+            return ""
+        if context.wall_clock_exceeded():
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
             return ""
         if response.usage is not None:
             context.total_input_tokens += response.usage.input_tokens
@@ -1007,6 +1100,10 @@ class AgentLoop:
     async def _conclude(
         self, context: ExecutionContext, pending_summaries: list[str]
     ) -> tuple[bool, str]:
+        if context.wall_clock_exceeded():
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+            return (False, "")
+
         instruction = (
             "The agent run has reached its step limit and must stop now. "
             "Give your final answer. If the goal is fully achieved, start your "
@@ -1045,6 +1142,9 @@ class AgentLoop:
                 admission.remaining_tokens,
             )
             return (False, "")
+        if context.wall_clock_exceeded():
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+            return (False, "")
         context.messages.append({"role": "user", "content": instruction})
         try:
             response = await self._chat(
@@ -1056,11 +1156,17 @@ class AgentLoop:
             )
         except asyncio.CancelledError:
             raise
+        except RunDeadlineExceeded:
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
+            return (False, "")
         except Exception:
             logging.getLogger(__name__).exception(
                 "conclude LLM call failed run_id=%s step=%d",
                 context.run_id, context.step,
             )
+            return (False, "")
+        if context.wall_clock_exceeded():
+            context.mark_interrupted(TerminationReason.MAX_WALL_CLOCK_EXCEEDED)
             return (False, "")
         if response.usage is not None:
             context.total_input_tokens += response.usage.input_tokens

--- a/py-runtime/src/sztu_code/core/trace/provider.py
+++ b/py-runtime/src/sztu_code/core/trace/provider.py
@@ -5,6 +5,7 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 
+from sztu_code.core.deadline import add_remaining_s
 from sztu_code.core.events.bus import EventBus
 from sztu_code.core.llm.base import LLMProvider
 from sztu_code.core.llm.types import LlmResponse
@@ -42,6 +43,7 @@ class TracingProvider:
         system: str | None = None,
         usage_estimator: Any | None = None,
         max_output_tokens: int | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         call_data: dict[str, Any]
         if self._include_payload:
@@ -65,10 +67,15 @@ class TracingProvider:
         )
 
         t0 = time.monotonic()
+        inner_kwargs: dict[str, Any] = {
+            "step": step,
+            "system": system,
+            "usage_estimator": usage_estimator,
+            "max_output_tokens": max_output_tokens,
+        }
+        add_remaining_s(self._inner.chat, inner_kwargs, remaining_s)
         result = await self._inner.chat(
-            messages, tool_schemas, bus, run_id, step=step, system=system,
-            usage_estimator=usage_estimator,
-            max_output_tokens=max_output_tokens,
+            messages, tool_schemas, bus, run_id, **inner_kwargs
         )
         latency_ms = int((time.monotonic() - t0) * 1000)
 

--- a/py-runtime/tests/integration/test_deadline_foundation.py
+++ b/py-runtime/tests/integration/test_deadline_foundation.py
@@ -17,6 +17,7 @@ class _DeadlineAdvancingProvider:
         self._clock = clock
         self._end_turn = end_turn
         self.calls = 0
+        self.remaining: list[float | None] = []
 
     async def chat(
         self,
@@ -28,8 +29,10 @@ class _DeadlineAdvancingProvider:
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         del messages, tool_schemas, bus, run_id, step, system, usage_estimator
+        self.remaining.append(remaining_s)
         self.calls += 1
         self._clock[0] = 1.0
         if self._end_turn:
@@ -54,16 +57,17 @@ async def test_agent_loop_stops_before_second_provider_request_after_deadline() 
     await AgentLoop(provider, ToolRegistry(), EventBus()).run(context)  # type: ignore[arg-type]
 
     assert provider.calls == 1
+    assert provider.remaining == [1.0]
     assert context.status == "interrupted"
     assert context.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
 
 
-async def test_agent_loop_preserves_late_end_turn_result_as_interrupted() -> None:
+async def test_agent_loop_discards_late_end_turn_after_deadline() -> None:
     clock = [0.0]
     provider = _DeadlineAdvancingProvider(clock, end_turn=True)
     context = ExecutionContext(
         run_id="late-end-turn",
-        goal="preserve the late result",
+        goal="discard the late result",
         max_steps=5,
         max_wall_clock_s=1,
         clock=lambda: clock[0],
@@ -72,6 +76,7 @@ async def test_agent_loop_preserves_late_end_turn_result_as_interrupted() -> Non
     await AgentLoop(provider, ToolRegistry(), EventBus()).run(context)  # type: ignore[arg-type]
 
     assert provider.calls == 1
+    assert provider.remaining == [1.0]
     assert context.status == "interrupted"
     assert context.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
-    assert context.result == "late result"
+    assert context.result == ""

--- a/py-runtime/tests/unit/test_loop.py
+++ b/py-runtime/tests/unit/test_loop.py
@@ -37,6 +37,7 @@ class _MockProvider:
     ) -> None:
         self._responses = iter(responses)
         self._exc = exc
+        self.calls = 0
 
     async def chat(
         self,
@@ -48,10 +49,86 @@ class _MockProvider:
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
+        self.calls += 1
         if self._exc is not None:
             raise self._exc
         return next(self._responses)
+
+
+class _SlowDeadlineProvider:
+    """Blocks until the AgentLoop cancels the in-flight request."""
+
+    def __init__(self, *, raise_cleanup_error: bool = False) -> None:
+        self.calls = 0
+        self.remaining: list[float | None] = []
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+        self.raise_cleanup_error = raise_cleanup_error
+
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: EventBus,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+        usage_estimator: object | None = None,
+        remaining_s: float | None = None,
+    ) -> LlmResponse:
+        self.calls += 1
+        self.remaining.append(remaining_s)
+        self.started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            if self.raise_cleanup_error:
+                raise RuntimeError("provider cleanup failed")
+            raise
+        return LlmResponse(stop_reason="end_turn", text="unexpected completion")
+
+
+class _ClockAdvancingProvider:
+    """Returns a response after advancing the injected monotonic clock."""
+
+    def __init__(
+        self,
+        clock: list[float],
+        *,
+        response: LlmResponse | None = None,
+        exc: BaseException | None = None,
+    ) -> None:
+        self.clock = clock
+        self.calls = 0
+        self.response = response
+        self.exc = exc
+
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: EventBus,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+        usage_estimator: object | None = None,
+        remaining_s: float | None = None,
+    ) -> LlmResponse:
+        self.calls += 1
+        self.clock[0] = 1.0
+        if self.exc is not None:
+            raise self.exc
+        if self.response is not None:
+            return self.response
+        return LlmResponse(
+            stop_reason="tool_use",
+            tool_calls=[_tc(name="unknown_tool")],
+        )
 
 
 class _CapRecordingProvider:
@@ -74,6 +151,7 @@ class _CapRecordingProvider:
         system: str | None = None,
         usage_estimator: object | None = None,
         max_output_tokens: int | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         self.calls += 1
         self.caps.append(max_output_tokens)
@@ -117,8 +195,8 @@ class _CompactingProvider:
         *,
         step: int = 0,
         system: str | None = None,
-    
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         self._calls += 1
         if self._calls == 1:
@@ -217,6 +295,31 @@ class _TimedTool(BaseTool):
             return ToolResult(content=f"done:{label}")
         finally:
             self._probe.active -= 1
+
+
+class _DeadlineAdvancingTool(BaseTool):
+    """Advances the injected clock after the allowed calls have started."""
+
+    description = "Records calls and advances a test clock"
+    input_schema: dict[str, object] = {
+        "type": "object",
+        "properties": {"label": {"type": "string"}},
+        "required": ["label"],
+    }
+
+    def __init__(self, clock: list[float], advance_after: int) -> None:
+        self.name = "deadline_read"
+        self.required_permission = ToolPermission.READ_ONLY
+        self._clock = clock
+        self._advance_after = advance_after
+        self.started: list[str] = []
+
+    async def invoke(self, params: dict[str, object]) -> ToolResult:
+        label = str(params["label"])
+        self.started.append(label)
+        if len(self.started) >= self._advance_after:
+            self._clock[0] = 1.0
+        return ToolResult(content=f"done:{label}")
 
 
 class _UnknownPermissionTool(_TimedTool):
@@ -350,6 +453,7 @@ async def test_steering_received_at_end_turn_continues_loop() -> None:
             step: int = 0,
             system: str | None = None,
             usage_estimator: object | None = None,
+            remaining_s: float | None = None,
         ) -> LlmResponse:
             self.calls.append([dict(message) for message in messages])
             if len(self.calls) == 1:
@@ -1295,9 +1399,186 @@ async def test_wall_clock_exceeded_stops_loop() -> None:
     # 模拟已运行超时：elapsed_s 会 >= max_wall_clock_s
     ctx.started_at = time.monotonic() - 10.0  # 10 秒前开始
     await loop.run(ctx)
-    # 无 result 时 wall_clock 超时标记为 failed（区别于有结果的中断）
-    assert ctx.status == "failed"
+    # Deadline 超时统一呈现为可识别的 interrupted 终态
+    assert ctx.status == "interrupted"
     assert ctx.reason == "max_wall_clock_exceeded"
+
+
+# 功能：验证正在等待的可取消 LLM 请求会被 Run deadline 截断并清理
+# 设计：slow fake provider 阻塞在 await，断言只调用一次、收到剩余预算且观察到取消
+async def test_llm_request_is_cancelled_at_run_deadline() -> None:
+    provider = _SlowDeadlineProvider()
+    loop = AgentLoop(provider, ToolRegistry(), EventBus())  # type: ignore[arg-type]
+    ctx = _ctx(max_steps=10)
+    ctx.max_wall_clock_s = 0.05
+
+    started = time.monotonic()
+    await asyncio.wait_for(loop.run(ctx), timeout=0.5)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.2
+    assert provider.calls == 1
+    assert provider.started.is_set()
+    assert provider.cancelled.is_set()
+    remaining = provider.remaining[0]
+    assert remaining is not None
+    assert 0.0 < remaining <= 0.05
+    assert ctx.status == "interrupted"
+    assert ctx.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+
+
+# 功能：验证旧版 Provider double 不接受 remaining_s 时仍可运行
+# 设计：AgentLoop 传递有限剩余时间，但兼容层应省略旧 double 不支持的关键字
+async def test_legacy_provider_double_is_compatible_with_deadline() -> None:
+    class _LegacyProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def chat(
+            self,
+            messages: list[dict[str, object]],
+            tool_schemas: list[dict[str, object]],
+            bus: EventBus,
+            run_id: str,
+            *,
+            step: int = 0,
+            system: str | None = None,
+            usage_estimator: object | None = None,
+        ) -> LlmResponse:
+            self.calls += 1
+            return LlmResponse(stop_reason="end_turn", text="done")
+
+    provider = _LegacyProvider()
+    loop = AgentLoop(provider, ToolRegistry(), EventBus())  # type: ignore[arg-type]
+    clock = [0.0]
+    ctx = _ctx(max_steps=10)
+    ctx.max_wall_clock_s = 1
+    ctx.clock = lambda: clock[0]
+
+    await loop.run(ctx)
+
+    assert provider.calls == 1
+    assert ctx.status == "success"
+
+
+# 功能：验证 Provider 取消清理异常不会覆盖 deadline 终止语义
+# 设计：fake 在收到取消后抛出清理异常，loop 仍应报告 interrupted/max_wall_clock_exceeded
+async def test_deadline_wins_over_provider_cleanup_error() -> None:
+    provider = _SlowDeadlineProvider(raise_cleanup_error=True)
+    loop = AgentLoop(provider, ToolRegistry(), EventBus())  # type: ignore[arg-type]
+    ctx = _ctx(max_steps=10)
+    ctx.max_wall_clock_s = 0.05
+
+    await asyncio.wait_for(loop.run(ctx), timeout=0.5)
+
+    assert provider.calls == 1
+    assert provider.cancelled.is_set()
+    assert ctx.status == "interrupted"
+    assert ctx.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+
+
+# 功能：验证 Provider 自身抛出的 TimeoutError 不会被误判为 Run deadline
+# 设计：即使注入时钟已到 deadline，Provider 自己抛出的超时仍应走普通 llm_error 路径
+async def test_provider_timeout_error_remains_llm_error() -> None:
+    clock = [0.0]
+    provider = _ClockAdvancingProvider(
+        clock,
+        exc=TimeoutError("provider timeout"),
+    )
+    loop, _ = _make_loop(provider)
+    ctx = _ctx(max_steps=10)
+    ctx.max_wall_clock_s = 1
+    ctx.clock = lambda: clock[0]
+
+    await loop.run(ctx)
+
+    assert ctx.status == "failed"
+    assert ctx.reason == "llm_error"
+
+
+# 功能：验证响应恰好跨过 deadline 时不会继续执行工具或 wrap-up/conclude
+# 设计：fake monotonic clock 在首个 provider 响应前推进到 deadline，loop 应只处理为中断
+async def test_deadline_after_llm_response_skips_follow_up_calls() -> None:
+    clock = [0.0]
+    provider = _ClockAdvancingProvider(clock)
+    loop = AgentLoop(
+        provider,  # type: ignore[arg-type]
+        ToolRegistry(),
+        EventBus(),
+        wrap_up_on_max_steps=True,
+        grace_step_on_max_steps=True,
+    )
+    ctx = _ctx(max_steps=1)
+    ctx.max_wall_clock_s = 1
+    ctx.clock = lambda: clock[0]
+
+    await loop.run(ctx)
+
+    assert provider.calls == 1
+    assert ctx.status == "interrupted"
+    assert ctx.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+
+
+@pytest.mark.parametrize("max_concurrency", [1, 2])
+async def test_tool_calls_after_deadline_are_not_started(max_concurrency: int) -> None:
+    # The first serial call, or the first two bounded concurrent calls, advance
+    # the injected clock. Later calls must be represented without invoking the tool.
+    clock = [0.0]
+    tool = _DeadlineAdvancingTool(clock, advance_after=max_concurrency)
+    registry = ToolRegistry()
+    registry.register(tool)
+    provider = _MockProvider([
+        LlmResponse(
+            stop_reason="tool_use",
+            tool_calls=[
+                _tc(
+                    "deadline_read",
+                    {"label": label},
+                    uid=f"deadline-tool-{label}",
+                )
+                for label in ("first", "second", "third")
+            ],
+        ),
+        LlmResponse(stop_reason="end_turn", text="unexpected follow-up"),
+    ])
+    loop = AgentLoop(
+        provider,
+        registry,
+        EventBus(),
+        tool_max_concurrency=max_concurrency,
+    )
+    ctx = _ctx(max_steps=5)
+    ctx.max_wall_clock_s = 1
+    ctx.clock = lambda: clock[0]
+
+    await loop.run(ctx)
+
+    assert tool.started == ["first", "second"][:max_concurrency]
+    assert provider.calls == 1
+    assert ctx.status == "interrupted"
+    assert ctx.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+
+
+# 功能：验证 deadline 边界到达的迟到 end_turn 不会覆盖已有结果
+# 设计：模拟 resume 场景已有结果，再让 Provider 返回跨过 deadline 的迟到文本
+async def test_late_end_turn_does_not_replace_existing_result() -> None:
+    clock = [0.0]
+    provider = _ClockAdvancingProvider(
+        clock,
+        response=LlmResponse(stop_reason="end_turn", text="late response"),
+    )
+    loop = AgentLoop(provider, ToolRegistry(), EventBus())  # type: ignore[arg-type]
+    ctx = _ctx(max_steps=10)
+    ctx.max_wall_clock_s = 1
+    ctx.clock = lambda: clock[0]
+    ctx.result = "existing result"
+
+    await loop.run(ctx)
+
+    assert provider.calls == 1
+    assert ctx.status == "interrupted"
+    assert ctx.reason == TerminationReason.MAX_WALL_CLOCK_EXCEEDED
+    assert ctx.result == "existing result"
 
 
 # 功能：验证墙钟超时但有 result 时标记为 interrupted（保留已有结果）

--- a/py-runtime/tests/unit/test_runner.py
+++ b/py-runtime/tests/unit/test_runner.py
@@ -32,8 +32,39 @@ class _EndTurnProvider:
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         return LlmResponse(stop_reason="end_turn", text="done")
+
+
+class _SlowProvider:
+    """Blocks until the runner-level deadline cancels the in-flight request."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.remaining: list[float | None] = []
+        self.cancelled = asyncio.Event()
+
+    async def chat(
+        self,
+        messages: list[dict[str, object]],
+        tool_schemas: list[dict[str, object]],
+        bus: EventBus,
+        run_id: str,
+        *,
+        step: int = 0,
+        system: str | None = None,
+        usage_estimator: object | None = None,
+        remaining_s: float | None = None,
+    ) -> LlmResponse:
+        self.calls += 1
+        self.remaining.append(remaining_s)
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+        return LlmResponse(stop_reason="end_turn", text="unexpected completion")
 
 
 class _LoopingProvider:
@@ -52,6 +83,7 @@ class _LoopingProvider:
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         # Recuris 记忆进化的 Meta-Agent 调用不计入主循环步数
         if system and "[memory-evolution]" in system:
@@ -79,6 +111,7 @@ class _CapturingProvider:
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         self.messages = [dict(m) for m in messages]
         self.system = system
@@ -115,6 +148,7 @@ new goal
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         self._calls += 1
         if self._calls == 1:
@@ -156,6 +190,7 @@ class _CancelableCompactingProvider:
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         if run_id == "compact":
             self.compact_started.set()
@@ -210,6 +245,7 @@ finish without session
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         if run_id == "compact":
             self.compact_started.set()
@@ -272,6 +308,7 @@ survive failure
         step: int = 0,
         system: str | None = None,
         usage_estimator: object | None = None,
+        remaining_s: float | None = None,
     ) -> LlmResponse:
         if run_id == "compact":
             self.compact_started.set()
@@ -425,6 +462,38 @@ async def test_run_finished_event_published_on_max_steps(tmp_path: Path) -> None
     finished = next(e for e in events if e.type == "run.finished")  # type: ignore[attr-defined]
     assert finished.status == "interrupted"  # type: ignore[attr-defined]
     assert finished.reason == "exceeded_max_steps"  # type: ignore[attr-defined]
+
+
+# 功能：验证 Runner 在 LLM hard cutoff 后发布统一终态，且不触发记忆进化
+# 设计：可取消 Provider 被 Run deadline 截断；max_wall_clock_exceeded 不属于进化触发原因
+async def test_run_finished_on_deadline_skips_memory_evolution(tmp_path: Path) -> None:
+    provider = _SlowProvider()
+    config = _config()
+    config.budget.max_wall_clock_s = 1.0
+    events: list[BaseModel] = []
+
+    async def collect(event: BaseModel) -> None:
+        events.append(event)
+
+    runner = AgentRunner(
+        config,
+        provider=provider,  # type: ignore[arg-type]
+        extra_handlers=[collect],
+        runs_dir=tmp_path,
+    )
+    outcome = await asyncio.wait_for(
+        runner.run_and_capture("deadline goal", workspace_root=tmp_path),
+        timeout=1.5,
+    )
+
+    assert outcome.status == "interrupted"
+    assert outcome.reason == "max_wall_clock_exceeded"
+    assert provider.calls == 1
+    assert provider.cancelled.is_set()
+    finished = next(event for event in events if event.type == "run.finished")  # type: ignore[attr-defined]
+    assert finished.status == "interrupted"  # type: ignore[attr-defined]
+    assert finished.reason == "max_wall_clock_exceeded"  # type: ignore[attr-defined]
+    assert not (tmp_path / ".sztu" / "memory").exists()
 
 
 # 功能：验证 events.jsonl 第一行为 run.started、最后一行为 run.finished

--- a/py-runtime/tests/unit/test_smart_routing.py
+++ b/py-runtime/tests/unit/test_smart_routing.py
@@ -26,3 +26,29 @@ def test_routing_is_stable_during_tools_and_releases_finished_runs() -> None:
         await provider.chat([{"role": "user", "content": "architecture"}], [], None, "r2")
         assert flagship.calls == 1
     asyncio.run(run())
+
+
+def test_remaining_s_is_forwarded_to_selected_provider() -> None:
+    class Fake:
+        def __init__(self) -> None:
+            self.remaining: list[float | None] = []
+
+        async def chat(self, *args, **kwargs):
+            self.remaining.append(kwargs.get("remaining_s"))
+            return LlmResponse(stop_reason="end_turn")
+
+    standard = Fake()
+    provider = SmartProvider(standard, Fake())
+
+    async def run() -> None:
+        await provider.chat(
+            [{"role": "user", "content": "simple task"}],
+            [],
+            None,
+            "run-1",
+            remaining_s=1.25,
+        )
+
+    asyncio.run(run())
+
+    assert standard.remaining == [1.25]

--- a/py-runtime/tests/unit/test_tracing_provider.py
+++ b/py-runtime/tests/unit/test_tracing_provider.py
@@ -148,9 +148,10 @@ async def test_step_forwarded_to_inner_provider(tmp_path: Path) -> None:
     inner.chat = AsyncMock(return_value=_make_response())
 
     provider = TracingProvider(inner, writer)
-    await provider.chat([], [], EventBus(), "r", step=7)
+    await provider.chat([], [], EventBus(), "r", step=7, remaining_s=2.5)
     await writer.stop()
 
     inner.chat.assert_called_once()
     _, kwargs = inner.chat.call_args
     assert kwargs["step"] == 7
+    assert kwargs["remaining_s"] == 2.5


### PR DESCRIPTION
## 变更

这是 Issue #69 中可独立 Review 的 PR-02，针对 Python Agent Loop 增加 LLM hard cutoff。

- 每次普通 LLM 请求前检查当前 Run 的剩余墙钟时间。
- 使用 AgentLoop 外层可取消边界终止慢 Provider 请求。
- deadline 到达后忽略迟到的 LLM 响应，不再启动新的工具、wrap-up 或 conclude 请求。
- 排队但未启动的工具记录为 `NOT_STARTED`。
- 将 deadline 终态统一为 `interrupted / max_wall_clock_exceeded`；普通 Provider 自身超时仍保留原有 `llm_error` 语义。
- 更新 Provider contract、Anthropic/OpenAI、Smart、Tracing wrapper 和测试 doubles，传递 `remaining_s`。
- deadline 中断不会触发 memory evolution。

## 验证

- PR-02 focused tests：`104 passed`
- Ruff：通过
- 7 个生产源文件 mypy：通过
- `compileall`：通过
- `git diff --check`：通过
- 全量 Python 套件：`1310 passed, 2 skipped, 19 failed, 8 errors`；剩余失败集中在主线已有的 `Sztubuddy` 提示词资源大小写、Prompt Harness、Markdown 链接和子进程导入问题，未出现 PR-02 focused 断言失败。

## 范围

本 PR 只处理 AgentLoop 的 LLM hard cutoff 和相关契约/测试迁移。Provider 内部 timeout/retry、retry/backoff、工具 timeout、权限等待、Subagent deadline、context compaction 和完整 cleanup 继续留在后续 PR。

Refs #69